### PR TITLE
fix(dev-stories): スマホでもヘッダーキャラクターを表示 #32

### DIFF
--- a/app/dev-stories/page.tsx
+++ b/app/dev-stories/page.tsx
@@ -38,22 +38,22 @@ export default function DevStoriesPage() {
               <img
                 src="/avatars/header_characters.png"
                 alt="フカイリとアサイリ"
-                className="h-8 sm:h-12 w-auto object-contain animate-wobble-left"
+                className="h-10 sm:h-12 w-auto object-contain animate-wobble-left"
               />
               <img
                 src="/avatars/header_dori_server.png"
                 alt="ドリとサーバ"
-                className="h-8 sm:h-12 w-auto object-contain animate-wobble-right"
+                className="h-10 sm:h-12 w-auto object-contain animate-wobble-right"
               />
               <img
                 src="/avatars/header_mill_kettle.png"
                 alt="ミルとケトル"
-                className="h-8 sm:h-12 w-auto object-contain animate-wobble-left"
+                className="h-10 sm:h-12 w-auto object-contain animate-wobble-left"
               />
               <img
                 src="/avatars/header_press_siphon.png"
                 alt="プレスとサイフォン"
-                className="h-8 sm:h-12 w-auto object-contain animate-wobble-right"
+                className="h-10 sm:h-12 w-auto object-contain animate-wobble-right"
               />
             </div>
           </div>

--- a/app/dev-stories/page.tsx
+++ b/app/dev-stories/page.tsx
@@ -34,26 +34,26 @@ export default function DevStoriesPage() {
               </p>
             </div>
             {/* キャラクター画像 */}
-            <div className="hidden sm:flex items-center gap-1">
+            <div className="flex items-center gap-0.5 sm:gap-1">
               <img
                 src="/avatars/header_characters.png"
                 alt="フカイリとアサイリ"
-                className="h-12 w-auto object-contain animate-wobble-left"
+                className="h-8 sm:h-12 w-auto object-contain animate-wobble-left"
               />
               <img
                 src="/avatars/header_dori_server.png"
                 alt="ドリとサーバ"
-                className="h-12 w-auto object-contain animate-wobble-right"
+                className="h-8 sm:h-12 w-auto object-contain animate-wobble-right"
               />
               <img
                 src="/avatars/header_mill_kettle.png"
                 alt="ミルとケトル"
-                className="h-12 w-auto object-contain animate-wobble-left"
+                className="h-8 sm:h-12 w-auto object-contain animate-wobble-left"
               />
               <img
                 src="/avatars/header_press_siphon.png"
                 alt="プレスとサイフォン"
-                className="h-12 w-auto object-contain animate-wobble-right"
+                className="h-8 sm:h-12 w-auto object-contain animate-wobble-right"
               />
             </div>
           </div>


### PR DESCRIPTION
## 概要

開発秘話ページのヘッダーにあるキャラクター画像がスマホサイズ（640px未満）で表示されない問題を修正しました。

## 変更内容

- `hidden sm:flex` を `flex` に変更し、スマホでも表示されるように
- 画像サイズをレスポンシブ化（`h-8 sm:h-12`）
- ギャップもレスポンシブ化（`gap-0.5 sm:gap-1`）

## テスト

- [x] npm run build が通ること
- [x] スマホサイズで開発秘話ページを確認

Closes #32
