### PR TITLE
スケジュールOCR機能改善: 担当者・サブタスク・時間経過の検出と表示

### DIFF
--- a/components/OCRTimeLabelEditor.tsx
+++ b/components/OCRTimeLabelEditor.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import type { TimeLabel } from '@/types';
-import { HiPlus, HiTrash, HiPencil } from 'react-icons/hi';
+import type { TimeLabel, SubTask } from '@/types';
+import { HiPlus, HiTrash, HiPencil, HiUser, HiArrowDown } from 'react-icons/hi';
 
 interface OCRTimeLabelEditorProps {
   timeLabels: TimeLabel[];
@@ -19,6 +19,10 @@ export function OCRTimeLabelEditor({
   const [editingTime, setEditingTime] = useState<{ hour: string; minute: string }>({ hour: '', minute: '' });
   const [editingContent, setEditingContent] = useState<string>('');
   const [editingMemo, setEditingMemo] = useState<string>('');
+  // 新フィールド用の状態
+  const [editingAssignee, setEditingAssignee] = useState<string>('');
+  const [editingSubTasks, setEditingSubTasks] = useState<SubTask[]>([]);
+  const [editingContinuesUntil, setEditingContinuesUntil] = useState<{ hour: string; minute: string }>({ hour: '', minute: '' });
 
   const handleEdit = (label: TimeLabel) => {
     setEditingId(label.id);
@@ -26,6 +30,11 @@ export function OCRTimeLabelEditor({
     setEditingTime({ hour: hour || '', minute: minute || '' });
     setEditingContent(label.content || '');
     setEditingMemo(label.memo || '');
+    // 新フィールド
+    setEditingAssignee(label.assignee || '');
+    setEditingSubTasks(label.subTasks || []);
+    const [continuesHour, continuesMinute] = (label.continuesUntil || '').split(':');
+    setEditingContinuesUntil({ hour: continuesHour || '', minute: continuesMinute || '' });
   };
 
   const handleSave = (id: string) => {
@@ -35,6 +44,14 @@ export function OCRTimeLabelEditor({
     const formattedMinute = editingTime.minute ? editingTime.minute.padStart(2, '0') : '00';
     const newTime = `${formattedHour}:${formattedMinute}`;
 
+    // continuesUntilのフォーマット
+    let continuesUntilTime: string | undefined;
+    if (editingContinuesUntil.hour) {
+      const continuesHour = editingContinuesUntil.hour.padStart(2, '0');
+      const continuesMinute = editingContinuesUntil.minute ? editingContinuesUntil.minute.padStart(2, '0') : '00';
+      continuesUntilTime = `${continuesHour}:${continuesMinute}`;
+    }
+
     const updated = timeLabels.map((label) =>
       label.id === id
         ? {
@@ -42,6 +59,10 @@ export function OCRTimeLabelEditor({
             time: newTime,
             content: editingContent,
             memo: editingMemo,
+            // 新フィールド
+            assignee: editingAssignee || undefined,
+            subTasks: editingSubTasks.length > 0 ? editingSubTasks : undefined,
+            continuesUntil: continuesUntilTime,
           }
         : label
     );
@@ -52,6 +73,30 @@ export function OCRTimeLabelEditor({
 
   const handleCancel = () => {
     setEditingId(null);
+  };
+
+  // サブタスク追加
+  const handleAddSubTask = () => {
+    const newSubTask: SubTask = {
+      id: `subtask-${Date.now()}`,
+      content: '',
+      order: editingSubTasks.length,
+    };
+    setEditingSubTasks([...editingSubTasks, newSubTask]);
+  };
+
+  // サブタスク削除
+  const handleDeleteSubTask = (subTaskId: string) => {
+    setEditingSubTasks(editingSubTasks.filter((st) => st.id !== subTaskId));
+  };
+
+  // サブタスク更新
+  const handleUpdateSubTask = (subTaskId: string, updates: Partial<SubTask>) => {
+    setEditingSubTasks(
+      editingSubTasks.map((st) =>
+        st.id === subTaskId ? { ...st, ...updates } : st
+      )
+    );
   };
 
   const handleAdd = () => {
@@ -158,6 +203,122 @@ export function OCRTimeLabelEditor({
                     />
                   </div>
 
+                  {/* 担当者編集 */}
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      <span className="flex items-center gap-1.5">
+                        <HiUser className="h-4 w-4" />
+                        担当者
+                      </span>
+                    </label>
+                    <input
+                      type="text"
+                      value={editingAssignee}
+                      onChange={(e) => setEditingAssignee(e.target.value)}
+                      className="w-full rounded-md border border-gray-300 px-3 py-2 text-base text-gray-900 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500"
+                      placeholder="例：浅田さん、小山さん"
+                    />
+                  </div>
+
+                  {/* 継続終了時間編集 */}
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      継続終了時間（時間経過タスクの場合）
+                    </label>
+                    <div className="flex items-center gap-2">
+                      <span className="text-gray-500 text-sm">〜</span>
+                      <input
+                        type="number"
+                        value={editingContinuesUntil.hour}
+                        onChange={(e) => {
+                          const value = e.target.value;
+                          if (value === '' || (parseInt(value) >= 0 && parseInt(value) <= 23)) {
+                            setEditingContinuesUntil({ ...editingContinuesUntil, hour: value });
+                          }
+                        }}
+                        min="0"
+                        max="23"
+                        className="w-20 rounded-md border border-gray-300 px-3 py-2 text-base text-gray-900 text-center focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                        placeholder="時"
+                      />
+                      <span className="text-gray-600">:</span>
+                      <input
+                        type="number"
+                        value={editingContinuesUntil.minute}
+                        onChange={(e) => {
+                          const value = e.target.value;
+                          if (value === '' || (parseInt(value) >= 0 && parseInt(value) <= 59)) {
+                            setEditingContinuesUntil({ ...editingContinuesUntil, minute: value });
+                          }
+                        }}
+                        min="0"
+                        max="59"
+                        className="w-20 rounded-md border border-gray-300 px-3 py-2 text-base text-gray-900 text-center focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                        placeholder="分"
+                      />
+                      <span className="text-gray-500 text-sm">まで</span>
+                      {editingContinuesUntil.hour && (
+                        <button
+                          type="button"
+                          onClick={() => setEditingContinuesUntil({ hour: '', minute: '' })}
+                          className="p-1 text-gray-400 hover:text-red-500 transition-colors"
+                          aria-label="継続終了時間をクリア"
+                        >
+                          <HiTrash className="h-4 w-4" />
+                        </button>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* サブタスク編集 */}
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-2">
+                      <span className="flex items-center gap-1.5">
+                        <HiArrowDown className="h-4 w-4" />
+                        連続タスク（サブタスク）
+                      </span>
+                    </label>
+                    <div className="space-y-2 ml-4">
+                      {editingSubTasks.map((subTask, index) => (
+                        <div key={subTask.id} className="flex items-start gap-2 p-2 bg-gray-50 rounded-md">
+                          <span className="text-gray-400 text-sm mt-2">↓</span>
+                          <div className="flex-1 space-y-2">
+                            <input
+                              type="text"
+                              value={subTask.content}
+                              onChange={(e) => handleUpdateSubTask(subTask.id, { content: e.target.value })}
+                              className="w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-900 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500"
+                              placeholder="タスク内容"
+                            />
+                            <input
+                              type="text"
+                              value={subTask.assignee || ''}
+                              onChange={(e) => handleUpdateSubTask(subTask.id, { assignee: e.target.value || undefined })}
+                              className="w-full rounded-md border border-gray-200 px-3 py-1 text-xs text-gray-700 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500"
+                              placeholder="担当者（任意）"
+                            />
+                          </div>
+                          <button
+                            type="button"
+                            onClick={() => handleDeleteSubTask(subTask.id)}
+                            className="p-1.5 text-red-500 hover:bg-red-50 rounded transition-colors mt-1"
+                            aria-label="サブタスクを削除"
+                          >
+                            <HiTrash className="h-4 w-4" />
+                          </button>
+                        </div>
+                      ))}
+                      <button
+                        type="button"
+                        onClick={handleAddSubTask}
+                        className="flex items-center gap-1.5 text-sm text-amber-600 hover:text-amber-700 transition-colors py-1"
+                      >
+                        <HiPlus className="h-4 w-4" />
+                        サブタスクを追加
+                      </button>
+                    </div>
+                  </div>
+
                   {/* 編集ボタン */}
                   <div className="flex gap-2 justify-end">
                     <button
@@ -185,9 +346,42 @@ export function OCRTimeLabelEditor({
                       {label.content && (
                         <span className="text-base text-gray-700">{label.content}</span>
                       )}
+                      {/* 継続終了時間 */}
+                      {label.continuesUntil && (
+                        <span className="text-xs text-amber-600 bg-amber-50 px-2 py-0.5 rounded-full">
+                          〜{label.continuesUntil}まで
+                        </span>
+                      )}
                     </div>
+                    {/* 担当者表示 */}
+                    {label.assignee && (
+                      <div className="flex items-center gap-1.5 mb-2">
+                        <HiUser className="h-3.5 w-3.5 text-gray-400" />
+                        <span className="text-sm text-gray-500 bg-gray-100 px-2 py-0.5 rounded-full">
+                          {label.assignee}
+                        </span>
+                      </div>
+                    )}
                     {label.memo && (
-                      <p className="text-sm text-gray-600 whitespace-pre-wrap">{label.memo}</p>
+                      <p className="text-sm text-gray-600 whitespace-pre-wrap mb-2">{label.memo}</p>
+                    )}
+                    {/* サブタスク表示 */}
+                    {label.subTasks && label.subTasks.length > 0 && (
+                      <div className="ml-4 space-y-1 border-l-2 border-gray-200 pl-3">
+                        {label.subTasks
+                          .sort((a, b) => a.order - b.order)
+                          .map((subTask) => (
+                            <div key={subTask.id} className="flex items-center gap-2">
+                              <HiArrowDown className="h-3.5 w-3.5 text-gray-400 flex-shrink-0" />
+                              <span className="text-sm text-gray-700">{subTask.content}</span>
+                              {subTask.assignee && (
+                                <span className="text-xs text-gray-500 bg-gray-100 px-1.5 py-0.5 rounded-full">
+                                  {subTask.assignee}
+                                </span>
+                              )}
+                            </div>
+                          ))}
+                      </div>
                     )}
                   </div>
                   <div className="flex gap-2">

--- a/components/TodaySchedule.tsx
+++ b/components/TodaySchedule.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import type { AppData, TodaySchedule, TimeLabel } from '@/types';
-import { HiPlus, HiX, HiClock } from 'react-icons/hi';
+import { HiPlus, HiX, HiClock, HiUser, HiArrowDown } from 'react-icons/hi';
 
 interface TodayScheduleProps {
   data: AppData | null;
@@ -469,16 +469,56 @@ function TodayScheduleInner({ data, onUpdate, selectedDate, currentSchedule }: T
                 {/* 内容入力（複数） */}
                 <div className="flex-1 min-w-0 flex flex-col gap-2">
                   {group.labels.map((label) => (
-                    <div key={label.id} className="w-full">
-                      <input
-                        type="text"
-                        value={label.content}
-                        onChange={(e) => updateTimeLabel(label.id, { content: e.target.value })}
-                        onCompositionStart={handleCompositionStart}
-                        onCompositionEnd={handleCompositionEnd}
-                        className="w-full bg-transparent border-0 border-b border-transparent focus:border-amber-400 text-base md:text-base text-gray-900 focus:outline-none placeholder:text-gray-400 transition-colors py-1"
-                        placeholder="内容を入力"
-                      />
+                    <div key={label.id} className={`w-full ${label.continuesUntil ? 'border-l-2 border-dashed border-amber-400 pl-3' : ''}`}>
+                      {/* メインコンテンツ行 */}
+                      <div className="flex items-center gap-2">
+                        <input
+                          type="text"
+                          value={label.content}
+                          onChange={(e) => updateTimeLabel(label.id, { content: e.target.value })}
+                          onCompositionStart={handleCompositionStart}
+                          onCompositionEnd={handleCompositionEnd}
+                          className="flex-1 bg-transparent border-0 border-b border-transparent focus:border-amber-400 text-base md:text-base text-gray-900 focus:outline-none placeholder:text-gray-400 transition-colors py-1"
+                          placeholder="内容を入力"
+                        />
+                        {/* 時間経過終了時間の表示 */}
+                        {label.continuesUntil && (
+                          <span className="flex-shrink-0 text-xs text-amber-600 bg-amber-50 px-2 py-0.5 rounded-full whitespace-nowrap">
+                            〜{label.continuesUntil}まで
+                          </span>
+                        )}
+                      </div>
+                      
+                      {/* 担当者表示 */}
+                      {label.assignee && (
+                        <div className="flex items-center gap-1.5 mt-1 ml-1">
+                          <HiUser className="h-3.5 w-3.5 text-gray-400 flex-shrink-0" />
+                          <span className="text-sm text-gray-500 bg-gray-100 px-2 py-0.5 rounded-full">
+                            {label.assignee}
+                          </span>
+                        </div>
+                      )}
+                      
+                      {/* サブタスク表示 */}
+                      {label.subTasks && label.subTasks.length > 0 && (
+                        <div className="mt-2 ml-4 space-y-1.5">
+                          {label.subTasks
+                            .sort((a, b) => a.order - b.order)
+                            .map((subTask) => (
+                              <div key={subTask.id} className="flex items-start gap-2">
+                                <HiArrowDown className="h-4 w-4 text-gray-400 flex-shrink-0 mt-0.5" />
+                                <div className="flex-1">
+                                  <span className="text-sm text-gray-700">{subTask.content}</span>
+                                  {subTask.assignee && (
+                                    <span className="ml-2 text-xs text-gray-500 bg-gray-100 px-1.5 py-0.5 rounded-full">
+                                      {subTask.assignee}
+                                    </span>
+                                  )}
+                                </div>
+                              </div>
+                            ))}
+                        </div>
+                      )}
                     </div>
                   ))}
                 </div>

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -1,12 +1,23 @@
 // クライアント側の型定義と一致させる必要があるため、簡易的な型定義をここに配置
 // 実際の型定義はクライアント側のtypes/index.tsを参照
 
+export interface SubTask {
+  id: string;
+  content: string;
+  assignee?: string; // 担当者名（自由入力）
+  order: number;
+}
+
 export interface TimeLabel {
   id: string;
   time: string; // HH:mm形式
   content: string;
   memo?: string;
   order?: number;
+  // === スケジュール機能改善で追加 ===
+  assignee?: string; // メインタスクの担当者
+  subTasks?: SubTask[]; // 連続タスク（小さい↓）
+  continuesUntil?: string; // 時間経過終了時間（HH:mm）
 }
 
 export interface RoastSchedule {

--- a/types/index.ts
+++ b/types/index.ts
@@ -57,12 +57,23 @@ export interface AssignmentDay {
   createdAt?: FirestoreTimestamp;
 }
 
+export interface SubTask {
+  id: string;
+  content: string;
+  assignee?: string; // 担当者名（自由入力）
+  order: number;
+}
+
 export interface TimeLabel {
   id: string;
   time: string; // HH:mm
   content: string;
   memo?: string;
   order?: number;
+  // === スケジュール機能改善で追加 ===
+  assignee?: string; // メインタスクの担当者
+  subTasks?: SubTask[]; // 連続タスク（小さい↓）
+  continuesUntil?: string; // 時間経過終了時間（HH:mm）
 }
 
 export interface TodaySchedule {


### PR DESCRIPTION
## Summary
- スケジュールOCR機能を改善し、担当者・連続タスク・時間経過の検出と表示を実装
- SubTask型を追加、TimeLabelに新フィールド（assignee, subTasks, continuesUntil）を追加
- OCRプロンプトを改修して新しい表記パターンを検出可能に
- TodayScheduleとOCRTimeLabelEditorに対応UIを追加

## Test plan
- [x] 3枚のテスト画像（docs/scheduleOCRimage/）でOCR検出を確認
- [x] 担当者の検出・表示・編集を確認
- [x] サブタスク（連続タスク）の検出・表示・編集を確認
- [x] 時間経過（継続終了時間）の検出・表示・編集を確認
- [x] Firebase Functionsデプロイ完了
- [x] フロントエンドビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)