### PR TITLE
[Issue #18] コーヒークイズ：正解後に次の問題へ自動遷移

### DIFF
--- a/components/coffee-quiz/CategoryQuestionList.tsx
+++ b/components/coffee-quiz/CategoryQuestionList.tsx
@@ -54,7 +54,7 @@ type SortOption = 'default' | 'difficulty';
 /**
  * カテゴリ別問題一覧コンテナ
  * 出題オプション:
- * 1. 個別問題クリック - 1問だけ解いて一覧に戻る
+ * 1. 個別問題クリック - クリックした問題から連続出題（正解で次へ自動遷移）
  * 2. シャッフル10問 - ランダム10問出題
  * 3. 全問連続 - カテゴリ全問題を出題
  */
@@ -105,10 +105,15 @@ export function CategoryQuestionList({
     return sorted;
   }, [questions, sortBy]);
 
-  // 個別問題を解く
+  // 個別問題を解く（クリックした問題から連続出題）
   const handleQuestionClick = (questionId: string) => {
+    // クリックした問題のインデックスを取得
+    const clickedIndex = sortedQuestions.findIndex(q => q.id === questionId);
+    // クリックした問題から最後までの問題IDリストを作成
+    const remainingQuestions = sortedQuestions.slice(clickedIndex);
+    const ids = remainingQuestions.map(q => q.id).join(',');
     const returnUrl = encodeURIComponent(`/coffee-trivia/category/${category}`);
-    router.push(`/coffee-trivia/quiz?mode=single&questionIds=${questionId}&returnUrl=${returnUrl}`);
+    router.push(`/coffee-trivia/quiz?mode=sequential&questionIds=${ids}&returnUrl=${returnUrl}`);
   };
 
   // シャッフル10問

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -14,7 +14,7 @@ import {
 } from '@/lib/coffee-quiz/questions';
 import { useQuizData } from './useQuizData';
 
-export type QuizMode = 'daily' | 'review' | 'category' | 'random' | 'single' | 'shuffle';
+export type QuizMode = 'daily' | 'review' | 'category' | 'random' | 'single' | 'shuffle' | 'sequential';
 
 interface UseQuizSessionOptions {
   mode?: QuizMode;
@@ -110,6 +110,7 @@ export function useQuizSession(options: UseQuizSessionOptions = {}) {
           break;
         case 'single':
         case 'shuffle':
+        case 'sequential':
           // 指定された問題IDで出題
           if (questionIds && questionIds.length > 0) {
             loadedQuestions = await getQuestionsByIds(questionIds);

--- a/lib/coffee-quiz/types.ts
+++ b/lib/coffee-quiz/types.ts
@@ -185,7 +185,7 @@ export interface QuizSession {
   startedAt: string; // ISO 8601
   completedAt?: string; // ISO 8601
   questions: QuizSessionQuestion[];
-  mode: 'daily' | 'review' | 'category' | 'random' | 'single' | 'shuffle';
+  mode: 'daily' | 'review' | 'category' | 'random' | 'single' | 'shuffle' | 'sequential';
   category?: QuizCategory;
 }
 


### PR DESCRIPTION
## 概要

このPRはIssue #18 を解決します。

コーヒークイズのカテゴリ別問題において、問題に正解した際に一覧画面に戻るのではなく、次の問題に自動的に遷移するようにしました。

## 変更内容

- **sequentialモード**を新規追加
  - 問題一覧から個別問題をクリックすると、その問題から連続で出題
  - 正解時は1.2秒後に自動的に次の問題へ遷移
  - 不正解時は「次の問題へ」ボタンと「一覧に戻る」ボタンを表示
  - 最後の問題正解時は「問題一覧に戻る」ボタンを表示

- **UX改善**
  - クイズを連続して解く際のスムーズな体験を実現
  - 一覧に戻る手間を省略
  - 学習のフローを途切れさせない設計
  - 自動遷移中でも「一覧に戻る」ボタンで途中終了可能

## 変更ファイル

- `app/coffee-trivia/quiz/page.tsx` - sequentialモードのUI追加
- `components/coffee-quiz/CategoryQuestionList.tsx` - 個別問題クリック時の処理変更
- `hooks/useQuizSession.ts` - QuizMode型にsequential追加
- `lib/coffee-quiz/types.ts` - QuizSession型にsequential追加

## テスト

- [x] npm run lint が通ること
- [ ] npm run build が通ること（Firebase API key設定要）
- [ ] 実機で動作確認
  - [ ] 問題一覧から問題をクリックして連続出題されること
  - [ ] 正解時に自動で次の問題へ遷移すること
  - [ ] 不正解時に「次の問題へ」と「一覧に戻る」が表示されること
  - [ ] 最後の問題正解時に「問題一覧に戻る」が表示されること
  - [ ] 自動遷移中に「一覧に戻る」をクリックして中断できること

Fixes #18