### PR TITLE
開発秘話詳細ページから画像表示を削除

### DIFF
--- a/app/dev-stories/[id]/EpisodeDetailClient.tsx
+++ b/app/dev-stories/[id]/EpisodeDetailClient.tsx
@@ -120,17 +120,6 @@ export default function EpisodeDetailClient({ id }: EpisodeDetailClientProps) {
                 {/* 日付 */}
                 <div className="text-sm text-gray-400 mb-4">{formatDate(episode.publishedAt)}</div>
 
-                {/* エピソード画像 */}
-                {episode.imageUrl && (
-                    <div className="mb-6 rounded-xl overflow-hidden shadow-sm">
-                        <img
-                            src={episode.imageUrl}
-                            alt={episode.title}
-                            className="w-full h-auto object-cover"
-                        />
-                    </div>
-                )}
-
                 {/* 対話セクション */}
                 <div className="mb-6">
                     <DialogueSection dialogues={episode.dialogues} />


### PR DESCRIPTION
エピソード詳細ページに表示されていた画像を非表示に変更。
画像はエピソード一覧のカードにのみ表示されるようになります。