### PR TITLE
[Issue #27] 更新履歴の詳細表示専用ページを追加

### DIFF
--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import React, { useState, useMemo } from 'react';
+import Link from 'next/link';
+import { HiArrowLeft } from 'react-icons/hi';
+import { MdHistory } from 'react-icons/md';
+import type { ChangelogEntryType } from '@/types';
+import { ChangeTypeFilter, ChangelogTimeline } from '@/components/changelog';
+import { DETAILED_CHANGELOG } from '@/data/dev-stories/detailed-changelog';
+
+export default function ChangelogPage() {
+  const [selectedTypes, setSelectedTypes] = useState<ChangelogEntryType[]>([]);
+
+  const handleToggleType = (type: ChangelogEntryType) => {
+    setSelectedTypes((prev) =>
+      prev.includes(type)
+        ? prev.filter((t) => t !== type)
+        : [...prev, type]
+    );
+  };
+
+  const handleClearFilter = () => {
+    setSelectedTypes([]);
+  };
+
+  const filteredEntries = useMemo(() => {
+    if (selectedTypes.length === 0) {
+      return DETAILED_CHANGELOG;
+    }
+    return DETAILED_CHANGELOG.filter((entry) =>
+      selectedTypes.includes(entry.type)
+    );
+  }, [selectedTypes]);
+
+  return (
+    <div
+      className="min-h-screen flex flex-col px-3 sm:px-6 lg:px-8 pt-3 sm:pt-6 lg:pt-8 pb-20 sm:pb-8"
+      style={{ backgroundColor: '#F7F7F5' }}
+    >
+      <div className="max-w-3xl mx-auto w-full flex flex-col flex-1">
+        {/* ヘッダー */}
+        <header className="mb-6 flex-shrink-0">
+          <div className="flex items-center gap-4">
+            <Link
+              href="/settings"
+              className="px-3 py-2 text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded transition-colors flex items-center justify-center min-h-[44px] min-w-[44px]"
+              title="戻る"
+              aria-label="戻る"
+            >
+              <HiArrowLeft className="h-6 w-6 flex-shrink-0" />
+            </Link>
+            <div className="flex-1">
+              <h1 className="text-2xl font-bold text-gray-800 flex items-center gap-2">
+                <MdHistory className="h-7 w-7 text-amber-500" />
+                更新履歴
+              </h1>
+              <p className="text-gray-500 text-sm mt-1 hidden sm:block">
+                ローストプラスの更新内容をご確認いただけます
+              </p>
+            </div>
+          </div>
+        </header>
+
+        {/* フィルター */}
+        <div className="bg-white rounded-lg shadow-sm border border-gray-100 p-4 mb-6 flex-shrink-0">
+          <ChangeTypeFilter
+            selectedTypes={selectedTypes}
+            onToggle={handleToggleType}
+            onClear={handleClearFilter}
+          />
+        </div>
+
+        {/* メインコンテンツ */}
+        <main className="flex-1">
+          <ChangelogTimeline entries={filteredEntries} />
+        </main>
+
+        {/* フッター */}
+        <footer className="mt-8 pt-6 border-t border-gray-200 text-center flex-shrink-0">
+          <p className="text-sm text-gray-400">
+            全 {DETAILED_CHANGELOG.length} 件の更新履歴
+            {selectedTypes.length > 0 && (
+              <span className="ml-2">（{filteredEntries.length} 件表示中）</span>
+            )}
+          </p>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -11,7 +11,6 @@ import { Loading } from '@/components/Loading';
 import { HiArrowLeft, HiDocumentText, HiShieldCheck, HiLogout, HiMail } from 'react-icons/hi';
 import { MdHistory } from 'react-icons/md';
 import LoginPage from '@/app/login/page';
-import { VersionHistory } from '@/components/settings/VersionHistory';
 import { VERSION_HISTORY } from '@/data/dev-stories/version-history';
 import { getUserData } from '@/lib/firestore';
 import { formatConsentDate } from '@/lib/consent';
@@ -204,13 +203,26 @@ export default function SettingsPage() {
                     </div>
 
                     {/* 更新履歴セクション */}
-                    <div className="bg-white rounded-lg shadow-md p-6">
-                        <h2 className="text-xl font-semibold text-gray-800 mb-4 flex items-center gap-2">
-                            <MdHistory className="h-5 w-5 text-gray-600" />
-                            更新履歴
-                        </h2>
-                        <VersionHistory entries={VERSION_HISTORY} maxDisplay={5} />
-                    </div>
+                    <Link
+                        href="/changelog"
+                        className="block bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow"
+                    >
+                        <div className="flex items-center justify-between">
+                            <div className="flex-1">
+                                <h2 className="text-xl font-semibold text-gray-800 mb-2 flex items-center gap-2">
+                                    <MdHistory className="h-5 w-5 text-amber-500" />
+                                    更新履歴
+                                </h2>
+                                <p className="text-sm text-gray-600">
+                                    アプリの更新内容を確認する
+                                </p>
+                                <p className="text-xs text-gray-400 mt-1">
+                                    最新: v{VERSION_HISTORY[0]?.version} ({VERSION_HISTORY[0]?.date})
+                                </p>
+                            </div>
+                            <span className="text-gray-400 text-xl">&gt;</span>
+                        </div>
+                    </Link>
 
                     {/* 法的情報セクション */}
                     <div className="bg-white rounded-lg shadow-md p-6">

--- a/components/changelog/ChangeTypeFilter.tsx
+++ b/components/changelog/ChangeTypeFilter.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import React from 'react';
+import type { ChangelogEntryType } from '@/types';
+import { CHANGE_TYPE_CONFIG, FILTER_TYPES } from '@/data/dev-stories/detailed-changelog';
+
+interface ChangeTypeFilterProps {
+  selectedTypes: ChangelogEntryType[];
+  onToggle: (type: ChangelogEntryType) => void;
+  onClear: () => void;
+}
+
+export const ChangeTypeFilter: React.FC<ChangeTypeFilterProps> = ({
+  selectedTypes,
+  onToggle,
+  onClear,
+}) => {
+  return (
+    <div className="flex flex-wrap gap-2 items-center">
+      <span className="text-sm text-gray-500 mr-1">フィルター:</span>
+      {FILTER_TYPES.map((type) => {
+        const config = CHANGE_TYPE_CONFIG[type];
+        const isSelected = selectedTypes.includes(type);
+        return (
+          <button
+            key={type}
+            onClick={() => onToggle(type)}
+            className={`px-3 py-1.5 rounded-full text-sm font-medium transition-all ${
+              isSelected
+                ? `${config.bgColor} ${config.color} ring-2 ring-offset-1 ring-current`
+                : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
+            }`}
+          >
+            {config.label}
+          </button>
+        );
+      })}
+      {selectedTypes.length > 0 && (
+        <button
+          onClick={onClear}
+          className="px-3 py-1.5 text-sm text-gray-400 hover:text-gray-600 transition-colors"
+        >
+          クリア
+        </button>
+      )}
+    </div>
+  );
+};

--- a/components/changelog/ChangelogTimeline.tsx
+++ b/components/changelog/ChangelogTimeline.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import React from 'react';
+import type { ChangelogEntry } from '@/types';
+import { VersionCard } from './VersionCard';
+import { MdHistory } from 'react-icons/md';
+
+interface ChangelogTimelineProps {
+  entries: ChangelogEntry[];
+}
+
+export const ChangelogTimeline: React.FC<ChangelogTimelineProps> = ({ entries }) => {
+  if (entries.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <div className="flex justify-center mb-4">
+          <div className="p-4 bg-gray-100 rounded-full">
+            <MdHistory className="h-12 w-12 text-gray-400" />
+          </div>
+        </div>
+        <p className="text-gray-500">該当する更新履歴がありません</p>
+        <p className="text-sm text-gray-400 mt-2">フィルターを変更してみてください</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {entries.map((entry) => (
+        <VersionCard key={entry.id} entry={entry} />
+      ))}
+    </div>
+  );
+};

--- a/components/changelog/VersionCard.tsx
+++ b/components/changelog/VersionCard.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import React from 'react';
+import type { ChangelogEntry } from '@/types';
+import { CHANGE_TYPE_CONFIG } from '@/data/dev-stories/detailed-changelog';
+
+interface VersionCardProps {
+  entry: ChangelogEntry;
+}
+
+export const VersionCard: React.FC<VersionCardProps> = ({ entry }) => {
+  const typeConfig = CHANGE_TYPE_CONFIG[entry.type];
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('ja-JP', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm border border-gray-100 p-4 sm:p-5 hover:shadow-md transition-shadow">
+      {/* ヘッダー部分 */}
+      <div className="flex flex-wrap items-center gap-2 mb-3">
+        {entry.version && (
+          <span className="px-2.5 py-1 bg-amber-100 text-amber-700 text-sm font-semibold rounded">
+            v{entry.version}
+          </span>
+        )}
+        <span className={`px-2.5 py-1 ${typeConfig.bgColor} ${typeConfig.color} text-sm font-medium rounded`}>
+          {typeConfig.label}
+        </span>
+        <span className="text-sm text-gray-400 ml-auto">
+          {formatDate(entry.date)}
+        </span>
+      </div>
+
+      {/* タイトル */}
+      <h3 className="text-lg font-semibold text-gray-800 mb-2">
+        {entry.title}
+      </h3>
+
+      {/* 内容 */}
+      <div className="text-sm text-gray-600 whitespace-pre-line leading-relaxed">
+        {entry.content}
+      </div>
+
+      {/* タグ */}
+      {entry.tags && entry.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 mt-3 pt-3 border-t border-gray-100">
+          {entry.tags.map((tag) => (
+            <span
+              key={tag}
+              className="px-2 py-0.5 bg-gray-50 text-gray-500 text-xs rounded"
+            >
+              #{tag}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/components/changelog/index.ts
+++ b/components/changelog/index.ts
@@ -1,0 +1,3 @@
+export { ChangeTypeFilter } from './ChangeTypeFilter';
+export { VersionCard } from './VersionCard';
+export { ChangelogTimeline } from './ChangelogTimeline';

--- a/data/dev-stories/detailed-changelog.ts
+++ b/data/dev-stories/detailed-changelog.ts
@@ -1,0 +1,156 @@
+import type { ChangelogEntry, ChangelogEntryType } from '@/types';
+
+// 変更タイプの日本語ラベルと色定義
+export const CHANGE_TYPE_CONFIG: Record<ChangelogEntryType, { label: string; color: string; bgColor: string }> = {
+  feature: { label: '機能追加', color: 'text-emerald-700', bgColor: 'bg-emerald-100' },
+  bugfix: { label: '修正', color: 'text-red-700', bgColor: 'bg-red-100' },
+  improvement: { label: '改善', color: 'text-blue-700', bgColor: 'bg-blue-100' },
+  docs: { label: 'ドキュメント', color: 'text-purple-700', bgColor: 'bg-purple-100' },
+  style: { label: 'デザイン', color: 'text-pink-700', bgColor: 'bg-pink-100' },
+  update: { label: '更新', color: 'text-gray-700', bgColor: 'bg-gray-100' },
+  story: { label: '開発秘話', color: 'text-amber-700', bgColor: 'bg-amber-100' },
+};
+
+// 詳細な更新履歴データ
+export const DETAILED_CHANGELOG: ChangelogEntry[] = [
+  {
+    id: 'v0.7.0',
+    version: '0.7.0',
+    date: '2026-01-24',
+    type: 'feature',
+    title: 'James Hoffmann V60レシピ・クイズ機能強化・利用規約同意機能',
+    content: `
+- James Hoffmann V60レシピを追加
+- クイズ機能の強化（カテゴリ追加、結果保存）
+- 利用規約・プライバシーポリシーの同意機能を実装
+- ユーザー同意状態のFirestore管理
+    `.trim(),
+    tags: ['ドリップ', 'クイズ', '法的対応'],
+    createdAt: '2026-01-24T00:00:00.000Z',
+    updatedAt: '2026-01-24T00:00:00.000Z',
+  },
+  {
+    id: 'v0.6.1',
+    version: '0.6.1',
+    date: '2026-01-18',
+    type: 'bugfix',
+    title: 'スケジュール読み取り機能の修正と改善',
+    content: `
+- OCR読み取り精度の向上
+- スケジュールパース処理のバグ修正
+- エラーハンドリングの改善
+    `.trim(),
+    tags: ['スケジュール', 'OCR'],
+    createdAt: '2026-01-18T00:00:00.000Z',
+    updatedAt: '2026-01-18T00:00:00.000Z',
+  },
+  {
+    id: 'v0.6.0',
+    version: '0.6.0',
+    date: '2026-01-18',
+    type: 'feature',
+    title: 'AIテイスティング分析・スケジュールOCR・開発秘話',
+    content: `
+- Gemini AIによるテイスティング分析機能を追加
+- スケジュール画像のOCR読み取り機能
+- 開発秘話セクションを追加
+- キャラクター対話形式でアプリの成り立ちを紹介
+    `.trim(),
+    tags: ['AI', 'OCR', '開発秘話'],
+    createdAt: '2026-01-18T00:00:00.000Z',
+    updatedAt: '2026-01-18T00:00:00.000Z',
+  },
+  {
+    id: 'v0.5.18',
+    version: '0.5.18',
+    date: '2026-01-15',
+    type: 'improvement',
+    title: '機能整理アップデート',
+    content: `
+- ナビゲーション構造の見直し
+- 未使用機能の整理
+- パフォーマンス最適化
+    `.trim(),
+    tags: ['リファクタリング'],
+    createdAt: '2026-01-15T00:00:00.000Z',
+    updatedAt: '2026-01-15T00:00:00.000Z',
+  },
+  {
+    id: 'v0.5.17',
+    version: '0.5.17',
+    date: '2026-01-10',
+    type: 'feature',
+    title: 'ドリップガイド機能追加',
+    content: `
+- 複数のドリップレシピに対応
+- ステップバイステップのガイド表示
+- タイマー連動機能
+    `.trim(),
+    tags: ['ドリップ', 'レシピ'],
+    createdAt: '2026-01-10T00:00:00.000Z',
+    updatedAt: '2026-01-10T00:00:00.000Z',
+  },
+  {
+    id: 'v0.5.16',
+    version: '0.5.16',
+    date: '2026-01-05',
+    type: 'feature',
+    title: '作業進捗機能追加',
+    content: `
+- 日々の作業進捗を記録
+- 進捗履歴の可視化
+- グループ別管理機能
+    `.trim(),
+    tags: ['進捗管理'],
+    createdAt: '2026-01-05T00:00:00.000Z',
+    updatedAt: '2026-01-05T00:00:00.000Z',
+  },
+  {
+    id: 'v0.5.15',
+    version: '0.5.15',
+    date: '2025-12-28',
+    type: 'style',
+    title: 'クリスマスモード追加',
+    content: `
+- ホーム画面のクリスマス装飾
+- 雪のアニメーション効果
+- 設定から切り替え可能
+    `.trim(),
+    tags: ['UI', '季節イベント'],
+    createdAt: '2025-12-28T00:00:00.000Z',
+    updatedAt: '2025-12-28T00:00:00.000Z',
+  },
+  {
+    id: 'v0.5.14',
+    version: '0.5.14',
+    date: '2025-12-20',
+    type: 'feature',
+    title: '欠点豆図鑑機能追加',
+    content: `
+- 欠点豆の種類と特徴を図鑑形式で表示
+- 画像付きの詳細説明
+- カスタム欠点豆の追加機能
+    `.trim(),
+    tags: ['欠点豆', '図鑑'],
+    createdAt: '2025-12-20T00:00:00.000Z',
+    updatedAt: '2025-12-20T00:00:00.000Z',
+  },
+];
+
+// フィルター用の全タイプリスト（表示順）
+export const FILTER_TYPES: ChangelogEntryType[] = [
+  'feature',
+  'improvement',
+  'bugfix',
+  'style',
+  'docs',
+];
+
+// 全タグを取得
+export const getAllTags = (): string[] => {
+  const tagSet = new Set<string>();
+  DETAILED_CHANGELOG.forEach((entry) => {
+    entry.tags?.forEach((tag) => tagSet.add(tag));
+  });
+  return Array.from(tagSet).sort();
+};

--- a/types/index.ts
+++ b/types/index.ts
@@ -326,7 +326,7 @@ export interface WorkProgress {
 }
 
 // 更新履歴・開発秘話のカテゴリ（レガシー、後方互換用）
-export type ChangelogEntryType = 'update' | 'story' | 'feature' | 'bugfix' | 'improvement';
+export type ChangelogEntryType = 'update' | 'story' | 'feature' | 'bugfix' | 'improvement' | 'docs' | 'style';
 
 // 更新履歴・開発秘話エントリ（レガシー、後方互換用）
 export interface ChangelogEntry {


### PR DESCRIPTION
## 概要

このPRはIssue #27 を解決します。更新履歴の詳細表示専用ページを追加しました。

## 変更内容

### 新規ファイル
- `app/changelog/page.tsx` - 更新履歴専用ページ
- `components/changelog/ChangeTypeFilter.tsx` - タイプ別フィルターコンポーネント
- `components/changelog/VersionCard.tsx` - バージョンカードコンポーネント
- `components/changelog/ChangelogTimeline.tsx` - タイムライン表示コンポーネント
- `data/dev-stories/detailed-changelog.ts` - 詳細な更新履歴データ

### 変更ファイル
- `types/index.ts` - `ChangelogEntryType`に`docs`と`style`を追加
- `app/settings/page.tsx` - 更新履歴セクションをクリック可能なリンクに変更

## 機能

- タグ（タイプ）別フィルタリング機能
  - 機能追加 / 修正 / 改善 / デザイン / ドキュメント
- バージョンごとのカード表示
- 変更内容の詳細リスト表示
- レスポンシブ対応

## テスト

- [x] npm run lint が通ること
- [x] npm run build が通ること
- [x] 実機で動作確認

Fixes #27
