### PR TITLE
[Issue #19] バッジコレクションのアイコンをモダン・シンプルなデザインに変更

### DIFF
--- a/app/coffee-trivia/badges/page.tsx
+++ b/app/coffee-trivia/badges/page.tsx
@@ -6,63 +6,14 @@ import { Loading } from '@/components/Loading';
 import { useQuizData } from '@/hooks/useQuizData';
 import { BADGE_DEFINITIONS } from '@/lib/coffee-quiz/types';
 import type { BadgeType } from '@/lib/coffee-quiz/types';
-
-// アイコン
-const ArrowLeftIcon = () => (
-  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <path d="m12 19-7-7 7-7" />
-    <path d="M19 12H5" />
-  </svg>
-);
-
-const TrophyIcon = () => (
-  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M6 9H4.5a2.5 2.5 0 0 1 0-5H6" />
-    <path d="M18 9h1.5a2.5 2.5 0 0 0 0-5H18" />
-    <path d="M4 22h16" />
-    <path d="M10 14.66V17c0 .55-.47.98-.97 1.21C7.85 18.75 7 20.24 7 22" />
-    <path d="M14 14.66V17c0 .55.47.98.97 1.21C16.15 18.75 17 20.24 17 22" />
-    <path d="M18 2H6v7a6 6 0 0 0 12 0V2Z" />
-  </svg>
-);
-
-const TrophyLargeIcon = () => (
-  <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M6 9H4.5a2.5 2.5 0 0 1 0-5H6" />
-    <path d="M18 9h1.5a2.5 2.5 0 0 0 0-5H18" />
-    <path d="M4 22h16" />
-    <path d="M10 14.66V17c0 .55-.47.98-.97 1.21C7.85 18.75 7 20.24 7 22" />
-    <path d="M14 14.66V17c0 .55.47.98.97 1.21C16.15 18.75 17 20.24 17 22" />
-    <path d="M18 2H6v7a6 6 0 0 0 12 0V2Z" />
-  </svg>
-);
-
-const FlameIcon = () => (
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z" />
-  </svg>
-);
-
-const CheckCircleIcon = () => (
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <circle cx="12" cy="12" r="10" />
-    <path d="m9 12 2 2 4-4" />
-  </svg>
-);
-
-const BookOpenIcon = () => (
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
-    <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
-  </svg>
-);
-
-const AwardIcon = () => (
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <circle cx="12" cy="8" r="6" />
-    <path d="M15.477 12.89 17 22l-5-3-5 3 1.523-9.11" />
-  </svg>
-);
+import {
+  LuArrowLeft,
+  LuTrophy,
+  LuFlame,
+  LuCircleCheck,
+  LuBookOpen,
+  LuAward,
+} from 'react-icons/lu';
 
 export default function BadgesPage() {
   const { progress, loading: quizLoading } = useQuizData();
@@ -104,10 +55,10 @@ export default function BadgesPage() {
           href="/coffee-trivia"
           className="p-2 -ml-2 text-[#3A2F2B] hover:text-[#EF8A00] hover:bg-[#FDF8F0] rounded-full transition-colors"
         >
-          <ArrowLeftIcon />
+          <LuArrowLeft size={24} />
         </Link>
         <h1 className="ml-3 text-lg font-bold text-[#211714] flex items-center gap-2">
-          <TrophyIcon />
+          <LuTrophy size={20} />
           バッジコレクション
         </h1>
       </header>
@@ -125,7 +76,7 @@ export default function BadgesPage() {
             transition={{ delay: 0.2, type: 'spring' }}
             className="mb-2 flex justify-center text-white/90"
           >
-            <TrophyLargeIcon />
+            <LuTrophy size={48} strokeWidth={1.5} />
           </motion.div>
           <div className="text-3xl font-bold mb-1">
             {earnedCount} / {totalCount}
@@ -146,7 +97,7 @@ export default function BadgesPage() {
         {/* ストリーク系バッジ */}
         <BadgeSection
           title="ストリーク"
-          icon={<FlameIcon />}
+          icon={<LuFlame size={18} />}
           badges={badgeGroups.streak}
           earnedBadges={progress?.earnedBadges || []}
           formatDate={formatDate}
@@ -156,7 +107,7 @@ export default function BadgesPage() {
         {/* 正解数系バッジ */}
         <BadgeSection
           title="正解数"
-          icon={<CheckCircleIcon />}
+          icon={<LuCircleCheck size={18} />}
           badges={badgeGroups.correct}
           earnedBadges={progress?.earnedBadges || []}
           formatDate={formatDate}
@@ -166,7 +117,7 @@ export default function BadgesPage() {
         {/* マスタリー系バッジ */}
         <BadgeSection
           title="カテゴリマスター"
-          icon={<BookOpenIcon />}
+          icon={<LuBookOpen size={18} />}
           badges={badgeGroups.master}
           earnedBadges={progress?.earnedBadges || []}
           formatDate={formatDate}
@@ -176,7 +127,7 @@ export default function BadgesPage() {
         {/* その他のバッジ */}
         <BadgeSection
           title="アチーブメント"
-          icon={<AwardIcon />}
+          icon={<LuAward size={18} />}
           badges={badgeGroups.achievement}
           earnedBadges={progress?.earnedBadges || []}
           formatDate={formatDate}


### PR DESCRIPTION
## 概要

このPRはIssue #19 を解決します。

バッジコレクションページ（`/coffee-trivia/badges`）で使用されていたインラインSVGアイコンを、`react-icons/lu`（Lucide）のモダンでミニマルなアイコンに置き換えました。

## 変更内容

- インラインSVGで定義されていた7つのアイコンコンポーネントを削除
- `react-icons/lu` から以下のLucideアイコンをインポート:
  - `LuArrowLeft` - 戻るボタン
  - `LuTrophy` - トロフィー（ヘッダー・サマリー）
  - `LuFlame` - ストリークセクション
  - `LuCircleCheck` - 正解数セクション
  - `LuBookOpen` - カテゴリマスターセクション
  - `LuAward` - アチーブメントセクション
- コード量を約50行削減

## 変更理由

Lucideアイコンを選択した理由:
- モダンでミニマルなデザイン
- 視認性が高い
- プロジェクトで既に使用している`react-icons`パッケージに含まれている
- アプリ全体のデザイントーンとの統一感

## テスト

- [x] `npm run lint` が通ること
- [x] TypeScript型チェックが通ること
- [ ] 実機で動作確認

## スクリーンショット

（実機確認後に追加予定）

Fixes #19