### PR TITLE
[Issue #16] スマホ画面でスケジュールの「○○時まで」表記がはみ出る問題を修正

### DIFF
--- a/components/TodaySchedule.tsx
+++ b/components/TodaySchedule.tsx
@@ -471,19 +471,19 @@ function TodayScheduleInner({ data, onUpdate, selectedDate, currentSchedule }: T
                   {group.labels.map((label) => (
                     <div key={label.id} className={`w-full ${label.continuesUntil ? 'border-l-2 border-dashed border-amber-400 pl-3' : ''}`}>
                       {/* メインコンテンツ行 */}
-                      <div className="flex items-center gap-2">
+                      <div className="flex items-center gap-2 min-w-0">
                         <input
                           type="text"
                           value={label.content}
                           onChange={(e) => updateTimeLabel(label.id, { content: e.target.value })}
                           onCompositionStart={handleCompositionStart}
                           onCompositionEnd={handleCompositionEnd}
-                          className="flex-1 bg-transparent border-0 border-b border-transparent focus:border-amber-400 text-base md:text-base text-gray-900 focus:outline-none placeholder:text-gray-400 transition-colors py-1"
+                          className="flex-1 min-w-0 bg-transparent border-0 border-b border-transparent focus:border-amber-400 text-base md:text-base text-gray-900 focus:outline-none placeholder:text-gray-400 transition-colors py-1"
                           placeholder="内容を入力"
                         />
                         {/* 時間経過終了時間の表示 */}
                         {label.continuesUntil && (
-                          <span className="flex-shrink-0 text-xs text-amber-600 bg-amber-50 px-2 py-0.5 rounded-full whitespace-nowrap">
+                          <span className="text-xs text-amber-600 bg-amber-50 px-2 py-0.5 rounded-full whitespace-nowrap">
                             〜{label.continuesUntil}まで
                           </span>
                         )}


### PR DESCRIPTION
## 概要

このPRはIssue #16 を解決します。

スマホのレイアウトでスケジュール画面にある「○○時まで」という記載が右にはみ出て正しく表示できない問題を修正しました。

## 変更内容

- メインコンテンツ行のdiv要素に `min-w-0` を追加してflexアイテムが親コンテナの幅を超えないようにした
- input要素に `min-w-0` を追加して縮小可能にした
- span要素から `flex-shrink-0` を削除して、極端に狭い画面でも対応できるようにした

## 技術的詳細

Flexboxレイアウトでは、子要素のデフォルトの `min-width` は `auto` となり、コンテンツに基づいて自動計算されます。これにより、子要素が親の幅を超えてはみ出すことがあります。`min-w-0` を追加することで、子要素が必要に応じて縮小され、オーバーフローを防ぎます。

## テスト

- [x] npm run lint が通ること
- [ ] 実機/開発者ツールのモバイルビューで動作確認

Fixes #16