### PR TITLE
[Issue #16] スマホでの「〜○○時まで」表示のはみ出しを修正

### DIFF
--- a/components/TodaySchedule.tsx
+++ b/components/TodaySchedule.tsx
@@ -471,14 +471,14 @@ function TodayScheduleInner({ data, onUpdate, selectedDate, currentSchedule }: T
                   {group.labels.map((label) => (
                     <div key={label.id} className={`w-full ${label.continuesUntil ? 'border-l-2 border-dashed border-amber-400 pl-3' : ''}`}>
                       {/* メインコンテンツ行 */}
-                      <div className="flex items-center gap-2">
+                      <div className="flex items-center gap-2 min-w-0">
                         <input
                           type="text"
                           value={label.content}
                           onChange={(e) => updateTimeLabel(label.id, { content: e.target.value })}
                           onCompositionStart={handleCompositionStart}
                           onCompositionEnd={handleCompositionEnd}
-                          className="flex-1 bg-transparent border-0 border-b border-transparent focus:border-amber-400 text-base md:text-base text-gray-900 focus:outline-none placeholder:text-gray-400 transition-colors py-1"
+                          className="flex-1 min-w-0 bg-transparent border-0 border-b border-transparent focus:border-amber-400 text-base md:text-base text-gray-900 focus:outline-none placeholder:text-gray-400 transition-colors py-1"
                           placeholder="内容を入力"
                         />
                         {/* 時間経過終了時間の表示 */}


### PR DESCRIPTION
## 概要

このPRはIssue #16を解決します。

スマホレイアウトでスケジュール画面の「〜○○時まで」表記が右にはみ出る問題を修正しました。

## 変更内容

- `components/TodaySchedule.tsx` (行472-480)
  - flexコンテナに `min-w-0` を追加してオーバーフローを防止
  - input要素にも `min-w-0` を追加して確実に縮小されるようにする

## 技術的背景

Flexboxでは子要素のデフォルト `min-width` が `auto` となり、コンテンツの最小幅まで縮小しません。
`min-w-0` を設定することで、子要素が親コンテナ内で適切に縮小されるようになります。

## テスト

- [x] npm run lint が通ること
- [x] npm run build が通ること
- [ ] 実機で動作確認

## スクリーンショット

（実機確認後に追加予定）

Fixes #16