### PR TITLE
[Issue #20] カテゴリ別クイズで正解後に○×マークが即時反映されない問題を修正

### DIFF
--- a/app/coffee-trivia/category/[category]/CategoryPageContent.tsx
+++ b/app/coffee-trivia/category/[category]/CategoryPageContent.tsx
@@ -33,9 +33,14 @@ interface CategoryPageContentProps {
 
 export function CategoryPageContent({ category }: CategoryPageContentProps) {
   const router = useRouter();
-  const { progress, loading: progressLoading } = useQuizData();
+  const { progress, loading: progressLoading, refreshProgress } = useQuizData();
   const [questions, setQuestions] = useState<QuizQuestion[]>([]);
   const [loading, setLoading] = useState(true);
+
+  // ページ表示時に進捗データを再読み込み（クイズ回答後の反映用）
+  useEffect(() => {
+    refreshProgress();
+  }, [refreshProgress]);
 
   // カテゴリの検証
   const validCategories: QuizCategory[] = ['basics', 'roasting', 'brewing', 'history'];

--- a/hooks/useQuizData.ts
+++ b/hooks/useQuizData.ts
@@ -390,6 +390,19 @@ export function useQuizData() {
     setProgress(initialProgress);
   }, []);
 
+  // localStorageから進捗を再読み込み
+  const refreshProgress = useCallback(() => {
+    if (!isHydrated) return;
+    try {
+      const stored = getQuizProgress();
+      if (stored) {
+        setProgress(stored);
+      }
+    } catch (err) {
+      console.error('Failed to refresh quiz progress:', err);
+    }
+  }, [isHydrated]);
+
   return {
     progress,
     loading,
@@ -403,6 +416,7 @@ export function useQuizData() {
     categoryMasteryStats,
     difficultyMasteryStats,
     resetProgress,
+    refreshProgress,
   };
 }
 


### PR DESCRIPTION
## 概要

このPRはIssue #20 を解決します。

カテゴリ別クイズで問題に回答した後、問題一覧画面に戻っても○×マークが反映されず、リーダーボード画面まで戻らないと表示されない問題を修正しました。

## 原因

- Next.js App Routerでは、ページ間遷移時にコンポーネントが完全に再マウントされない場合がある
- `useQuizData`フックは初回マウント時に一度だけ`localStorage`からデータを読み込む
- クイズページで回答を保存した後、カテゴリページに戻っても`localStorage`からの再読み込みが行われず、古いデータが表示されていた

## 変更内容

- `useQuizData`フックに`refreshProgress`関数を追加
- `CategoryPageContent`コンポーネントで、ページ表示時に`refreshProgress`を呼び出すよう修正

## テスト

- [x] npm run lint が通ること
- [ ] 実機で動作確認（カテゴリ別クイズで回答後に○×マークが即時反映されること）

Fixes #20