### PR TITLE
[Issue #42] 📝 Phase 2: フォーム統一（P0: 入力フィールド）

### DIFF
--- a/components/DefectBeanForm.tsx
+++ b/components/DefectBeanForm.tsx
@@ -6,6 +6,7 @@ import { useState, useEffect } from 'react';
 import { HiX, HiCamera, HiTrash } from 'react-icons/hi';
 import { CameraCapture } from './CameraCapture';
 import type { DefectBean } from '@/types';
+import { Input, Textarea, Button } from '@/components/ui';
 
 interface DefectBeanFormProps {
   mode?: 'add' | 'edit';
@@ -221,11 +222,10 @@ export function DefectBeanForm({
             <label className="block text-sm font-semibold text-gray-700 mb-2">
               名称 <span className="text-red-500">*</span>
             </label>
-            <input
+            <Input
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent min-h-[44px] text-gray-900 bg-white"
               placeholder="例: カビ豆"
               required
             />
@@ -236,11 +236,11 @@ export function DefectBeanForm({
             <label className="block text-sm font-semibold text-gray-700 mb-2">
               特徴（見た目の説明）
             </label>
-            <textarea
+            <Textarea
               value={characteristics}
               onChange={(e) => setCharacteristics(e.target.value)}
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent min-h-[100px] resize-y text-gray-900 bg-white"
               placeholder="例: 黒いカビが生えている。表面が黒ずんでいる。"
+              rows={4}
             />
           </div>
 
@@ -249,11 +249,11 @@ export function DefectBeanForm({
             <label className="block text-sm font-semibold text-gray-700 mb-2">
               味への影響
             </label>
-            <textarea
+            <Textarea
               value={tasteImpact}
               onChange={(e) => setTasteImpact(e.target.value)}
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent min-h-[100px] resize-y text-gray-900 bg-white"
               placeholder="例: カビ臭さがコーヒーの風味を損なう。"
+              rows={4}
             />
           </div>
 
@@ -262,40 +262,41 @@ export function DefectBeanForm({
             <label className="block text-sm font-semibold text-gray-700 mb-2">
               省く理由
             </label>
-            <textarea
+            <Textarea
               value={removalReason}
               onChange={(e) => setRemovalReason(e.target.value)}
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent min-h-[100px] resize-y text-gray-900 bg-white"
               placeholder="例: 品質を保つため、カビ豆は必ず除去する。"
+              rows={4}
             />
           </div>
 
           {/* ボタン */}
           <div className={`flex gap-3 pt-4 border-t border-gray-200 ${mode === 'edit' && onDelete ? 'justify-between' : 'justify-end'}`}>
             {mode === 'edit' && onDelete && (
-              <button
+              <Button
                 type="button"
+                variant="danger"
                 onClick={handleDelete}
-                className="px-4 py-3 bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors min-h-[44px] disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
                 disabled={isSubmitting || isDeleting}
               >
                 <HiTrash className="h-5 w-5" />
                 {isDeleting ? '削除中...' : '削除'}
-              </button>
+              </Button>
             )}
             <div className="flex gap-3">
-              <button
+              <Button
                 type="button"
+                variant="secondary"
                 onClick={onCancel}
-                className="px-6 py-3 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 transition-colors min-h-[44px]"
                 disabled={isSubmitting || isDeleting}
               >
                 キャンセル
-              </button>
-              <button
+              </Button>
+              <Button
                 type="submit"
-                className="px-6 py-3 bg-amber-600 text-white rounded-lg hover:bg-amber-700 transition-colors min-h-[44px] disabled:opacity-50 disabled:cursor-not-allowed font-semibold"
+                variant="primary"
                 disabled={isSubmitting || isDeleting}
+                loading={isSubmitting}
               >
                 {isSubmitting
                   ? mode === 'edit'
@@ -304,7 +305,7 @@ export function DefectBeanForm({
                   : mode === 'edit'
                     ? '更新'
                     : '追加'}
-              </button>
+              </Button>
             </div>
           </div>
         </form>

--- a/components/RoastRecordForm.tsx
+++ b/components/RoastRecordForm.tsx
@@ -5,6 +5,7 @@ import type { RoastTimerRecord, AppData } from '@/types';
 import { ALL_BEANS, type BeanName } from '@/lib/beanConfig';
 import { formatTime } from '@/lib/roastTimerUtils';
 import { useToastContext } from '@/components/Toast';
+import { Input, Select, Button } from '@/components/ui';
 
 const ROAST_LEVELS: Array<'浅煎り' | '中煎り' | '中深煎り' | '深煎り'> = [
   '浅煎り',
@@ -168,19 +169,13 @@ function RoastRecordFormInner({
         <label className="block text-sm sm:text-base font-medium text-gray-700 mb-1 sm:mb-2">
           豆の名前 <span className="text-red-500">*</span>
         </label>
-        <select
+        <Select
           value={beanName}
           onChange={(e) => setBeanName(e.target.value as BeanName)}
-          className="w-full rounded-md border border-gray-300 px-3 sm:px-4 py-2 sm:py-2.5 text-base sm:text-lg text-gray-900 bg-white focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500 min-h-[44px]"
+          options={ALL_BEANS.map((bean) => ({ value: bean, label: bean }))}
+          placeholder="選択してください"
           required
-        >
-          <option value="">選択してください</option>
-          {ALL_BEANS.map((bean) => (
-            <option key={bean} value={bean}>
-              {bean}
-            </option>
-          ))}
-        </select>
+        />
       </div>
 
       {/* 重さ */}
@@ -188,21 +183,15 @@ function RoastRecordFormInner({
         <label className="block text-sm sm:text-base font-medium text-gray-700 mb-1 sm:mb-2">
           重さ <span className="text-red-500">*</span>
         </label>
-        <select
-          value={weight}
+        <Select
+          value={weight.toString()}
           onChange={(e) =>
             setWeight(e.target.value ? (parseInt(e.target.value, 10) as 200 | 300 | 500) : '')
           }
-          className="w-full rounded-md border border-gray-300 px-3 sm:px-4 py-2 sm:py-2.5 text-base sm:text-lg text-gray-900 bg-white focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500 min-h-[44px]"
+          options={WEIGHTS.map((w) => ({ value: w.toString(), label: `${w}g` }))}
+          placeholder="選択してください"
           required
-        >
-          <option value="">選択してください</option>
-          {WEIGHTS.map((w) => (
-            <option key={w} value={w}>
-              {w}g
-            </option>
-          ))}
-        </select>
+        />
       </div>
 
       {/* 焙煎度合い */}
@@ -210,23 +199,17 @@ function RoastRecordFormInner({
         <label className="block text-sm sm:text-base font-medium text-gray-700 mb-1 sm:mb-2">
           焙煎度合い <span className="text-red-500">*</span>
         </label>
-        <select
+        <Select
           value={roastLevel}
           onChange={(e) =>
             setRoastLevel(
               e.target.value as '浅煎り' | '中煎り' | '中深煎り' | '深煎り' | ''
             )
           }
-          className="w-full rounded-md border border-gray-300 px-3 sm:px-4 py-2 sm:py-2.5 text-base sm:text-lg text-gray-900 bg-white focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500 min-h-[44px]"
+          options={ROAST_LEVELS.map((level) => ({ value: level, label: level }))}
+          placeholder="選択してください"
           required
-        >
-          <option value="">選択してください</option>
-          {ROAST_LEVELS.map((level) => (
-            <option key={level} value={level}>
-              {level}
-            </option>
-          ))}
-        </select>
+        />
       </div>
 
       {/* 実際のロースト時間 */}
@@ -236,25 +219,23 @@ function RoastRecordFormInner({
         </label>
         <div className="flex gap-3 sm:gap-4">
           <div className="flex-1">
-            <input
+            <Input
               type="text"
               inputMode="numeric"
               value={durationMinutes}
               onChange={(e) => handleDurationMinutesChange(e.target.value)}
               placeholder="分"
-              className="w-full rounded-md border border-gray-300 px-3 sm:px-4 py-2 sm:py-2.5 text-base sm:text-lg text-gray-900 bg-white focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500 min-h-[44px]"
               required
             />
           </div>
           <div className="flex-1">
-            <input
+            <Input
               type="text"
               inputMode="numeric"
               value={durationSeconds}
               onChange={(e) => handleDurationSecondsChange(e.target.value)}
               placeholder="秒"
               maxLength={2}
-              className="w-full rounded-md border border-gray-300 px-3 sm:px-4 py-2 sm:py-2.5 text-base sm:text-lg text-gray-900 bg-white focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500 min-h-[44px]"
             />
           </div>
         </div>
@@ -270,11 +251,10 @@ function RoastRecordFormInner({
         <label className="block text-sm sm:text-base font-medium text-gray-700 mb-1 sm:mb-2">
           焙煎日 <span className="text-red-500">*</span>
         </label>
-        <input
+        <Input
           type="date"
           value={roastDate}
           onChange={(e) => setRoastDate(e.target.value)}
-          className="w-full rounded-md border border-gray-300 px-3 sm:px-4 py-2 sm:py-2.5 text-base sm:text-lg text-gray-900 bg-white focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500 min-h-[44px]"
           required
         />
       </div>
@@ -282,34 +262,36 @@ function RoastRecordFormInner({
       {/* ボタン */}
       <div className="pt-2 sm:pt-4 flex flex-col sm:flex-row gap-3">
         {isEditMode && onDelete && (
-          <button
+          <Button
             type="button"
+            variant="danger"
             onClick={() => {
               if (record && window.confirm('この記録を削除しますか？')) {
                 onDelete(record.id);
               }
             }}
-            className="w-full sm:w-auto px-6 py-3 bg-red-600 text-white rounded-lg font-semibold hover:bg-red-700 transition-colors text-base sm:text-lg min-h-[44px]"
+            className="w-full sm:w-auto"
           >
             削除
-          </button>
+          </Button>
         )}
         <div className="flex-1 flex gap-3">
           {onCancel && (
-            <button
+            <Button
               type="button"
+              variant="secondary"
               onClick={onCancel}
-              className="px-6 py-3 bg-gray-300 text-gray-800 rounded-lg font-semibold hover:bg-gray-400 transition-colors text-base sm:text-lg min-h-[44px]"
             >
               キャンセル
-            </button>
+            </Button>
           )}
-          <button
+          <Button
             type="submit"
-            className="flex-1 flex items-center justify-center gap-2 px-6 py-3 bg-amber-600 text-white rounded-lg font-semibold hover:bg-amber-700 transition-colors text-base sm:text-lg min-h-[44px]"
+            variant="primary"
+            className="flex-1"
           >
             {isEditMode ? '更新' : '保存'}
-          </button>
+          </Button>
         </div>
       </div>
     </form>

--- a/components/TastingRecordForm.tsx
+++ b/components/TastingRecordForm.tsx
@@ -22,6 +22,7 @@ import {
   ChatCircleText
 } from 'phosphor-react';
 import { motion, AnimatePresence } from 'framer-motion';
+import { Input, Select, Textarea, Button } from '@/components/ui';
 
 interface TastingRecordFormProps {
   record: TastingRecord | null;
@@ -314,27 +315,14 @@ export function TastingRecordForm({
               <User size={18} weight="bold" className="text-amber-500" />
               メンバー <span className="text-red-500">*</span>
             </label>
-            <div className="relative">
-              <select
-                value={selectedMemberId}
-                onChange={(e) => handleMemberChange(e.target.value)}
-                className="w-full pl-4 pr-10 py-3.5 bg-gray-50 border-2 border-transparent rounded-2xl focus:bg-white focus:border-amber-500 focus:outline-none transition-all appearance-none text-gray-900 font-medium"
-                required
-                disabled={readOnly}
-              >
-                <option value="" className="text-gray-900">選択してください</option>
-                {selectableMembers.map((member) => (
-                  <option key={member.id} value={member.id} className="text-gray-900">
-                    {member.name}
-                  </option>
-                ))}
-              </select>
-              <div className="absolute right-4 top-1/2 -translate-y-1/2 pointer-events-none text-gray-400">
-                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M19 9l-7 7-7-7" />
-                </svg>
-              </div>
-            </div>
+            <Select
+              value={selectedMemberId}
+              onChange={(e) => handleMemberChange(e.target.value)}
+              options={selectableMembers.map((member) => ({ value: member.id, label: member.name }))}
+              placeholder="選択してください"
+              required
+              disabled={readOnly}
+            />
           </div>
 
           {/* 豆の名前（セッションモードでは非表示） */}
@@ -344,11 +332,10 @@ export function TastingRecordForm({
                 <Coffee size={18} weight="bold" className="text-amber-500" />
                 豆の名前 <span className="text-red-500">*</span>
               </label>
-              <input
+              <Input
                 type="text"
                 value={beanName}
                 onChange={(e) => setBeanName(e.target.value)}
-                className="w-full px-4 py-3.5 bg-gray-50 border-2 border-transparent rounded-2xl focus:bg-white focus:border-amber-500 focus:outline-none transition-all text-gray-900 font-medium placeholder:text-gray-400"
                 placeholder="例: エチオピア イルガチェフェ"
                 required
                 disabled={readOnly}
@@ -364,11 +351,10 @@ export function TastingRecordForm({
                   <Calendar size={18} weight="bold" className="text-amber-500" />
                   試飲日 <span className="text-red-500">*</span>
                 </label>
-                <input
+                <Input
                   type="date"
                   value={tastingDate}
                   onChange={(e) => setTastingDate(e.target.value)}
-                  className="w-full px-4 py-3.5 bg-gray-50 border-2 border-transparent rounded-2xl focus:bg-white focus:border-amber-500 focus:outline-none transition-all text-gray-900 font-medium"
                   required
                   disabled={readOnly}
                 />
@@ -382,26 +368,15 @@ export function TastingRecordForm({
                   <Thermometer size={18} weight="bold" className="text-amber-500" />
                   焙煎度合い <span className="text-red-500">*</span>
                 </label>
-                <div className="relative">
-                  <select
-                    value={roastLevel}
-                    onChange={(e) =>
-                      setRoastLevel(e.target.value as '浅煎り' | '中煎り' | '中深煎り' | '深煎り')
-                    }
-                    className="w-full pl-4 pr-10 py-3.5 bg-gray-50 border-2 border-transparent rounded-2xl focus:bg-white focus:border-amber-500 focus:outline-none transition-all appearance-none text-gray-900 font-medium"
-                    required
-                    disabled={readOnly}
-                  >
-                    {ROAST_LEVELS.map((level) => (
-                      <option key={level} value={level}>{level}</option>
-                    ))}
-                  </select>
-                  <div className="absolute right-4 top-1/2 -translate-y-1/2 pointer-events-none text-gray-400">
-                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M19 9l-7 7-7-7" />
-                    </svg>
-                  </div>
-                </div>
+                <Select
+                  value={roastLevel}
+                  onChange={(e) =>
+                    setRoastLevel(e.target.value as '浅煎り' | '中煎り' | '中深煎り' | '深煎り')
+                  }
+                  options={ROAST_LEVELS.map((level) => ({ value: level, label: level }))}
+                  required
+                  disabled={readOnly}
+                />
               </div>
             )}
           </div>
@@ -510,11 +485,10 @@ export function TastingRecordForm({
               <ChatCircleText size={18} weight="bold" className="text-amber-500" />
               コメント
             </label>
-            <textarea
+            <Textarea
               value={overallImpression}
               onChange={(e) => setOverallImpression(e.target.value)}
               rows={6}
-              className="w-full px-4 py-3.5 bg-gray-50 border-2 border-transparent rounded-2xl focus:bg-white focus:border-amber-500 focus:outline-none transition-all text-gray-900 font-medium placeholder:text-gray-400 resize-none"
               placeholder="コーヒーの全体的な印象、味の深み、後味などを自由に記録してください..."
               disabled={readOnly}
             />
@@ -531,34 +505,39 @@ export function TastingRecordForm({
             className="sticky bottom-6 flex gap-4 bg-white/80 backdrop-blur-md p-4 rounded-3xl shadow-xl border border-white/20 z-20"
           >
             {onDelete && record && (
-              <button
+              <Button
                 type="button"
+                variant="outline"
                 onClick={handleDelete}
-                className="flex-1 px-6 py-4 bg-white border-2 border-gray-100 text-gray-500 rounded-2xl hover:bg-red-50 hover:text-red-600 hover:border-red-100 transition-all font-bold text-lg flex items-center justify-center gap-2"
+                className="flex-1"
               >
                 削除
-              </button>
+              </Button>
             )}
-            <button
+            <Button
               type="submit"
-              className="flex-[2] px-6 py-4 bg-gradient-to-r from-amber-600 to-amber-500 text-white rounded-2xl hover:from-amber-700 hover:to-amber-600 shadow-lg shadow-amber-200 transition-all font-bold text-lg flex items-center justify-center gap-2"
+              variant="primary"
+              size="lg"
+              className="flex-[2]"
             >
               <Smiley size={24} weight="bold" />
               {existingRecordId || record ? '記録を更新する' : '記録を保存する'}
-            </button>
+            </Button>
           </motion.div>
         )}
       </AnimatePresence>
 
       {readOnly && (
         <div className="flex gap-4">
-          <button
+          <Button
             type="button"
+            variant="secondary"
             onClick={onCancel}
-            className="flex-1 px-6 py-4 bg-white border-2 border-gray-100 text-gray-700 rounded-2xl hover:bg-gray-50 transition-all font-bold text-lg"
+            fullWidth
+            size="lg"
           >
             戻る
-          </button>
+          </Button>
         </div>
       )}
     </motion.form>

--- a/components/TastingSessionForm.tsx
+++ b/components/TastingSessionForm.tsx
@@ -11,9 +11,9 @@ import {
   Trash,
   X,
   Plus,
-  Check,
-  CaretDown
+  Check
 } from 'phosphor-react';
+import { Input, Select, Button } from '@/components/ui';
 
 interface TastingSessionFormProps {
   session: TastingSession | null;
@@ -88,11 +88,10 @@ export function TastingSessionForm({
             <Coffee size={20} weight="bold" className="text-amber-600" />
             豆の名前 <span className="text-red-500">*</span>
           </label>
-          <input
+          <Input
             type="text"
             value={beanName}
             onChange={(e) => setBeanName(e.target.value)}
-            className="w-full px-6 py-5 bg-gray-50 border-2 border-transparent rounded-2xl focus:bg-white focus:border-amber-500 focus:outline-none transition-all text-stone-800 font-bold placeholder:text-stone-300 shadow-inner text-lg"
             required
             placeholder="例: コロンビア・エチオピアなど"
           />
@@ -105,27 +104,16 @@ export function TastingSessionForm({
               <Thermometer size={20} weight="bold" className="text-amber-600" />
               焙煎度合い <span className="text-red-500">*</span>
             </label>
-            <div className="relative">
-              <select
-                value={roastLevel}
-                onChange={(e) =>
-                  setRoastLevel(
-                    e.target.value as '浅煎り' | '中煎り' | '中深煎り' | '深煎り'
-                  )
-                }
-                className="w-full px-6 py-5 bg-gray-50 border-2 border-transparent rounded-2xl focus:bg-white focus:border-amber-500 focus:outline-none transition-all text-stone-800 font-bold appearance-none shadow-inner text-lg"
-                required
-              >
-                {ROAST_LEVELS.map((level) => (
-                  <option key={level} value={level}>
-                    {level}
-                  </option>
-                ))}
-              </select>
-              <div className="absolute right-5 top-1/2 -translate-y-1/2 pointer-events-none text-stone-400">
-                <CaretDown size={20} weight="bold" />
-              </div>
-            </div>
+            <Select
+              value={roastLevel}
+              onChange={(e) =>
+                setRoastLevel(
+                  e.target.value as '浅煎り' | '中煎り' | '中深煎り' | '深煎り'
+                )
+              }
+              options={ROAST_LEVELS.map((level) => ({ value: level, label: level }))}
+              required
+            />
           </div>
 
           {/* 試飲日 */}
@@ -134,11 +122,10 @@ export function TastingSessionForm({
               <CalendarBlank size={20} weight="bold" className="text-amber-600" />
               試飲日 <span className="text-red-500">*</span>
             </label>
-            <input
+            <Input
               type="date"
               value={createdAt}
               onChange={(e) => setCreatedAt(e.target.value)}
-              className="w-full px-6 py-5 bg-gray-50 border-2 border-transparent rounded-2xl focus:bg-white focus:border-amber-500 focus:outline-none transition-all text-stone-800 font-bold shadow-inner text-lg"
               required
             />
           </div>
@@ -148,26 +135,32 @@ export function TastingSessionForm({
       {/* ボタン */}
       <div className="flex flex-col sm:flex-row gap-4">
         {!isNew && onDelete && (
-          <button
+          <Button
             type="button"
+            variant="danger"
             onClick={handleDelete}
-            className="flex-1 px-6 py-5 bg-white border-2 border-red-100 text-red-500 rounded-2xl font-black text-lg shadow-sm hover:bg-red-50 transition-all flex items-center justify-center gap-2 order-3 sm:order-1 whitespace-nowrap"
+            size="lg"
+            className="flex-1 order-3 sm:order-1"
           >
             <Trash size={24} weight="bold" />
             削除
-          </button>
+          </Button>
         )}
-        <button
+        <Button
           type="button"
+          variant="secondary"
           onClick={onCancel}
-          className="flex-1 px-6 py-5 bg-white border-2 border-stone-100 text-stone-400 rounded-2xl font-black text-lg shadow-sm hover:bg-stone-50 transition-all flex items-center justify-center gap-2 order-2 whitespace-nowrap"
+          size="lg"
+          className="flex-1 order-2"
         >
           <X size={24} weight="bold" />
           キャンセル
-        </button>
-        <button
+        </Button>
+        <Button
           type="submit"
-          className="flex-[1.5] px-8 py-5 bg-gradient-to-r from-amber-600 to-amber-500 text-white rounded-2xl font-black text-lg shadow-xl shadow-amber-200/50 hover:from-amber-700 hover:to-amber-600 transition-all active:scale-95 flex items-center justify-center gap-2 order-1 sm:order-3 whitespace-nowrap"
+          variant="primary"
+          size="lg"
+          className="flex-[1.5] order-1 sm:order-3"
         >
           {isNew ? (
             <>
@@ -180,7 +173,7 @@ export function TastingSessionForm({
               更新する
             </>
           )}
-        </button>
+        </Button>
       </div>
     </motion.form>
   );

--- a/components/drip-guide/RecipeForm.tsx
+++ b/components/drip-guide/RecipeForm.tsx
@@ -6,6 +6,7 @@ import { StepEditor } from './StepEditor';
 import { FloppyDisk, ArrowLeft, ArrowClockwise } from 'phosphor-react';
 import Link from 'next/link';
 import { MOCK_RECIPES } from '@/lib/drip-guide/mockData';
+import { Input, Textarea, Button } from '@/components/ui';
 
 interface RecipeFormProps {
     initialRecipe?: DripRecipe;
@@ -105,11 +106,10 @@ export const RecipeForm: React.FC<RecipeFormProps> = ({ initialRecipe, onSubmit 
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                         <div className="col-span-2">
                             <label className="block text-sm font-medium text-gray-700 mb-1">レシピ名 <span className="text-red-500">*</span></label>
-                            <input
+                            <Input
                                 type="text"
                                 value={name}
                                 onChange={(e) => setName(e.target.value)}
-                                className="w-full p-3 sm:p-2 border rounded-lg focus:ring-2 focus:ring-amber-500 outline-none text-base"
                                 placeholder="例: BYSN Standard Drip"
                                 required
                             />
@@ -117,11 +117,10 @@ export const RecipeForm: React.FC<RecipeFormProps> = ({ initialRecipe, onSubmit 
 
                         <div>
                             <label className="block text-sm font-medium text-gray-700 mb-1">豆の名前 <span className="text-red-500">*</span></label>
-                            <input
+                            <Input
                                 type="text"
                                 value={beanName}
                                 onChange={(e) => setBeanName(e.target.value)}
-                                className="w-full p-3 sm:p-2 border rounded-lg focus:ring-2 focus:ring-amber-500 outline-none text-base"
                                 placeholder="例: Ethiopia Yirgacheffe"
                                 required
                             />
@@ -129,33 +128,30 @@ export const RecipeForm: React.FC<RecipeFormProps> = ({ initialRecipe, onSubmit 
 
                         <div>
                             <label className="block text-sm font-medium text-gray-700 mb-1">用途・タグ</label>
-                            <input
+                            <Input
                                 type="text"
                                 value={purpose}
                                 onChange={(e) => setPurpose(e.target.value)}
-                                className="w-full p-3 sm:p-2 border rounded-lg focus:ring-2 focus:ring-amber-500 outline-none text-base"
                                 placeholder="例: 試飲会用"
                             />
                         </div>
 
                         <div>
                             <label className="block text-sm font-medium text-gray-700 mb-1">豆の量 (g)</label>
-                            <input
+                            <Input
                                 type="number"
                                 value={beanAmountGram}
                                 onChange={(e) => setBeanAmountGram(parseInt(e.target.value) || 0)}
-                                className="w-full p-3 sm:p-2 border rounded-lg focus:ring-2 focus:ring-amber-500 outline-none text-base"
                                 min={1}
                             />
                         </div>
 
                         <div>
                             <label className="block text-sm font-medium text-gray-700 mb-1">総湯量 (g)</label>
-                            <input
+                            <Input
                                 type="number"
                                 value={totalWaterGram}
                                 onChange={(e) => setTotalWaterGram(parseInt(e.target.value) || 0)}
-                                className="w-full p-3 sm:p-2 border rounded-lg focus:ring-2 focus:ring-amber-500 outline-none text-base"
                                 min={1}
                             />
                         </div>
@@ -165,7 +161,7 @@ export const RecipeForm: React.FC<RecipeFormProps> = ({ initialRecipe, onSubmit 
                             <div className="flex gap-2 items-center">
                                 <div>
                                     <div className="flex items-center gap-2">
-                                        <input
+                                        <Input
                                             type="number"
                                             value={Math.floor(totalDurationSec / 60)}
                                             onChange={(e) => {
@@ -173,7 +169,7 @@ export const RecipeForm: React.FC<RecipeFormProps> = ({ initialRecipe, onSubmit 
                                                 const seconds = totalDurationSec % 60;
                                                 setTotalDurationSec(minutes * 60 + seconds);
                                             }}
-                                            className="w-20 p-3 sm:p-2 border rounded-lg focus:ring-2 focus:ring-amber-500 outline-none text-base text-right"
+                                            className="w-20 text-right"
                                             min={0}
                                         />
                                         <span className="text-gray-600 text-sm whitespace-nowrap font-medium">分</span>
@@ -181,7 +177,7 @@ export const RecipeForm: React.FC<RecipeFormProps> = ({ initialRecipe, onSubmit 
                                 </div>
                                 <div>
                                     <div className="flex items-center gap-2">
-                                        <input
+                                        <Input
                                             type="number"
                                             value={totalDurationSec % 60}
                                             onChange={(e) => {
@@ -189,7 +185,7 @@ export const RecipeForm: React.FC<RecipeFormProps> = ({ initialRecipe, onSubmit 
                                                 const seconds = parseInt(e.target.value) || 0;
                                                 setTotalDurationSec(minutes * 60 + seconds);
                                             }}
-                                            className="w-20 p-3 sm:p-2 border rounded-lg focus:ring-2 focus:ring-amber-500 outline-none text-base text-right"
+                                            className="w-20 text-right"
                                             min={0}
                                             max={59}
                                         />
@@ -201,10 +197,9 @@ export const RecipeForm: React.FC<RecipeFormProps> = ({ initialRecipe, onSubmit 
 
                         <div className="col-span-2">
                             <label className="block text-sm font-medium text-gray-700 mb-1">説明・メモ</label>
-                            <textarea
+                            <Textarea
                                 value={description}
                                 onChange={(e) => setDescription(e.target.value)}
-                                className="w-full p-3 sm:p-2 border rounded-lg focus:ring-2 focus:ring-amber-500 outline-none text-base"
                                 rows={3}
                                 placeholder="レシピの特徴や注意点など"
                             />
@@ -259,22 +254,23 @@ export const RecipeForm: React.FC<RecipeFormProps> = ({ initialRecipe, onSubmit 
             <div className="fixed bottom-0 left-0 right-0 p-4 bg-white border-t border-gray-200 z-10">
                 <div className="max-w-3xl mx-auto flex flex-row gap-3 justify-center">
                     {initialRecipe?.isDefault && (
-                        <button
+                        <Button
                             type="button"
+                            variant="secondary"
                             onClick={handleResetToDefault}
-                            className="flex items-center justify-center gap-2 bg-gray-100 text-gray-700 px-6 py-2.5 rounded-lg font-medium text-base hover:bg-gray-200 transition-colors active:scale-95 touch-manipulation"
                         >
                             <ArrowClockwise size={20} />
                             デフォルトに戻す
-                        </button>
+                        </Button>
                     )}
-                    <button
+                    <Button
                         type="submit"
-                        className="flex items-center justify-center gap-2 bg-amber-600 text-white px-8 py-3 rounded-full font-bold text-lg shadow-lg hover:bg-amber-700 transition-transform active:scale-95 touch-manipulation"
+                        variant="primary"
+                        size="lg"
                     >
                         <FloppyDisk size={24} />
                         レシピを保存
-                    </button>
+                    </Button>
                 </div>
             </div>
         </form>


### PR DESCRIPTION
## 概要

このPRはIssue #42（📝 Phase 2: フォーム統一）を解決します。

既存の5つのフォームコンポーネントを、統一UIコンポーネント（`components/ui/`）に置き換えました。

## 変更内容

### 対象ファイル
- `components/RoastRecordForm.tsx` - Select, Input, Button に置き換え
- `components/TastingRecordForm.tsx` - Select, Input, Textarea, Button に置き換え
- `components/TastingSessionForm.tsx` - Input, Select, Button に置き換え
- `components/drip-guide/RecipeForm.tsx` - Input, Textarea, Button に置き換え
- `components/DefectBeanForm.tsx` - Input, Textarea, Button に置き換え

### 主な変更点
- インラインスタイルの `<select>`, `<input>`, `<textarea>`, `<button>` を統一UIコンポーネントに置き換え
- フォーム送信・バリデーションロジックは変更なし
- SliderInput（TastingRecordForm）およびラジオボタン（RecipeForm）は対象外

## 効果

- **一貫したスタイリング**: すべてのフォームで統一されたUIスタイル
- **クリスマスモード対応準備**: `isChristmasMode` propをサポートする基盤
- **コード簡潔化**: 合計 -49行のコード削減

## テスト

- [x] `npm run lint` が通ること（既存の警告は今回の修正に無関係）
- [x] `npm run build` が通ること
- [ ] 各フォームの入力・送信が正常動作（実機確認）

Closes #42
