### PR TITLE
fix(tasting): 試飲感想記録ページのレイアウトシフトを修正 #31

### DIFF
--- a/components/TastingSessionCarousel.tsx
+++ b/components/TastingSessionCarousel.tsx
@@ -35,7 +35,7 @@ export function TastingSessionCarousel({
   onUpdateSession,
 }: TastingSessionCarouselProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const [isDesktop, setIsDesktop] = useState(false);
+  // isDesktop 状態を削除 - CSSメディアクエリで対応
 
   // AI分析の状態管理
   const [isAnalyzing, setIsAnalyzing] = useState<{ [key: string]: boolean }>({});
@@ -43,7 +43,7 @@ export function TastingSessionCarousel({
   const [analyzedIds, setAnalyzedIds] = useState<Set<string>>(new Set());
   // AI分析モーダル用の状態
   const [aiModalSession, setAiModalSession] = useState<TastingSession | null>(null);
-  // アクティブなカードのインデックス
+  // アクティブなカードのインデックス（モバイル用）
   const [activeIndex, setActiveIndex] = useState(0);
 
   // 自動分析を実行する関数
@@ -68,23 +68,14 @@ export function TastingSessionCarousel({
     setIsAnalyzing(prev => ({ ...prev, [session.id]: false }));
   }, [isAnalyzing, analyzedIds, onUpdateSession]);
 
-  // ... (既存のuseEffectなどはそのまま) ...
-
-  // 画面幅に応じてレイアウトモードを決定
-  useEffect(() => {
-    const updateLayout = () => {
-      setIsDesktop(window.innerWidth >= 768);
-    };
-
-    updateLayout();
-    window.addEventListener('resize', updateLayout);
-    return () => window.removeEventListener('resize', updateLayout);
-  }, []);
-
-  // 横スクロールの追跡とホイールイベント
+  // 横スクロールの追跡とホイールイベント（モバイル用）
   useEffect(() => {
     const container = scrollContainerRef.current;
-    if (!container || isDesktop) return;
+    if (!container) return;
+
+    // md以上（768px以上）ではスクロール処理を無効化
+    const mediaQuery = window.matchMedia('(min-width: 768px)');
+    if (mediaQuery.matches) return;
 
     const handleScroll = () => {
       const index = Math.round(container.scrollLeft / container.clientWidth);
@@ -106,7 +97,7 @@ export function TastingSessionCarousel({
       container.removeEventListener('scroll', handleScroll);
       container.removeEventListener('wheel', handleWheel);
     };
-  }, [isDesktop, activeIndex]);
+  }, [activeIndex]);
 
   const formatDate = (dateStr: string) => {
     const date = new Date(dateStr);
@@ -163,24 +154,23 @@ export function TastingSessionCarousel({
   };
 
   // ========================================
-  // デスクトップ向けレイアウト
+  // 両レイアウトを同時にレンダリングし、CSSメディアクエリで表示切り替え
+  // これによりSSR時のハイドレーションミスマッチとレイアウトシフトを防止
   // ========================================
-  if (isDesktop) {
-    return (
-      <div className="w-full px-4 md:px-8 lg:px-12 py-8">
+  return (
+    <>
+      {/* ========================================
+          デスクトップ向けレイアウト (md以上で表示)
+          ======================================== */}
+      <div className="hidden md:block w-full px-4 md:px-8 lg:px-12 py-8">
         <div className="flex flex-col gap-10 max-w-5xl mx-auto">
-          {sessionData.map(({ session, recordCount, averageScores, comments }, index) => {
+          {sessionData.map(({ session, recordCount, averageScores, comments }) => {
             const roastStyle = getRoastBadgeStyle(session.roastLevel);
             const hasAnalysis = !!session.aiAnalysis;
             const analyzing = !!isAnalyzing[session.id];
 
             return (
-              <motion.div
-                key={session.id}
-                initial={{ opacity: 0, y: 30 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: index * 0.1, ease: "easeOut" }}
-              >
+              <div key={session.id}>
                 <Link
                   href={`/tasting?sessionId=${session.id}`}
                   className="block group relative"
@@ -250,7 +240,7 @@ export function TastingSessionCarousel({
                                   <span>{recordCount} / {activeMemberCount}</span>
                                 </div>
                               </div>
-                              <div className="flex-1 min-h-[160px]">
+                              <div className="flex-1 min-h-[160px] max-h-[300px] overflow-y-auto">
                                 {comments.length > 0 ? (
                                   <ul className="space-y-4">
                                     {comments.map((comment, commentIndex) => (
@@ -288,13 +278,12 @@ export function TastingSessionCarousel({
                                       <span className="text-xs font-black text-[#8D6E63]">{item.value.toFixed(1)}</span>
                                     </div>
                                     <div className="h-2.5 bg-[#EFEBE9] rounded-full overflow-hidden shadow-inner border border-[#D7CCC8]/30">
-                                      <motion.div
-                                        initial={{ width: 0 }}
-                                        whileInView={{ width: `${((item.value - 1) / 4) * 100}%` }}
-                                        viewport={{ once: true }}
-                                        transition={{ duration: 1, ease: "easeOut", delay: 0.2 }}
-                                        className="h-full rounded-full shadow-sm"
-                                        style={{ backgroundColor: item.color }}
+                                      <div
+                                        className="h-full rounded-full shadow-sm transition-all duration-700"
+                                        style={{
+                                          width: `${((item.value - 1) / 4) * 100}%`,
+                                          backgroundColor: item.color
+                                        }}
                                       />
                                     </div>
                                   </div>
@@ -329,11 +318,7 @@ export function TastingSessionCarousel({
                             )}
 
                             {hasAnalysis && (
-                              <motion.div
-                                initial={{ opacity: 0, height: 0 }}
-                                animate={{ opacity: 1, height: 'auto' }}
-                                className="bg-white/60 p-6 rounded-sm border border-[#D7CCC8] shadow-sm relative overflow-hidden"
-                              >
+                              <div className="bg-white/60 p-6 rounded-sm border border-[#D7CCC8] shadow-sm relative overflow-hidden">
                                 <div className="absolute top-0 left-0 w-full h-1 bg-[#D7CCC8]/30"></div>
                                 <div className="flex items-center gap-2 mb-3">
                                   <Notepad size={20} weight="duotone" className="text-[#8D6E63]" />
@@ -342,7 +327,7 @@ export function TastingSessionCarousel({
                                 <p className="text-sm font-serif leading-loose text-[#4E342E] whitespace-pre-wrap">
                                   {session.aiAnalysis}
                                 </p>
-                              </motion.div>
+                              </div>
                             )}
                           </div>
                         </div>
@@ -361,251 +346,246 @@ export function TastingSessionCarousel({
                     </div>
                   </div>
                 </Link>
-              </motion.div>
+              </div>
             );
           })}
         </div>
       </div>
-    );
-  }
 
-  // ========================================
-  // モバイル向けレイアウト（横スクロールカルーセル）
-  // ========================================
-  return (
-    <div className="relative w-full h-[calc(100vh-140px)] overflow-hidden flex flex-col">
-      {/* 横スクロールコンテナ */}
-      <div
-        ref={scrollContainerRef}
-        className="flex flex-row gap-4 px-4 h-full overflow-x-auto overflow-y-hidden snap-x snap-mandatory 
-                   [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-track]:bg-stone-200/50 [&::-webkit-scrollbar-track]:mx-8 [&::-webkit-scrollbar-track]:rounded-full
-                   [&::-webkit-scrollbar-thumb]:bg-[#8D6E63] [&::-webkit-scrollbar-thumb]:rounded-full"
-        style={{
-          WebkitOverflowScrolling: 'touch'
-        }}
-      >
-        {sessionData.map(({ session, recordCount, averageScores, comments }, index) => {
-          const hasAnalysis = !!session.aiAnalysis;
-          const analyzing = !!isAnalyzing[session.id];
+      {/* ========================================
+          モバイル向けレイアウト (md未満で表示)
+          ======================================== */}
+      <div className="md:hidden relative w-full h-[calc(100vh-140px)] overflow-hidden flex flex-col">
+        {/* 横スクロールコンテナ */}
+        <div
+          ref={scrollContainerRef}
+          className="flex flex-row gap-4 px-4 h-full overflow-x-auto overflow-y-hidden snap-x snap-mandatory
+                     [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-track]:bg-stone-200/50 [&::-webkit-scrollbar-track]:mx-8 [&::-webkit-scrollbar-track]:rounded-full
+                     [&::-webkit-scrollbar-thumb]:bg-[#8D6E63] [&::-webkit-scrollbar-thumb]:rounded-full"
+          style={{
+            WebkitOverflowScrolling: 'touch'
+          }}
+        >
+          {sessionData.map(({ session, recordCount, averageScores, comments }) => {
+            const hasAnalysis = !!session.aiAnalysis;
+            const analyzing = !!isAnalyzing[session.id];
 
-          return (
-            <motion.div
-              key={session.id}
-              initial={{ opacity: 0, scale: 0.95 }}
-              animate={{ opacity: 1, scale: 1 }}
-              transition={{ delay: index * 0.05 }}
-              className="flex-shrink-0 w-[calc(100vw-2rem)] h-full snap-center"
-            >
-              <Link
-                href={`/tasting?sessionId=${session.id}`}
-                className="block h-full"
+            return (
+              <div
+                key={session.id}
+                className="flex-shrink-0 w-[calc(100vw-2rem)] h-full snap-center"
               >
-                <div
-                  className="rounded-[4px] shadow-lg flex flex-col h-full overflow-hidden relative border border-[#3E2723]/20"
-                  style={{
-                    backgroundImage: 'url("/images/backgrounds/wood-texture.png")',
-                    backgroundSize: 'cover',
-                    backgroundPosition: 'center',
-                  }}
+                <Link
+                  href={`/tasting?sessionId=${session.id}`}
+                  className="block h-full"
                 >
-                  <div className="absolute inset-0 bg-[#1a0f0a]/30 mix-blend-multiply pointer-events-none" />
+                  <div
+                    className="rounded-[4px] shadow-lg flex flex-col h-full overflow-hidden relative border border-[#3E2723]/20"
+                    style={{
+                      backgroundImage: 'url("/images/backgrounds/wood-texture.png")',
+                      backgroundSize: 'cover',
+                      backgroundPosition: 'center',
+                    }}
+                  >
+                    <div className="absolute inset-0 bg-[#1a0f0a]/30 mix-blend-multiply pointer-events-none" />
 
-                  <div className="relative z-10 p-1 flex flex-col h-full">
-                    <div className="bg-[#FDFBF7] rounded-[2px] shadow-inner border border-[#D7CCC8]/50 flex flex-col h-full">
+                    <div className="relative z-10 p-1 flex flex-col h-full">
+                      <div className="bg-[#FDFBF7] rounded-[2px] shadow-inner border border-[#D7CCC8]/50 flex flex-col h-full">
 
-                      {/* ヘッダー（タイトル） */}
-                      <div className="flex-shrink-0 p-5 pb-4 border-b border-dashed border-[#8D6E63]/30 bg-[#FFF8E1]/30">
-                        <div className="flex items-center gap-3">
-                          <div className="p-2 bg-amber-50 rounded-xl">
-                            <Coffee size={24} weight="fill" className="text-amber-700" />
-                          </div>
-                          <div className="flex-1 min-w-0">
-                            <h3 className="text-lg font-serif font-black text-[#3E2723] tracking-tight leading-tight truncate">
-                              {session.beanName}
-                            </h3>
-                            <div className="flex items-center gap-2 mt-1">
-                              <span
-                                className="px-2 py-0.5 text-[9px] font-bold uppercase tracking-widest border border-current rounded-full"
-                                style={{
-                                  color: getRoastBadgeStyle(session.roastLevel).bg,
-                                  borderColor: getRoastBadgeStyle(session.roastLevel).bg
-                                }}
-                              >
-                                {session.roastLevel}
-                              </span>
-                              <span className="text-[10px] text-[#A1887F] font-medium">
-                                {formatDate(session.createdAt)}
-                              </span>
+                        {/* ヘッダー（タイトル） */}
+                        <div className="flex-shrink-0 p-5 pb-4 border-b border-dashed border-[#8D6E63]/30 bg-[#FFF8E1]/30">
+                          <div className="flex items-center gap-3">
+                            <div className="p-2 bg-amber-50 rounded-xl">
+                              <Coffee size={24} weight="fill" className="text-amber-700" />
+                            </div>
+                            <div className="flex-1 min-w-0">
+                              <h3 className="text-lg font-serif font-black text-[#3E2723] tracking-tight leading-tight truncate">
+                                {session.beanName}
+                              </h3>
+                              <div className="flex items-center gap-2 mt-1">
+                                <span
+                                  className="px-2 py-0.5 text-[9px] font-bold uppercase tracking-widest border border-current rounded-full"
+                                  style={{
+                                    color: getRoastBadgeStyle(session.roastLevel).bg,
+                                    borderColor: getRoastBadgeStyle(session.roastLevel).bg
+                                  }}
+                                >
+                                  {session.roastLevel}
+                                </span>
+                                <span className="text-[10px] text-[#A1887F] font-medium">
+                                  {formatDate(session.createdAt)}
+                                </span>
+                              </div>
                             </div>
                           </div>
                         </div>
-                      </div>
 
-                      {/* 横バーチャート（スコア表示） */}
-                      {recordCount > 0 && (
-                        <div className="flex-shrink-0 px-4 py-3 bg-[#fffdf5] border-b border-dashed border-[#8D6E63]/20">
-                          <div className="space-y-2">
-                            {[
-                              { label: '苦味', value: averageScores.bitterness, color: '#44403C' },
-                              { label: '酸味', value: averageScores.acidity, color: '#EA580C' },
-                              { label: 'ボディ', value: averageScores.body, color: '#92400E' },
-                              { label: '甘み', value: averageScores.sweetness, color: '#E11D48' },
-                              { label: '香り', value: averageScores.aroma, color: '#059669' },
-                            ].map((item) => (
-                              <div key={item.label} className="flex items-center gap-2">
-                                <span className="text-[10px] font-bold text-[#5D4037] w-10 flex-shrink-0">{item.label}</span>
-                                <div className="flex-1 h-2 bg-[#EFEBE9] rounded-full overflow-hidden">
-                                  <div
-                                    className="h-full rounded-full transition-all duration-500"
-                                    style={{
-                                      width: `${((item.value - 1) / 4) * 100}%`,
-                                      backgroundColor: item.color
-                                    }}
-                                  />
+                        {/* 横バーチャート（スコア表示） */}
+                        {recordCount > 0 && (
+                          <div className="flex-shrink-0 px-4 py-3 bg-[#fffdf5] border-b border-dashed border-[#8D6E63]/20">
+                            <div className="space-y-2">
+                              {[
+                                { label: '苦味', value: averageScores.bitterness, color: '#44403C' },
+                                { label: '酸味', value: averageScores.acidity, color: '#EA580C' },
+                                { label: 'ボディ', value: averageScores.body, color: '#92400E' },
+                                { label: '甘み', value: averageScores.sweetness, color: '#E11D48' },
+                                { label: '香り', value: averageScores.aroma, color: '#059669' },
+                              ].map((item) => (
+                                <div key={item.label} className="flex items-center gap-2">
+                                  <span className="text-[10px] font-bold text-[#5D4037] w-10 flex-shrink-0">{item.label}</span>
+                                  <div className="flex-1 h-2 bg-[#EFEBE9] rounded-full overflow-hidden">
+                                    <div
+                                      className="h-full rounded-full transition-all duration-500"
+                                      style={{
+                                        width: `${((item.value - 1) / 4) * 100}%`,
+                                        backgroundColor: item.color
+                                      }}
+                                    />
+                                  </div>
+                                  <span className="text-[10px] font-bold text-[#8D6E63] w-6 text-right">{item.value.toFixed(1)}</span>
                                 </div>
-                                <span className="text-[10px] font-bold text-[#8D6E63] w-6 text-right">{item.value.toFixed(1)}</span>
-                              </div>
-                            ))}
+                              ))}
+                            </div>
                           </div>
-                        </div>
-                      )}
+                        )}
 
-                      {/* 感想 + AIコメント */}
-                      <div className="flex-1 flex flex-col min-h-0 p-4 bg-[#fffdf5]">
-                        {/* 感想セクション */}
-                        <div className="flex-1 min-h-0 overflow-hidden">
-                          <div className="flex items-center gap-2 mb-3">
-                            <Quotes size={16} weight="fill" className="text-[#8D6E63]" />
-                            <h4 className="text-sm font-serif font-bold text-[#5D4037]">感想</h4>
-                            <span className="text-[10px] font-bold text-[#A1887F] ml-auto">{recordCount}件の記録</span>
+                        {/* 感想 + AIコメント */}
+                        <div className="flex-1 flex flex-col min-h-0 p-4 bg-[#fffdf5]">
+                          {/* 感想セクション */}
+                          <div className="flex-1 min-h-0 overflow-hidden">
+                            <div className="flex items-center gap-2 mb-3">
+                              <Quotes size={16} weight="fill" className="text-[#8D6E63]" />
+                              <h4 className="text-sm font-serif font-bold text-[#5D4037]">感想</h4>
+                              <span className="text-[10px] font-bold text-[#A1887F] ml-auto">{recordCount}件の記録</span>
+                            </div>
+
+                            <div className="h-[calc(100%-28px)] overflow-y-auto pr-1 [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-thumb]:bg-[#D7CCC8] [&::-webkit-scrollbar-thumb]:rounded-full">
+                              {comments.length > 0 ? (
+                                <ul className="space-y-3">
+                                  {comments.map((comment, commentIndex) => (
+                                    <li key={commentIndex} className="text-sm text-[#4E342E] leading-relaxed pl-3 border-l-2 border-[#A1887F]/40 font-serif italic">
+                                      {comment}
+                                    </li>
+                                  ))}
+                                </ul>
+                              ) : (
+                                <div className="flex items-center justify-center h-full opacity-40">
+                                  <p className="text-xs font-serif text-[#8D6E63]">まだ感想がありません</p>
+                                </div>
+                              )}
+                            </div>
                           </div>
 
-                          <div className="h-[calc(100%-28px)] overflow-y-auto pr-1 [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-thumb]:bg-[#D7CCC8] [&::-webkit-scrollbar-thumb]:rounded-full">
-                            {comments.length > 0 ? (
-                              <ul className="space-y-3">
-                                {comments.map((comment, commentIndex) => (
-                                  <li key={commentIndex} className="text-sm text-[#4E342E] leading-relaxed pl-3 border-l-2 border-[#A1887F]/40 font-serif italic">
-                                    {comment}
-                                  </li>
-                                ))}
-                              </ul>
-                            ) : (
-                              <div className="flex items-center justify-center h-full opacity-40">
-                                <p className="text-xs font-serif text-[#8D6E63]">まだ感想がありません</p>
+                          {/* AI分析ボタン */}
+                          <div className="flex-shrink-0 border-t border-dashed border-[#D7CCC8] pt-3 mt-3">
+                            {!hasAnalysis && !analyzing && recordCount === 0 && (
+                              <p className="text-center text-xs font-serif text-[#8D6E63] italic py-2">記録が追加されるとAI分析が開始されます</p>
+                            )}
+
+                            {analyzing && (
+                              <div className="flex items-center justify-center gap-2 py-2">
+                                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-[#5D4037]"></div>
+                                <span className="text-xs font-serif text-[#8D6E63]">分析中...</span>
                               </div>
+                            )}
+
+                            {hasAnalysis && (
+                              <button
+                                onClick={(e) => {
+                                  e.preventDefault();
+                                  e.stopPropagation();
+                                  setAiModalSession(session);
+                                }}
+                                className="w-full flex items-center justify-between gap-2 bg-[#fffcf0] p-3 rounded border border-[#D7CCC8] hover:bg-[#FFF8E1] transition-colors active:scale-[0.98]"
+                              >
+                                <div className="flex items-center gap-2">
+                                  <Notepad size={16} weight="fill" className="text-[#8D6E63]" />
+                                  <span className="text-xs font-bold text-[#5D4037] font-serif">AIコーヒーマイスターのコメント</span>
+                                </div>
+                                <CaretRight size={16} weight="bold" className="text-[#A1887F]" />
+                              </button>
                             )}
                           </div>
                         </div>
 
-                        {/* AI分析ボタン */}
-                        <div className="flex-shrink-0 border-t border-dashed border-[#D7CCC8] pt-3 mt-3">
-                          {!hasAnalysis && !analyzing && recordCount === 0 && (
-                            <p className="text-center text-xs font-serif text-[#8D6E63] italic py-2">記録が追加されるとAI分析が開始されます</p>
-                          )}
-
-                          {analyzing && (
-                            <div className="flex items-center justify-center gap-2 py-2">
-                              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-[#5D4037]"></div>
-                              <span className="text-xs font-serif text-[#8D6E63]">分析中...</span>
-                            </div>
-                          )}
-
-                          {hasAnalysis && (
-                            <button
-                              onClick={(e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                                setAiModalSession(session);
-                              }}
-                              className="w-full flex items-center justify-between gap-2 bg-[#fffcf0] p-3 rounded border border-[#D7CCC8] hover:bg-[#FFF8E1] transition-colors active:scale-[0.98]"
-                            >
-                              <div className="flex items-center gap-2">
-                                <Notepad size={16} weight="fill" className="text-[#8D6E63]" />
-                                <span className="text-xs font-bold text-[#5D4037] font-serif">AIコーヒーマイスターのコメント</span>
-                              </div>
-                              <CaretRight size={16} weight="bold" className="text-[#A1887F]" />
-                            </button>
-                          )}
-                        </div>
                       </div>
+                    </div>
+                  </div>
+                </Link>
+              </div>
+            )
+          })}
+        </div>
 
+        {/* ページインジケーター */}
+        <div className="flex-shrink-0 flex justify-center gap-1.5 py-4">
+          {sessionData.map((_, index) => (
+            <div
+              key={index}
+              className={`w-1.5 h-1.5 rounded-full transition-all duration-300 ${index === activeIndex ? 'bg-[#5D4037] scale-125' : 'bg-[#D7CCC8]'
+                }`}
+            />
+          ))}
+        </div>
+
+        {/* AI分析モーダル */}
+        <AnimatePresence>
+          {aiModalSession && (
+            <div className="fixed inset-0 z-[100] flex items-end justify-center">
+              <motion.div
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                onClick={() => setAiModalSession(null)}
+                className="absolute inset-0 bg-stone-900/50 backdrop-blur-sm"
+              />
+              <motion.div
+                initial={{ opacity: 0, y: 100 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: 100 }}
+                className="relative bg-[#FDFBF7] rounded-t-[2rem] shadow-2xl w-full max-h-[80vh] overflow-hidden flex flex-col"
+              >
+                {/* ハンドル */}
+                <div className="flex justify-center pt-3 pb-2">
+                  <div className="w-10 h-1 bg-[#D7CCC8] rounded-full" />
+                </div>
+
+                {/* ヘッダー */}
+                <div className="px-6 pb-4 border-b border-dashed border-[#D7CCC8]">
+                  <div className="flex items-center gap-3">
+                    <div className="p-2 bg-amber-50 rounded-xl">
+                      <Notepad size={24} weight="fill" className="text-amber-700" />
+                    </div>
+                    <div>
+                      <h3 className="text-lg font-serif font-black text-[#3E2723]">
+                        AIコーヒーマイスター
+                      </h3>
+                      <p className="text-xs text-[#8D6E63]">{aiModalSession.beanName}</p>
                     </div>
                   </div>
                 </div>
-              </Link>
-            </motion.div>
-          )
-        })}
-      </div>
 
-      {/* ページインジケーター */}
-      <div className="flex-shrink-0 flex justify-center gap-1.5 py-4">
-        {sessionData.map((_, index) => (
-          <div
-            key={index}
-            className={`w-1.5 h-1.5 rounded-full transition-all duration-300 ${index === activeIndex ? 'bg-[#5D4037] scale-125' : 'bg-[#D7CCC8]'
-              }`}
-          />
-        ))}
-      </div>
-
-      {/* AI分析モーダル */}
-      <AnimatePresence>
-        {aiModalSession && (
-          <div className="fixed inset-0 z-[100] flex items-end justify-center">
-            <motion.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              onClick={() => setAiModalSession(null)}
-              className="absolute inset-0 bg-stone-900/50 backdrop-blur-sm"
-            />
-            <motion.div
-              initial={{ opacity: 0, y: 100 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: 100 }}
-              className="relative bg-[#FDFBF7] rounded-t-[2rem] shadow-2xl w-full max-h-[80vh] overflow-hidden flex flex-col"
-            >
-              {/* ハンドル */}
-              <div className="flex justify-center pt-3 pb-2">
-                <div className="w-10 h-1 bg-[#D7CCC8] rounded-full" />
-              </div>
-
-              {/* ヘッダー */}
-              <div className="px-6 pb-4 border-b border-dashed border-[#D7CCC8]">
-                <div className="flex items-center gap-3">
-                  <div className="p-2 bg-amber-50 rounded-xl">
-                    <Notepad size={24} weight="fill" className="text-amber-700" />
-                  </div>
-                  <div>
-                    <h3 className="text-lg font-serif font-black text-[#3E2723]">
-                      AIコーヒーマイスター
-                    </h3>
-                    <p className="text-xs text-[#8D6E63]">{aiModalSession.beanName}</p>
-                  </div>
+                {/* コンテンツ */}
+                <div className="flex-1 overflow-y-auto p-6">
+                  <p className="text-sm font-serif leading-loose text-[#4E342E] whitespace-pre-wrap">
+                    {aiModalSession.aiAnalysis}
+                  </p>
                 </div>
-              </div>
 
-              {/* コンテンツ */}
-              <div className="flex-1 overflow-y-auto p-6">
-                <p className="text-sm font-serif leading-loose text-[#4E342E] whitespace-pre-wrap">
-                  {aiModalSession.aiAnalysis}
-                </p>
-              </div>
-
-              {/* 閉じるボタン */}
-              <div className="p-4 border-t border-[#D7CCC8] bg-[#F5F5F5]">
-                <button
-                  onClick={() => setAiModalSession(null)}
-                  className="w-full py-3 bg-[#5D4037] text-white rounded-2xl font-bold text-sm hover:bg-[#4E342E] transition-colors active:scale-[0.98]"
-                >
-                  閉じる
-                </button>
-              </div>
-            </motion.div>
-          </div>
-        )}
-      </AnimatePresence>
-    </div>
+                {/* 閉じるボタン */}
+                <div className="p-4 border-t border-[#D7CCC8] bg-[#F5F5F5]">
+                  <button
+                    onClick={() => setAiModalSession(null)}
+                    className="w-full py-3 bg-[#5D4037] text-white rounded-2xl font-bold text-sm hover:bg-[#4E342E] transition-colors active:scale-[0.98]"
+                  >
+                    閉じる
+                  </button>
+                </div>
+              </motion.div>
+            </div>
+          )}
+        </AnimatePresence>
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
## 概要

試飲感想記録ページ (/tasting) を開いた瞬間にカードのレイアウトが崩れる問題を修正しました。

## 変更内容

### 問題の原因
1. **`isDesktop` 状態の初期値問題**: `useState(false)` で初期化されていたため、PCでも最初にモバイルレイアウトでレンダリングされ、`useEffect` 実行後にデスクトップに切り替わることでレイアウトがジャンプしていた
2. **Framer Motion アニメーション**: `initial={{ opacity: 0, y: 30 }}` により、カードが透明から表示されるため初期表示時にガタついていた
3. **カード高さの変動**: 感想セクションがコンテンツ量により伸縮していた

### 修正内容
- `isDesktop` 状態を削除し、CSSメディアクエリ (`hidden md:block` / `md:hidden`) に置き換え
- 初期表示時のFramer Motionアニメーションを削除（カードが即座に表示されるように変更）
- 感想セクションに `max-h-[300px]` を追加し、カード高さの変動を抑制
- SSR時とクライアント側で同一のHTMLが生成されるように変更

## テスト

- [x] npm run lint（今回の変更対象ファイルにエラーなし）
- [x] npm run build が通ること
- [ ] 実機で動作確認（デスクトップ/モバイル両方）

## 技術的な詳細

両方のレイアウト（デスクトップ・モバイル）を同時にレンダリングし、CSSの `display: none` で表示を切り替えるアプローチを採用しました。これにより：

- SSR時とクライアント側で同じHTMLが生成される（ハイドレーションミスマッチを防止）
- JavaScript評価前でも正しいレイアウトが表示される
- `useEffect` による遅延レイアウト切り替えが不要に

Closes #31
