### PR TITLE
refactor(ui): Phase 3 - ボタンコンポーネントの統一

### DIFF
--- a/app/assignment/page.tsx
+++ b/app/assignment/page.tsx
@@ -32,6 +32,7 @@ import { IoArrowBack } from "react-icons/io5";
 import { PiShuffleBold } from "react-icons/pi";
 import { FaUsers, FaUserTie } from "react-icons/fa";
 import { HiPlus, HiCog } from "react-icons/hi";
+import { Button } from '@/components/ui';
 
 const toMillisSafe = (value?: FirestoreTimestamp | null): number => {
     if (!value) return 0;
@@ -472,9 +473,14 @@ export default function AssignmentPage() {
                 <div className="w-full px-4 h-16 relative flex items-center justify-center">
                     {/* 左側: 戻るボタン */}
                     <div className="absolute left-4 flex items-center z-10">
-                        <button onClick={() => router.back()} className="text-gray-600 hover:text-gray-900 p-2 -ml-2">
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => router.back()}
+                            className="!text-gray-600 hover:!text-gray-900 !p-2 -ml-2"
+                        >
                             <IoArrowBack size={24} />
-                        </button>
+                        </Button>
                     </div>
 
                     {/* 中央: 見出し */}
@@ -490,25 +496,26 @@ export default function AssignmentPage() {
                     {/* 右側: 設定ボタン + シャッフルボタン */}
                     <div className="absolute right-4 flex items-center gap-2 z-10">
                         {isDeveloperMode && (
-                            <button
+                            <Button
+                                variant="outline"
+                                size="sm"
                                 onClick={() => setIsPairExclusionModalOpen(true)}
-                                className="flex items-center gap-1 px-3 py-2 rounded-full font-bold shadow-md transition-colors bg-white text-gray-700 hover:bg-gray-100 border border-gray-300"
+                                className="!rounded-full !px-3 !py-2 shadow-md !bg-white !text-gray-700 hover:!bg-gray-100 !border !border-gray-300"
                                 title="ペア除外設定"
                             >
                                 <HiCog className="w-5 h-5" />
-                            </button>
+                            </Button>
                         )}
-                        <button
+                        <Button
+                            variant="primary"
+                            size="sm"
                             onClick={handleShuffle}
                             disabled={isShuffleDisabled}
-                            className={`flex items-center gap-2 px-4 py-2 rounded-full font-bold shadow-md transition-colors ${isShuffleDisabled
-                                ? 'bg-gray-400 text-gray-200 cursor-not-allowed'
-                                : 'bg-primary text-white hover:bg-primary-dark active:scale-95'
-                                }`}
+                            className="!rounded-full !px-4 !py-2 shadow-md active:scale-95"
                         >
-                            <PiShuffleBold />
+                            <PiShuffleBold className="mr-1" />
                             <span className="hidden md:inline">シャッフル</span>
-                        </button>
+                        </Button>
                     </div>
                 </div>
             </header>

--- a/app/progress/page.tsx
+++ b/app/progress/page.tsx
@@ -9,6 +9,7 @@ import { addWorkProgress, updateWorkProgress, updateWorkProgresses, deleteWorkPr
 import { HiArrowLeft, HiPlus, HiX, HiPencil, HiTrash, HiFilter, HiSearch, HiOutlineCollection, HiArchive } from 'react-icons/hi';
 import { MdTimeline } from 'react-icons/md';
 import LoginPage from '@/app/login/page';
+import { Button } from '@/components/ui';
 import type { WorkProgress, WorkProgressStatus } from '@/types';
 import { WorkProgressCard } from '@/components/work-progress/WorkProgressCard';
 import { QuickAddModal } from '@/components/work-progress/QuickAddModal';
@@ -385,42 +386,50 @@ export default function ProgressPage() {
           <div className="flex justify-end items-center gap-2 sm:gap-3 flex-shrink-0">
             {viewMode === 'normal' && !showEmptyState && (
               <>
-                <button
+                <Button
+                  variant="outline"
+                  size="sm"
                   onClick={() => setShowFilterDialog(true)}
-                  className="px-3 py-2 text-sm bg-white text-gray-700 rounded-lg shadow-md hover:bg-gray-50 transition-colors flex items-center justify-center gap-2 min-h-[44px] min-w-[44px]"
+                  className="shadow-md !bg-white !text-gray-700 hover:!bg-gray-50"
                   aria-label="フィルタと並び替え"
                   title="フィルタと並び替え"
                 >
                   <HiFilter className="h-4 w-4" />
-                  <span className="hidden md:inline text-sm font-medium whitespace-nowrap">フィルター</span>
-                </button>
+                  <span className="hidden md:inline ml-2 text-sm font-medium whitespace-nowrap">フィルター</span>
+                </Button>
                 {archivedWorkProgressesByDate.length > 0 && (
-                  <button
+                  <Button
+                    variant="outline"
+                    size="sm"
                     onClick={() => setViewMode('archived')}
-                    className="px-3 py-2 text-sm bg-white text-gray-700 rounded-lg shadow-md hover:bg-gray-50 transition-colors flex items-center justify-center min-h-[44px] min-w-[44px]"
+                    className="shadow-md !bg-white !text-gray-700 hover:!bg-gray-50"
                     aria-label="アーカイブ一覧"
                     title="アーカイブ一覧"
                   >
                     <HiArchive className="h-4 w-4" />
-                  </button>
+                  </Button>
                 )}
-                <button
+                <Button
+                  variant="primary"
+                  size="sm"
                   onClick={() => setShowModeSelectDialog(true)}
-                  className="px-4 py-2 text-sm font-bold text-white bg-primary rounded-lg shadow-md hover:bg-primary-dark transition-colors flex items-center justify-center gap-2 min-h-[44px]"
+                  className="shadow-md"
                 >
                   <HiPlus className="h-4 w-4" />
-                  <span className="hidden sm:inline">追加</span>
-                </button>
+                  <span className="hidden sm:inline ml-2">追加</span>
+                </Button>
               </>
             )}
             {viewMode === 'archived' && (
-              <button
+              <Button
+                variant="secondary"
+                size="sm"
                 onClick={() => setViewMode('normal')}
-                className="px-4 py-2 text-sm font-bold text-gray-700 bg-white border border-gray-300 rounded-lg shadow-sm hover:bg-gray-50 transition-colors flex items-center justify-center gap-2 min-h-[44px]"
+                className="shadow-sm !bg-white !text-gray-700 !border !border-gray-300 hover:!bg-gray-50"
               >
                 <MdTimeline className="h-4 w-4" />
-                <span className="hidden sm:inline">一覧に戻る</span>
-              </button>
+                <span className="hidden sm:inline ml-2">一覧に戻る</span>
+              </Button>
             )}
           </div>
         </div>
@@ -458,24 +467,24 @@ export default function ProgressPage() {
                     まずは新しい作業を追加してみましょう。
                   </p>
                   <div className="flex flex-col sm:flex-row gap-4">
-                    <button
-                      onClick={() => {
-                        setShowAddForm(true);
-                      }}
-                      className="px-6 py-3 bg-primary text-white rounded-xl shadow-lg hover:bg-primary-dark hover:shadow-xl transition-all flex items-center justify-center gap-2 font-bold"
+                    <Button
+                      variant="primary"
+                      size="lg"
+                      onClick={() => setShowAddForm(true)}
+                      className="shadow-lg hover:shadow-xl !rounded-xl"
                     >
-                      <HiPlus className="h-5 w-5" />
+                      <HiPlus className="h-5 w-5 mr-2" />
                       作業を追加
-                    </button>
-                    <button
-                      onClick={() => {
-                        setShowAddGroupForm(true);
-                      }}
-                      className="px-6 py-3 bg-white text-amber-600 border border-amber-200 rounded-xl shadow-md hover:bg-amber-50 hover:shadow-lg transition-all flex items-center justify-center gap-2 font-bold"
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="lg"
+                      onClick={() => setShowAddGroupForm(true)}
+                      className="shadow-md hover:shadow-lg !rounded-xl"
                     >
-                      <HiOutlineCollection className="h-5 w-5" />
+                      <HiOutlineCollection className="h-5 w-5 mr-2" />
                       グループを作成
-                    </button>
+                    </Button>
                   </div>
                   {archivedWorkProgressesByDate.length > 0 && (
                     <button
@@ -706,30 +715,36 @@ export default function ProgressPage() {
                   新しい作業を追加するか、作業をまとめるグループを作成するか選択してください。
                 </p>
                 <div className="space-y-3">
-                  <button
+                  <Button
+                    variant="primary"
+                    size="md"
+                    fullWidth
                     onClick={() => {
-                    setShowModeSelectDialog(false);
-                    setShowAddForm(true);
+                      setShowModeSelectDialog(false);
+                      setShowAddForm(true);
                     }}
-                    className="w-full py-3 px-4 bg-primary text-white font-bold rounded-xl shadow-md hover:bg-primary-dark transition-colors flex items-center justify-center gap-3"
+                    className="shadow-md !rounded-xl !py-3"
                   >
-                    <div className="bg-white/20 p-2 rounded-full shadow-sm">
+                    <div className="bg-white/20 p-2 rounded-full shadow-sm mr-3">
                       <HiPlus className="h-5 w-5" />
                     </div>
                     <span>作業を追加</span>
-                  </button>
-                  <button
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    size="md"
+                    fullWidth
                     onClick={() => {
-                    setShowModeSelectDialog(false);
-                    setShowAddGroupForm(true);
+                      setShowModeSelectDialog(false);
+                      setShowAddGroupForm(true);
                     }}
-                    className="w-full py-3 px-4 bg-gray-50 hover:bg-gray-100 text-gray-700 font-bold rounded-xl border border-gray-200 transition-colors flex items-center justify-center gap-3"
+                    className="!bg-gray-50 hover:!bg-gray-100 !text-gray-700 !border !border-gray-200 !rounded-xl !py-3"
                   >
-                    <div className="bg-white p-2 rounded-full shadow-sm">
+                    <div className="bg-white p-2 rounded-full shadow-sm mr-3">
                       <HiOutlineCollection className="h-5 w-5" />
                     </div>
                     <span>グループを作成</span>
-                  </button>
+                  </Button>
                 </div>
               </div>
               <div className="bg-gray-50 px-6 py-4 border-t border-gray-100">
@@ -1007,22 +1022,27 @@ function WorkProgressFormDialog({
 
           <div className="mt-8 flex gap-3">
             {isEditing && onDelete && (
-              <button
+              <Button
                 type="button"
+                variant="danger"
+                size="md"
                 onClick={onDelete}
-                className="px-4 py-3 text-red-600 bg-red-50 hover:bg-red-100 rounded-xl font-bold transition-colors flex items-center justify-center"
+                className="!bg-red-50 !text-red-600 hover:!bg-red-100 !rounded-xl"
                 title="削除"
               >
                 <HiTrash className="h-5 w-5" />
-              </button>
+              </Button>
             )}
-            <button
+            <Button
               type="submit"
+              variant="primary"
+              size="md"
               disabled={isSubmitting}
-              className="flex-1 px-6 py-3 bg-amber-600 text-white rounded-xl font-bold shadow-md hover:bg-amber-700 hover:shadow-lg transition-all flex items-center justify-center gap-2 disabled:opacity-70 disabled:cursor-not-allowed"
+              loading={isSubmitting}
+              className="flex-1 shadow-md hover:shadow-lg !rounded-xl"
             >
               {isSubmitting ? '保存中...' : (isEditing ? '更新する' : '追加する')}
-            </button>
+            </Button>
           </div>
         </form>
       </div>
@@ -1072,20 +1092,24 @@ function GroupFormDialog({
             />
           </div>
           <div className="flex gap-3">
-            <button
+            <Button
               type="button"
+              variant="secondary"
+              size="md"
               onClick={onClose}
-              className="flex-1 px-4 py-2.5 text-gray-600 bg-gray-100 hover:bg-gray-200 rounded-xl font-bold transition-colors"
+              className="flex-1 !rounded-xl"
             >
               キャンセル
-            </button>
-            <button
+            </Button>
+            <Button
               type="submit"
+              variant="primary"
+              size="md"
               disabled={!groupName.trim()}
-              className="flex-1 px-4 py-2.5 bg-amber-600 text-white rounded-xl font-bold shadow-md hover:bg-amber-700 transition-colors disabled:opacity-50"
+              className="flex-1 shadow-md !rounded-xl"
             >
               {isEditing ? '更新' : '作成'}
-            </button>
+            </Button>
           </div>
         </form>
       </div>
@@ -1174,12 +1198,15 @@ function FilterDialog({
         </div>
 
         <div className="bg-gray-50 px-6 py-4 border-t border-gray-100">
-          <button
+          <Button
+            variant="primary"
+            size="md"
+            fullWidth
             onClick={onClose}
-            className="w-full py-3 bg-amber-600 text-white font-bold rounded-xl shadow-md hover:bg-amber-700 transition-colors"
+            className="shadow-md !rounded-xl"
           >
             完了
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/app/schedule/page.tsx
+++ b/app/schedule/page.tsx
@@ -12,6 +12,7 @@ import { HiArrowLeft, HiCalendar, HiClock, HiChevronLeft, HiChevronRight, HiCame
 import { DatePickerModal } from '@/components/DatePickerModal';
 import { ScheduleOCRModal } from '@/components/ScheduleOCRModal';
 import LoginPage from '@/app/login/page';
+import { Button } from '@/components/ui';
 import type { TimeLabel, RoastSchedule } from '@/types';
 
 type TabType = 'today' | 'roast';
@@ -355,15 +356,17 @@ export default function SchedulePage() {
           </div>
           <div className="flex-1 flex justify-end items-center">
             <div className="hidden sm:flex items-center gap-2 sm:gap-3">
-              <button
+              <Button
+                variant="primary"
+                size="md"
                 onClick={() => setIsOCROpen(true)}
-                className="px-3 py-2 sm:px-4 sm:py-2.5 text-xs sm:text-sm bg-primary text-white hover:bg-primary-dark rounded-lg transition-colors flex items-center gap-2 min-h-[44px] shadow-md"
+                className="shadow-md"
                 title="画像から読み取り"
                 aria-label="画像から読み取り"
               >
-                <HiCamera className="h-5 w-5 flex-shrink-0" />
+                <HiCamera className="h-5 w-5 flex-shrink-0 mr-2" />
                 <span className="font-medium">AIで読み取る</span>
-              </button>
+              </Button>
             </div>
           </div>
         </header>
@@ -381,14 +384,16 @@ export default function SchedulePage() {
             >
               本日のスケジュール
             </button>
-            <button
+            <Button
+              variant="primary"
+              size="sm"
               onClick={() => setIsOCROpen(true)}
-              className="px-3 py-2 sm:px-4 sm:py-2.5 bg-primary text-white hover:bg-primary-dark rounded-lg transition-colors text-xs sm:text-sm min-h-[44px] flex items-center justify-center shadow-md"
+              className="!px-3 !py-2 sm:!px-4 sm:!py-2.5 shadow-md"
               title="画像から読み取り"
               aria-label="画像から読み取り"
             >
               <HiCamera className="h-5 w-5 sm:h-6 sm:w-6" />
-            </button>
+            </Button>
             <button
               onClick={() => setActiveTab('roast')}
               className={`flex-1 px-3 py-2 sm:px-4 sm:py-2.5 rounded transition-colors text-xs sm:text-sm min-h-[44px] ${

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -11,6 +11,7 @@ import { Loading } from '@/components/Loading';
 import { HiArrowLeft, HiDocumentText, HiShieldCheck, HiLogout, HiMail } from 'react-icons/hi';
 import { MdHistory } from 'react-icons/md';
 import LoginPage from '@/app/login/page';
+import { Button } from '@/components/ui';
 import { VERSION_HISTORY } from '@/data/dev-stories/version-history';
 import { getUserData } from '@/lib/firestore';
 import { formatConsentDate } from '@/lib/consent';
@@ -180,23 +181,22 @@ export default function SettingsPage() {
                                     <p className="text-sm text-gray-600 mb-3">
                                         新しいバージョンが利用可能です。更新を適用してください。
                                     </p>
-                                    <button
-                                        onClick={applyUpdate}
-                                        className="px-4 py-2 bg-orange-500 text-white rounded-lg hover:bg-orange-600 transition-colors font-medium"
-                                    >
+                                    <Button variant="primary" size="md" onClick={applyUpdate}>
                                         更新する
-                                    </button>
+                                    </Button>
                                 </div>
                             )}
                             {!isUpdateAvailable && process.env.NODE_ENV === 'production' && (
                                 <div className="pt-4 border-t border-gray-200">
-                                    <button
+                                    <Button
+                                        variant="outline"
+                                        size="md"
                                         onClick={checkForUpdates}
                                         disabled={isChecking}
-                                        className="px-4 py-2 text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                                        loading={isChecking}
                                     >
                                         {isChecking ? '確認中...' : '更新を確認'}
-                                    </button>
+                                    </Button>
                                 </div>
                             )}
                         </div>
@@ -297,13 +297,16 @@ export default function SettingsPage() {
                                 </div>
                             </div>
                             <div className="pt-4 border-t border-gray-200">
-                                <button
+                                <Button
+                                    variant="danger"
+                                    size="md"
+                                    fullWidth
                                     onClick={handleLogout}
-                                    className="w-full px-4 py-3 text-red-600 bg-red-50 rounded-lg hover:bg-red-100 transition-colors font-medium flex items-center justify-center gap-2"
+                                    className="!bg-red-50 !text-red-600 hover:!bg-red-100"
                                 >
-                                    <HiLogout className="h-5 w-5" />
+                                    <HiLogout className="h-5 w-5 mr-2" />
                                     ログアウト
-                                </button>
+                                </Button>
                             </div>
                         </div>
                     </div>
@@ -342,19 +345,17 @@ export default function SettingsPage() {
                                     )}
                                 </div>
                                 <div className="flex gap-3 justify-end">
-                                    <button
+                                    <Button
                                         type="button"
+                                        variant="secondary"
+                                        size="md"
                                         onClick={handleCancelPassword}
-                                        className="px-4 py-2 text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors"
                                     >
                                         キャンセル
-                                    </button>
-                                    <button
-                                        type="submit"
-                                        className="px-4 py-2 bg-orange-500 text-white rounded-lg hover:bg-orange-600 transition-colors"
-                                    >
+                                    </Button>
+                                    <Button type="submit" variant="primary" size="md">
                                         確定
-                                    </button>
+                                    </Button>
                                 </div>
                             </form>
                         </div>

--- a/components/RoastTimerDialogs.tsx
+++ b/components/RoastTimerDialogs.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+import { Button } from '@/components/ui';
 
 interface CompletionDialogProps {
   isOpen: boolean;
@@ -36,12 +37,9 @@ export function CompletionDialog({ isOpen, onClose, onContinue }: CompletionDial
           タッパーと木べらを持って焙煎室に行きましょう。
         </p>
         <div className="flex gap-3 sm:gap-4 justify-end">
-          <button
-            onClick={onContinue}
-            className="px-6 py-3 bg-amber-600 text-white rounded-lg font-semibold hover:bg-amber-700 transition-colors text-base sm:text-lg min-h-[44px]"
-          >
+          <Button variant="primary" size="md" onClick={onContinue}>
             OK
-          </button>
+          </Button>
         </div>
       </div>
     </div>
@@ -85,18 +83,22 @@ export function ContinuousRoastDialog({
           焙煎機が温かいうちに次の焙煎が可能です。
         </p>
         <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center">
-          <button
+          <Button
+            variant="primary"
+            size="md"
             onClick={onYes}
-            className="px-4 sm:px-6 py-3 bg-amber-600 text-white rounded-lg font-semibold hover:bg-amber-700 transition-colors text-sm sm:text-base min-h-[44px] whitespace-nowrap flex-1 sm:flex-none order-1 sm:order-2"
+            className="flex-1 sm:flex-none order-1 sm:order-2 whitespace-nowrap"
           >
             続けて焙煎する
-          </button>
-          <button
+          </Button>
+          <Button
+            variant="secondary"
+            size="md"
             onClick={onNo}
-            className="px-4 sm:px-6 py-3 bg-[#00b8d4] text-white rounded-lg font-semibold hover:bg-[#00a0b8] transition-colors text-sm sm:text-base min-h-[44px] whitespace-nowrap flex-1 sm:flex-none order-2 sm:order-1"
+            className="flex-1 sm:flex-none order-2 sm:order-1 whitespace-nowrap !bg-[#00b8d4] hover:!bg-[#00a0b8]"
           >
             アフターパージ
-          </button>
+          </Button>
         </div>
       </div>
     </div>
@@ -134,18 +136,12 @@ export function AfterPurgeDialog({ isOpen, onClose, onRecord }: AfterPurgeDialog
           機械をアフターパージに設定してください。{'\n'}焙煎時間の記録ができます。
         </p>
         <div className="flex gap-3 sm:gap-4 justify-end">
-          <button
-            onClick={onClose}
-            className="px-6 py-3 bg-gray-600 text-white rounded-lg font-semibold hover:bg-gray-700 transition-colors text-base sm:text-lg min-h-[44px]"
-          >
+          <Button variant="secondary" size="md" onClick={onClose}>
             閉じる
-          </button>
-          <button
-            onClick={onRecord}
-            className="px-6 py-3 bg-amber-600 text-white rounded-lg font-semibold hover:bg-amber-700 transition-colors text-base sm:text-lg min-h-[44px]"
-          >
+          </Button>
+          <Button variant="primary" size="md" onClick={onRecord}>
             記録に進む
-          </button>
+          </Button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- `RoastTimerDialogs.tsx`: ダイアログ内の5つのボタンを `Button` コンポーネントに置換
- `app/settings/page.tsx`: 更新・ログアウト・モーダルボタンを統一（5箇所）
- `app/assignment/page.tsx`: 戻る・シャッフル・設定ボタンを統一（3箇所）
- `app/schedule/page.tsx`: OCRボタン（デスクトップ・モバイル）を統一（2箇所）
- `app/progress/page.tsx`: ヘッダー・エンプティステート・ダイアログ内ボタンを統一（多数）

### 除外項目
- `RoastTimerControls.tsx`: ファイルが存在しないため除外
- 管理者バッジボタン（assignment）: 状態による動的スタイルが複雑なため現状維持
- タブナビゲーション（schedule）: アクティブ状態の管理が特殊なため現状維持
- 日付ナビゲーションボタン（schedule）: 細かいサイズ制御が必要なため現状維持

Closes #43

## Test plan
- [ ] 各ページでボタンの表示・動作を確認
- [ ] モバイル/デスクトップ両方で確認
- [ ] ダイアログ内のボタン動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)