### PR TITLE
chore: デバッグ用 console.log を削除 #40

### DIFF
--- a/components/RoastTimer.tsx
+++ b/components/RoastTimer.tsx
@@ -445,7 +445,6 @@ export function RoastTimer() {
   };
 
   const handleReset = () => {
-    console.log('handleReset called');
     // 音を確実に停止
     stopSound();
     resetTimer();

--- a/components/drip-guide/RecipeList.tsx
+++ b/components/drip-guide/RecipeList.tsx
@@ -25,20 +25,17 @@ export const RecipeList: React.FC<RecipeListProps> = ({ recipes, onDelete }) => 
     const router = useRouter();
 
     const handleDeleteClick = (recipeId: string) => {
-        console.log('Delete button clicked for recipe:', recipeId);
         setDeleteTargetId(recipeId);
     };
 
     const handleConfirmDelete = () => {
         if (deleteTargetId) {
-            console.log('Deleting recipe:', deleteTargetId);
             onDelete(deleteTargetId);
             setDeleteTargetId(null);
         }
     };
 
     const handleCancelDelete = () => {
-        console.log('Delete cancelled');
         setDeleteTargetId(null);
     };
 


### PR DESCRIPTION
## 概要

本番環境に残存していたデバッグ用 `console.log` を削除します。

## 変更内容

- `components/RoastTimer.tsx:448` - `handleReset` 関数のデバッグログを削除
- `components/drip-guide/RecipeList.tsx` - 削除操作関連のデバッグログを削除（3箇所）
  - `handleDeleteClick`
  - `handleConfirmDelete`
  - `handleCancelDelete`

## テスト

- [x] npm run build が通ること
- [ ] 実機で動作確認（焙煎タイマーリセット、レシピ削除）

Closes #40
