### PR TITLE
コーヒークイズのデータ保存をlocalStorageに移行

### DIFF
--- a/app/coffee-trivia/badges/page.tsx
+++ b/app/coffee-trivia/badges/page.tsx
@@ -2,9 +2,7 @@
 
 import { motion } from 'framer-motion';
 import Link from 'next/link';
-import { useAuth } from '@/lib/auth';
 import { Loading } from '@/components/Loading';
-import LoginPage from '@/app/login/page';
 import { useQuizData } from '@/hooks/useQuizData';
 import { BADGE_DEFINITIONS } from '@/lib/coffee-quiz/types';
 import type { BadgeType } from '@/lib/coffee-quiz/types';
@@ -67,15 +65,10 @@ const AwardIcon = () => (
 );
 
 export default function BadgesPage() {
-  const { user, loading: authLoading } = useAuth();
   const { progress, loading: quizLoading } = useQuizData();
 
-  if (authLoading || quizLoading) {
+  if (quizLoading) {
     return <Loading />;
-  }
-
-  if (!user) {
-    return <LoginPage />;
   }
 
   const earnedBadgeTypes = new Set(progress?.earnedBadges.map((b) => b.type) || []);

--- a/app/coffee-trivia/page.tsx
+++ b/app/coffee-trivia/page.tsx
@@ -1,10 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { useAuth } from '@/lib/auth';
 import { Loading } from '@/components/Loading';
 import { useAppLifecycle } from '@/hooks/useAppLifecycle';
-import LoginPage from '@/app/login/page';
 import Link from 'next/link';
 import { QuizDashboard, HelpGuideModal } from '@/components/coffee-quiz';
 import { useQuizData } from '@/hooks/useQuizData';
@@ -38,17 +36,12 @@ const HelpCircleIcon = () => (
 );
 
 export default function CoffeeTriviaPage() {
-  const { user, loading: authLoading } = useAuth();
   const { progress, loading: quizLoading, getDueCardsForReview, questionsStats, categoryMasteryStats } = useQuizData();
   const [showHelpGuide, setShowHelpGuide] = useState(false);
   useAppLifecycle();
 
-  if (authLoading) {
+  if (quizLoading) {
     return <Loading />;
-  }
-
-  if (!user) {
-    return <LoginPage />;
   }
 
   const dueCardsCount = getDueCardsForReview().length;

--- a/app/coffee-trivia/quiz/page.tsx
+++ b/app/coffee-trivia/quiz/page.tsx
@@ -184,28 +184,6 @@ function QuizPageContent() {
     );
   }
 
-  if (!isAuthenticated) {
-    return (
-      <div className="min-h-screen bg-[#FDF8F0] flex items-center justify-center p-4">
-        <div className="bg-white rounded-2xl shadow-lg p-6 text-center max-w-sm border border-[#211714]/5">
-          <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-[#211714]/5 flex items-center justify-center text-[#211714]/40">
-            <LockIcon />
-          </div>
-          <h2 className="text-lg font-bold text-[#211714] mb-2">ログインが必要です</h2>
-          <p className="text-[#3A2F2B]/70 text-sm mb-4">
-            クイズに挑戦するにはログインしてください
-          </p>
-          <Link
-            href="/login"
-            className="inline-block bg-[#EF8A00] hover:bg-[#D67A00] text-white py-2.5 px-6 rounded-xl font-semibold transition-colors"
-          >
-            ログイン
-          </Link>
-        </div>
-      </div>
-    );
-  }
-
   // ローディング
   if (isLoading || !session) {
     return (

--- a/app/coffee-trivia/review/page.tsx
+++ b/app/coffee-trivia/review/page.tsx
@@ -163,34 +163,6 @@ export default function ReviewPage() {
     startSession();
   };
 
-  // 認証チェック
-  if (authLoading) {
-    return (
-      <div className="min-h-screen bg-[#FDF8F0] flex items-center justify-center">
-        <div className="w-8 h-8 rounded-full border-2 border-[#EF8A00]/20 border-t-[#EF8A00] animate-spin" />
-      </div>
-    );
-  }
-
-  if (!isAuthenticated) {
-    return (
-      <div className="min-h-screen bg-[#FDF8F0] flex items-center justify-center p-4">
-        <div className="bg-white rounded-2xl shadow-lg p-6 text-center max-w-sm border border-[#211714]/5">
-          <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-[#211714]/5 flex items-center justify-center text-[#211714]/40">
-            <LockIcon />
-          </div>
-          <h2 className="text-lg font-bold text-[#211714] mb-2">ログインが必要です</h2>
-          <Link
-            href="/login"
-            className="inline-block bg-[#EF8A00] hover:bg-[#D67A00] text-white py-2.5 px-6 rounded-xl font-semibold transition-colors"
-          >
-            ログイン
-          </Link>
-        </div>
-      </div>
-    );
-  }
-
   // 復習する問題がない場合
   if (noReviewCards) {
     return (

--- a/app/coffee-trivia/stats/page.tsx
+++ b/app/coffee-trivia/stats/page.tsx
@@ -3,15 +3,14 @@
 import { useState } from 'react';
 import { motion } from 'framer-motion';
 import Link from 'next/link';
-import { useAuth } from '@/lib/auth';
 import { Loading } from '@/components/Loading';
-import LoginPage from '@/app/login/page';
 import { useQuizData } from '@/hooks/useQuizData';
 import { useDeveloperMode } from '@/hooks/useDeveloperMode';
 import { LevelDisplay } from '@/components/coffee-quiz/LevelDisplay';
 import { StreakCounter } from '@/components/coffee-quiz/StreakCounter';
 import { ResetConfirmDialog } from '@/components/coffee-quiz/ResetConfirmDialog';
 import { DebugPanel } from '@/components/coffee-quiz/DebugPanel';
+import { DataManagement } from '@/components/coffee-quiz/DataManagement';
 import { CATEGORY_LABELS, DIFFICULTY_LABELS } from '@/lib/coffee-quiz/types';
 import type { QuizCategory, QuizDifficulty } from '@/lib/coffee-quiz/types';
 
@@ -63,16 +62,15 @@ const TrashIcon = () => (
 );
 
 export default function StatsPage() {
-  const { user, loading: authLoading } = useAuth();
   const { progress, loading: quizLoading, questionsStats, difficultyMasteryStats, resetProgress } = useQuizData();
   const { isEnabled: isDeveloperMode } = useDeveloperMode();
   const [showResetDialog, setShowResetDialog] = useState(false);
   const [isResetting, setIsResetting] = useState(false);
 
-  const handleReset = async () => {
+  const handleReset = () => {
     setIsResetting(true);
     try {
-      await resetProgress();
+      resetProgress();
       setShowResetDialog(false);
     } catch (error) {
       console.error('Failed to reset progress:', error);
@@ -81,12 +79,8 @@ export default function StatsPage() {
     }
   };
 
-  if (authLoading || quizLoading) {
+  if (quizLoading) {
     return <Loading />;
-  }
-
-  if (!user) {
-    return <LoginPage />;
   }
 
   const stats = progress?.stats;
@@ -295,6 +289,11 @@ export default function StatsPage() {
                 </span>
                 データ管理
               </h2>
+
+              {/* バックアップ・リストア */}
+              <div className="mb-4">
+                <DataManagement />
+              </div>
 
               <p className="text-[#3A2F2B]/70 text-sm mb-4">
                 学習データをリセットして、最初からやり直すことができます。

--- a/components/coffee-quiz/DataManagement.tsx
+++ b/components/coffee-quiz/DataManagement.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { useState, useRef } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { exportQuizProgress, importQuizProgress } from '@/lib/localStorage';
+
+interface DataManagementProps {
+  onImportSuccess?: () => void;
+}
+
+// ダウンロードアイコン
+const DownloadIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+    <polyline points="7 10 12 15 17 10" />
+    <line x1="12" y1="15" x2="12" y2="3" />
+  </svg>
+);
+
+// アップロードアイコン
+const UploadIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+    <polyline points="17 8 12 3 7 8" />
+    <line x1="12" y1="3" x2="12" y2="15" />
+  </svg>
+);
+
+// チェックアイコン
+const CheckIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+);
+
+// アラートアイコン
+const AlertIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="12" r="10" />
+    <line x1="12" y1="8" x2="12" y2="12" />
+    <line x1="12" y1="16" x2="12.01" y2="16" />
+  </svg>
+);
+
+type MessageType = 'success' | 'error' | null;
+
+interface Message {
+  type: MessageType;
+  text: string;
+}
+
+export function DataManagement({ onImportSuccess }: DataManagementProps) {
+  const [message, setMessage] = useState<Message>({ type: null, text: '' });
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // エクスポート処理
+  const handleExport = () => {
+    const jsonData = exportQuizProgress();
+    if (!jsonData) {
+      setMessage({ type: 'error', text: 'エクスポートするデータがありません' });
+      return;
+    }
+
+    // ファイルとしてダウンロード
+    const blob = new Blob([jsonData], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    const date = new Date().toISOString().split('T')[0];
+    a.download = `roastplus-quiz-data-${date}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+
+    setMessage({ type: 'success', text: 'データをエクスポートしました' });
+    setTimeout(() => setMessage({ type: null, text: '' }), 3000);
+  };
+
+  // インポート処理
+  const handleImport = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const content = e.target?.result as string;
+      const result = importQuizProgress(content);
+
+      if (result.success) {
+        setMessage({ type: 'success', text: 'データをインポートしました。ページをリロードします...' });
+        onImportSuccess?.();
+        // リロードしてデータを反映
+        setTimeout(() => window.location.reload(), 1500);
+      } else {
+        setMessage({ type: 'error', text: result.error || 'インポートに失敗しました' });
+      }
+    };
+    reader.onerror = () => {
+      setMessage({ type: 'error', text: 'ファイルの読み込みに失敗しました' });
+    };
+    reader.readAsText(file);
+
+    // 同じファイルを再選択できるようにリセット
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  return (
+    <div className="bg-white rounded-xl border border-[#211714]/5 p-4">
+      <h3 className="text-sm font-semibold text-[#211714] mb-3">
+        データ管理
+      </h3>
+      <p className="text-xs text-[#3A2F2B]/60 mb-4">
+        データのバックアップや他の端末への移行ができます
+      </p>
+
+      <div className="flex gap-3">
+        <button
+          onClick={handleExport}
+          className="flex-1 flex items-center justify-center gap-2 bg-[#FDF8F0] hover:bg-[#F5EFE6] text-[#3A2F2B] py-2.5 px-4 rounded-xl text-sm font-medium transition-colors border border-[#211714]/10"
+        >
+          <DownloadIcon />
+          エクスポート
+        </button>
+
+        <button
+          onClick={() => fileInputRef.current?.click()}
+          className="flex-1 flex items-center justify-center gap-2 bg-[#FDF8F0] hover:bg-[#F5EFE6] text-[#3A2F2B] py-2.5 px-4 rounded-xl text-sm font-medium transition-colors border border-[#211714]/10"
+        >
+          <UploadIcon />
+          インポート
+        </button>
+
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".json"
+          onChange={handleImport}
+          className="hidden"
+        />
+      </div>
+
+      {/* メッセージ表示 */}
+      <AnimatePresence>
+        {message.type && (
+          <motion.div
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -10 }}
+            className={`mt-3 flex items-center gap-2 text-sm py-2 px-3 rounded-lg ${
+              message.type === 'success'
+                ? 'bg-emerald-50 text-emerald-700'
+                : 'bg-rose-50 text-rose-700'
+            }`}
+          >
+            {message.type === 'success' ? <CheckIcon /> : <AlertIcon />}
+            {message.text}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/components/coffee-quiz/index.ts
+++ b/components/coffee-quiz/index.ts
@@ -15,3 +15,4 @@ export { MasteryDisplay, MasteryCompact, CategoryMasteryDisplay } from './Master
 export { QuestionListItem } from './QuestionListItem';
 export { CategoryQuestionList } from './CategoryQuestionList';
 export { DebugPanel } from './DebugPanel';
+export { DataManagement } from './DataManagement';


### PR DESCRIPTION
## Summary
- Firebase依存を削除し、localStorageベースのデータ保存に変更
- 認証なしでクイズ機能を利用可能に
- エクスポート/インポート機能を追加（端末間のデータ移行用）
- 各ページからログイン必須チェックを削除

## Test plan
- [x] 初回アクセス: ログインなしでダッシュボード表示
- [x] クイズ実行: ロック画面なしで開始可能
- [x] 回答記録: 進捗が保存される
- [x] ページリロード: データが復元される
- [x] エクスポート/インポート機能の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)