### PR TITLE
feat(clock): デジタル時計ページの追加とカスタマイズ設定

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -79,6 +79,27 @@ excluded_tools: []
 # initial prompt for the project. It will always be given to the LLM upon activating the project
 # (contrary to the memories, which are loaded on demand).
 initial_prompt: ""
-
+# the name by which the project can be referenced within Serena
 project_name: "roastplus"
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default)
 included_optional_tools: []
+
+# list of mode names to that are always to be included in the set of active modes
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this setting overrides the global configuration.
+# Set this to [] to disable base modes for this project.
+# Set this to a list of mode names to always include the respective modes for this project.
+base_modes:
+
+# list of mode names that are to be activated by default.
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+default_modes:
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+fixed_tools: []

--- a/app/clock/page.tsx
+++ b/app/clock/page.tsx
@@ -1,16 +1,17 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useCallback, useSyncExternalStore } from 'react';
 import Link from 'next/link';
-import { IoArrowBack } from 'react-icons/io5';
+import { HiArrowLeft } from 'react-icons/hi';
 
 const DAY_NAMES = ['日', '月', '火', '水', '木', '金', '土'];
 
-function formatTime(date: Date): string {
-  const h = String(date.getHours()).padStart(2, '0');
-  const m = String(date.getMinutes()).padStart(2, '0');
-  const s = String(date.getSeconds()).padStart(2, '0');
-  return `${h}:${m}:${s}`;
+function formatTime(date: Date): { h: string; m: string; s: string } {
+  return {
+    h: String(date.getHours()).padStart(2, '0'),
+    m: String(date.getMinutes()).padStart(2, '0'),
+    s: String(date.getSeconds()).padStart(2, '0'),
+  };
 }
 
 function formatDate(date: Date): string {
@@ -21,54 +22,97 @@ function formatDate(date: Date): string {
   return `${y}/${m}/${d} (${day})`;
 }
 
-export default function ClockPage() {
-  const [now, setNow] = useState<Date | null>(null);
-
-  useEffect(() => {
-    setNow(new Date());
-    const timer = setInterval(() => {
-      setNow(new Date());
-    }, 1000);
+function useCurrentTime() {
+  const subscribe = useCallback((callback: () => void) => {
+    const timer = setInterval(callback, 1000);
     return () => clearInterval(timer);
   }, []);
 
+  const getSnapshot = useCallback(() => {
+    const now = new Date();
+    return `${now.getFullYear()}-${now.getMonth()}-${now.getDate()}-${now.getHours()}-${now.getMinutes()}-${now.getSeconds()}`;
+  }, []);
+
+  const getServerSnapshot = useCallback(() => '', []);
+
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  if (!snapshot) return null;
+  return new Date();
+}
+
+export default function ClockPage() {
+  const now = useCurrentTime();
+
   if (!now) {
     return (
-      <div className="flex items-center justify-center h-screen bg-[#1a1a2e]">
-        <span className="text-white text-2xl">読み込み中...</span>
+      <div className="flex items-center justify-center h-screen bg-white">
+        <div className="flex items-center gap-3">
+          <div className="h-5 w-5 rounded-full border-2 border-amber-600 border-t-transparent animate-spin" />
+          <span className="text-gray-500 text-lg">読み込み中...</span>
+        </div>
       </div>
     );
   }
 
-  return (
-    <div className="flex flex-col items-center justify-center h-screen bg-[#1a1a2e] select-none relative">
-      <Link
-        href="/"
-        className="absolute top-4 left-4 text-white/60 hover:text-white/90 transition-colors p-2 rounded-lg"
-        aria-label="ホームに戻る"
-      >
-        <IoArrowBack size={28} />
-      </Link>
+  const time = formatTime(now);
 
+  return (
+    <div className="flex flex-col items-center justify-center h-screen bg-white select-none relative">
+      {/* ヘッダー：戻るボタン */}
+      <div className="absolute top-4 left-4 sm:top-6 sm:left-6">
+        <Link
+          href="/"
+          className="flex items-center justify-center min-h-[44px] min-w-[44px] px-3 py-2 text-gray-500 hover:text-gray-800 hover:bg-gray-100 rounded-lg transition-colors"
+          aria-label="ホームに戻る"
+        >
+          <HiArrowLeft className="h-6 w-6" />
+        </Link>
+      </div>
+
+      {/* 時計表示エリア */}
       <div className="text-center">
+        {/* デジタル時計 */}
         <time
-          className="block font-mono font-bold tracking-wider text-[#00e5ff] leading-none"
-          style={{
-            fontSize: 'clamp(5rem, 20vw, 16rem)',
-            textShadow: '0 0 30px rgba(0, 229, 255, 0.4), 0 0 60px rgba(0, 229, 255, 0.2)',
-          }}
+          className="flex items-baseline justify-center gap-1 leading-none"
           dateTime={now.toISOString()}
         >
-          {formatTime(now)}
+          <span
+            className="font-mono font-bold tracking-tight text-[#211714]"
+            style={{ fontSize: 'clamp(5rem, 20vw, 14rem)' }}
+          >
+            {time.h}
+          </span>
+          <span
+            className="font-mono font-bold text-amber-600 animate-pulse"
+            style={{ fontSize: 'clamp(4rem, 16vw, 11rem)' }}
+          >
+            :
+          </span>
+          <span
+            className="font-mono font-bold tracking-tight text-[#211714]"
+            style={{ fontSize: 'clamp(5rem, 20vw, 14rem)' }}
+          >
+            {time.m}
+          </span>
+          <span
+            className="font-mono font-light tracking-tight text-amber-600/70 ml-1"
+            style={{ fontSize: 'clamp(2.5rem, 8vw, 6rem)' }}
+          >
+            {time.s}
+          </span>
         </time>
+
+        {/* 日付表示 */}
         <p
-          className="mt-4 font-mono text-white/70 tracking-widest"
-          style={{
-            fontSize: 'clamp(1.2rem, 4vw, 3rem)',
-          }}
+          className="mt-4 sm:mt-6 font-mono text-gray-400 tracking-widest"
+          style={{ fontSize: 'clamp(1rem, 3.5vw, 2.2rem)' }}
         >
           {formatDate(now)}
         </p>
+
+        {/* アクセントライン */}
+        <div className="mt-6 sm:mt-8 mx-auto w-24 sm:w-32 h-1 rounded-full bg-gradient-to-r from-amber-400 via-amber-600 to-amber-400 opacity-60" />
       </div>
     </div>
   );

--- a/app/clock/page.tsx
+++ b/app/clock/page.tsx
@@ -75,29 +75,30 @@ export default function ClockPage() {
         {/* デジタル時計 */}
         <time
           className="flex items-baseline justify-center gap-1 leading-none"
+          style={{ fontFamily: 'var(--font-inter), sans-serif', fontFeatureSettings: '"tnum"' }}
           dateTime={now.toISOString()}
         >
           <span
-            className="font-mono font-black text-[#211714]"
-            style={{ fontSize: 'clamp(6rem, 28vw, 28vw)', letterSpacing: '-0.04em' }}
+            className="font-black text-[#211714]"
+            style={{ fontSize: 'clamp(6rem, 28vw, 28vw)' }}
           >
             {time.h}
           </span>
           <span
-            className="font-mono font-black text-amber-600"
-            style={{ fontSize: 'clamp(4rem, 18vw, 18vw)', letterSpacing: '-0.04em' }}
+            className="font-black text-amber-600"
+            style={{ fontSize: 'clamp(4rem, 18vw, 18vw)' }}
           >
             :
           </span>
           <span
-            className="font-mono font-black text-[#211714]"
-            style={{ fontSize: 'clamp(6rem, 28vw, 28vw)', letterSpacing: '-0.04em' }}
+            className="font-black text-[#211714]"
+            style={{ fontSize: 'clamp(6rem, 28vw, 28vw)' }}
           >
             {time.m}
           </span>
           <span
-            className="font-mono font-black text-amber-600/70 ml-1"
-            style={{ fontSize: 'clamp(2.5rem, 10vw, 10vw)', letterSpacing: '-0.04em' }}
+            className="font-black text-amber-600/70 ml-1"
+            style={{ fontSize: 'clamp(2.5rem, 10vw, 10vw)' }}
           >
             {time.s}
           </span>
@@ -105,8 +106,8 @@ export default function ClockPage() {
 
         {/* 日付表示 */}
         <p
-          className="mt-4 sm:mt-6 font-mono text-gray-400 tracking-widest"
-          style={{ fontSize: 'clamp(1.2rem, 4vw, 3rem)' }}
+          className="mt-4 sm:mt-6 text-gray-400 tracking-widest"
+          style={{ fontSize: 'clamp(1.2rem, 4vw, 3rem)', fontFamily: 'var(--font-inter), sans-serif' }}
         >
           {formatDate(now)}
         </p>

--- a/app/clock/page.tsx
+++ b/app/clock/page.tsx
@@ -1,16 +1,28 @@
 'use client';
 
-import { useCallback, useSyncExternalStore } from 'react';
+import { useState, useCallback, useSyncExternalStore } from 'react';
 import Link from 'next/link';
-import { HiArrowLeft } from 'react-icons/hi';
+import { HiArrowLeft, HiCog6Tooth } from 'react-icons/hi2';
+import { useClockSettings } from '@/hooks/useClockSettings';
+import { ClockSettingsModal } from '@/components/clock/ClockSettingsModal';
+import { getThemeColors, getFontFamily, getFontWidthFactor, getScaledClamp } from '@/lib/clockSettings';
 
 const DAY_NAMES = ['日', '月', '火', '水', '木', '金', '土'];
 
-function formatTime(date: Date): { h: string; m: string; s: string } {
+function formatTime(date: Date, use24Hour: boolean): { h: string; m: string; s: string; ampm?: string } {
+  let hours = date.getHours();
+  let ampm: string | undefined;
+
+  if (!use24Hour) {
+    ampm = hours >= 12 ? 'PM' : 'AM';
+    hours = hours % 12 || 12;
+  }
+
   return {
-    h: String(date.getHours()).padStart(2, '0'),
+    h: String(hours).padStart(2, '0'),
     m: String(date.getMinutes()).padStart(2, '0'),
     s: String(date.getSeconds()).padStart(2, '0'),
+    ampm,
   };
 }
 
@@ -43,78 +55,137 @@ function useCurrentTime() {
 
 export default function ClockPage() {
   const now = useCurrentTime();
+  const { settings, isLoaded, updateSettings, resetSettings } = useClockSettings();
+  const [showSettings, setShowSettings] = useState(false);
 
-  if (!now) {
+  const colors = getThemeColors(settings.theme);
+  const fontFamily = getFontFamily(settings.fontKey);
+  const scale = settings.fontScale;
+  const wf = getFontWidthFactor(settings.fontKey);
+
+  if (!now || !isLoaded) {
     return (
-      <div className="flex items-center justify-center h-screen bg-white">
+      <div className="flex items-center justify-center h-screen" style={{ backgroundColor: colors.bg }}>
         <div className="flex items-center gap-3">
-          <div className="h-5 w-5 rounded-full border-2 border-amber-600 border-t-transparent animate-spin" />
-          <span className="text-gray-500 text-lg">読み込み中...</span>
+          <div className="h-5 w-5 rounded-full border-2 border-t-transparent animate-spin" style={{ borderColor: colors.accent, borderTopColor: 'transparent' }} />
+          <span className="text-lg" style={{ color: colors.uiText }}>読み込み中...</span>
         </div>
       </div>
     );
   }
 
-  const time = formatTime(now);
+  const time = formatTime(now, settings.use24Hour);
 
   return (
-    <div className="flex flex-col items-center justify-center h-screen bg-white select-none relative">
-      {/* ヘッダー：戻るボタン */}
+    <div
+      className="flex flex-col items-center justify-center h-screen select-none relative"
+      style={{ backgroundColor: colors.bg }}
+    >
+      {/* ヘッダー：戻るボタン＋設定ボタン */}
       <div className="absolute top-4 left-4 sm:top-6 sm:left-6">
         <Link
           href="/"
-          className="flex items-center justify-center min-h-[44px] min-w-[44px] px-3 py-2 text-gray-500 hover:text-gray-800 hover:bg-gray-100 rounded-lg transition-colors"
+          className="flex items-center justify-center min-h-[44px] min-w-[44px] px-3 py-2 rounded-lg transition-colors"
+          style={{ color: colors.uiText }}
           aria-label="ホームに戻る"
         >
           <HiArrowLeft className="h-6 w-6" />
         </Link>
       </div>
 
+      <div className="absolute top-4 right-4 sm:top-6 sm:right-6">
+        <button
+          onClick={() => setShowSettings(true)}
+          className="flex items-center justify-center min-h-[44px] min-w-[44px] px-3 py-2 rounded-lg transition-colors"
+          style={{ color: colors.uiText }}
+          aria-label="時計の設定"
+        >
+          <HiCog6Tooth className="h-6 w-6" />
+        </button>
+      </div>
+
       {/* 時計表示エリア */}
       <div className="text-center">
+        {/* AM/PM 表示（12時間モード時） */}
+        {!settings.use24Hour && time.ampm && (
+          <p
+            className="font-bold tracking-widest mb-2"
+            style={{
+              fontSize: getScaledClamp(1.5, 5, scale, wf),
+              fontFamily,
+              color: colors.accent,
+            }}
+          >
+            {time.ampm}
+          </p>
+        )}
+
         {/* デジタル時計 */}
         <time
           className="flex items-baseline justify-center gap-1 leading-none"
-          style={{ fontFamily: 'var(--font-inter), sans-serif', fontFeatureSettings: '"tnum"' }}
+          style={{ fontFamily, fontFeatureSettings: '"tnum"' }}
           dateTime={now.toISOString()}
         >
           <span
-            className="font-black text-[#211714]"
-            style={{ fontSize: 'clamp(6rem, 28vw, 28vw)' }}
+            className="font-black"
+            style={{ fontSize: getScaledClamp(6, 28, scale, wf), color: colors.text }}
           >
             {time.h}
           </span>
           <span
-            className="font-black text-amber-600"
-            style={{ fontSize: 'clamp(4rem, 18vw, 18vw)' }}
+            className="font-black"
+            style={{ fontSize: getScaledClamp(4, 18, scale, wf), color: colors.accent }}
           >
             :
           </span>
           <span
-            className="font-black text-[#211714]"
-            style={{ fontSize: 'clamp(6rem, 28vw, 28vw)' }}
+            className="font-black"
+            style={{ fontSize: getScaledClamp(6, 28, scale, wf), color: colors.text }}
           >
             {time.m}
           </span>
-          <span
-            className="font-black text-amber-600/70 ml-1"
-            style={{ fontSize: 'clamp(2.5rem, 10vw, 10vw)' }}
-          >
-            {time.s}
-          </span>
+          {settings.showSeconds && (
+            <span
+              className="font-black ml-1"
+              style={{ fontSize: getScaledClamp(2.5, 10, scale, wf), color: colors.accentSub }}
+            >
+              {time.s}
+            </span>
+          )}
         </time>
 
         {/* 日付表示 */}
-        <p
-          className="mt-4 sm:mt-6 font-bold text-[#211714]/60 tracking-widest"
-          style={{ fontSize: 'clamp(1.5rem, 5vw, 5vw)', fontFamily: 'var(--font-inter), sans-serif' }}
-        >
-          {formatDate(now)}
-        </p>
+        {settings.showDate && (
+          <p
+            className="mt-4 sm:mt-6 font-bold tracking-widest"
+            style={{
+              fontSize: getScaledClamp(1.5, 5, scale, wf),
+              fontFamily,
+              color: colors.dateText,
+            }}
+          >
+            {formatDate(now)}
+          </p>
+        )}
 
         {/* アクセントライン */}
-        <div className="mt-6 sm:mt-8 mx-auto w-24 sm:w-32 h-1 rounded-full bg-gradient-to-r from-amber-400 via-amber-600 to-amber-400 opacity-60" />
+        <div
+          className="mt-6 sm:mt-8 mx-auto w-24 sm:w-32 h-1 rounded-full opacity-60"
+          style={{
+            background: `linear-gradient(to right, ${colors.accentSub}, ${colors.accent}, ${colors.accentSub})`,
+          }}
+        />
       </div>
+
+      {/* 設定モーダル */}
+      {showSettings && (
+        <ClockSettingsModal
+          settings={settings}
+          onUpdate={updateSettings}
+          onReset={resetSettings}
+          onClose={() => setShowSettings(false)}
+        />
+      )}
     </div>
   );
 }

--- a/app/clock/page.tsx
+++ b/app/clock/page.tsx
@@ -78,26 +78,26 @@ export default function ClockPage() {
           dateTime={now.toISOString()}
         >
           <span
-            className="font-mono font-bold tracking-tight text-[#211714]"
-            style={{ fontSize: 'clamp(5rem, 20vw, 14rem)' }}
+            className="font-mono font-black text-[#211714]"
+            style={{ fontSize: 'clamp(6rem, 28vw, 28vw)', letterSpacing: '-0.04em' }}
           >
             {time.h}
           </span>
           <span
-            className="font-mono font-bold text-amber-600 animate-pulse"
-            style={{ fontSize: 'clamp(4rem, 16vw, 11rem)' }}
+            className="font-mono font-black text-amber-600"
+            style={{ fontSize: 'clamp(4rem, 18vw, 18vw)', letterSpacing: '-0.04em' }}
           >
             :
           </span>
           <span
-            className="font-mono font-bold tracking-tight text-[#211714]"
-            style={{ fontSize: 'clamp(5rem, 20vw, 14rem)' }}
+            className="font-mono font-black text-[#211714]"
+            style={{ fontSize: 'clamp(6rem, 28vw, 28vw)', letterSpacing: '-0.04em' }}
           >
             {time.m}
           </span>
           <span
-            className="font-mono font-light tracking-tight text-amber-600/70 ml-1"
-            style={{ fontSize: 'clamp(2.5rem, 8vw, 6rem)' }}
+            className="font-mono font-black text-amber-600/70 ml-1"
+            style={{ fontSize: 'clamp(2.5rem, 10vw, 10vw)', letterSpacing: '-0.04em' }}
           >
             {time.s}
           </span>
@@ -106,7 +106,7 @@ export default function ClockPage() {
         {/* 日付表示 */}
         <p
           className="mt-4 sm:mt-6 font-mono text-gray-400 tracking-widest"
-          style={{ fontSize: 'clamp(1rem, 3.5vw, 2.2rem)' }}
+          style={{ fontSize: 'clamp(1.2rem, 4vw, 3rem)' }}
         >
           {formatDate(now)}
         </p>

--- a/app/clock/page.tsx
+++ b/app/clock/page.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { IoArrowBack } from 'react-icons/io5';
+
+const DAY_NAMES = ['日', '月', '火', '水', '木', '金', '土'];
+
+function formatTime(date: Date): string {
+  const h = String(date.getHours()).padStart(2, '0');
+  const m = String(date.getMinutes()).padStart(2, '0');
+  const s = String(date.getSeconds()).padStart(2, '0');
+  return `${h}:${m}:${s}`;
+}
+
+function formatDate(date: Date): string {
+  const y = date.getFullYear();
+  const m = date.getMonth() + 1;
+  const d = date.getDate();
+  const day = DAY_NAMES[date.getDay()];
+  return `${y}/${m}/${d} (${day})`;
+}
+
+export default function ClockPage() {
+  const [now, setNow] = useState<Date | null>(null);
+
+  useEffect(() => {
+    setNow(new Date());
+    const timer = setInterval(() => {
+      setNow(new Date());
+    }, 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  if (!now) {
+    return (
+      <div className="flex items-center justify-center h-screen bg-[#1a1a2e]">
+        <span className="text-white text-2xl">読み込み中...</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center h-screen bg-[#1a1a2e] select-none relative">
+      <Link
+        href="/"
+        className="absolute top-4 left-4 text-white/60 hover:text-white/90 transition-colors p-2 rounded-lg"
+        aria-label="ホームに戻る"
+      >
+        <IoArrowBack size={28} />
+      </Link>
+
+      <div className="text-center">
+        <time
+          className="block font-mono font-bold tracking-wider text-[#00e5ff] leading-none"
+          style={{
+            fontSize: 'clamp(5rem, 20vw, 16rem)',
+            textShadow: '0 0 30px rgba(0, 229, 255, 0.4), 0 0 60px rgba(0, 229, 255, 0.2)',
+          }}
+          dateTime={now.toISOString()}
+        >
+          {formatTime(now)}
+        </time>
+        <p
+          className="mt-4 font-mono text-white/70 tracking-widest"
+          style={{
+            fontSize: 'clamp(1.2rem, 4vw, 3rem)',
+          }}
+        >
+          {formatDate(now)}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/clock/page.tsx
+++ b/app/clock/page.tsx
@@ -106,8 +106,8 @@ export default function ClockPage() {
 
         {/* 日付表示 */}
         <p
-          className="mt-4 sm:mt-6 text-gray-400 tracking-widest"
-          style={{ fontSize: 'clamp(1.2rem, 4vw, 3rem)', fontFamily: 'var(--font-inter), sans-serif' }}
+          className="mt-4 sm:mt-6 font-bold text-[#211714]/60 tracking-widest"
+          style={{ fontSize: 'clamp(1.5rem, 5vw, 5vw)', fontFamily: 'var(--font-inter), sans-serif' }}
         >
           {formatDate(now)}
         </p>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,12 +7,18 @@ import { ServiceWorkerRegistration } from "@/components/ServiceWorkerRegistratio
 import { ToastProvider } from "@/components/Toast";
 import { SplashScreen } from "@/components/SplashScreen";
 
-import { Zen_Old_Mincho } from "next/font/google";
+import { Zen_Old_Mincho, Inter } from "next/font/google";
 
 const zenOldMincho = Zen_Old_Mincho({
   weight: ["400", "500", "600", "700", "900"],
   subsets: ["latin"],
   variable: "--font-zen-old-mincho",
+  display: "swap",
+});
+
+const inter = Inter({
+  subsets: ["latin"],
+  variable: "--font-inter",
   display: "swap",
 });
 
@@ -49,7 +55,7 @@ export default function RootLayout({
   return (
     <html lang="ja" suppressHydrationWarning>
       <body
-        className={`${zenOldMincho.variable} antialiased font-serif`}
+        className={`${zenOldMincho.variable} ${inter.variable} antialiased font-serif`}
         suppressHydrationWarning
       >
         <Script

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,7 +7,7 @@ import { ServiceWorkerRegistration } from "@/components/ServiceWorkerRegistratio
 import { ToastProvider } from "@/components/Toast";
 import { SplashScreen } from "@/components/SplashScreen";
 
-import { Zen_Old_Mincho, Inter } from "next/font/google";
+import { Zen_Old_Mincho, Inter, Roboto_Mono, Oswald, Orbitron, Noto_Sans_JP } from "next/font/google";
 
 const zenOldMincho = Zen_Old_Mincho({
   weight: ["400", "500", "600", "700", "900"],
@@ -19,6 +19,30 @@ const zenOldMincho = Zen_Old_Mincho({
 const inter = Inter({
   subsets: ["latin"],
   variable: "--font-inter",
+  display: "swap",
+});
+
+const robotoMono = Roboto_Mono({
+  subsets: ["latin"],
+  variable: "--font-roboto-mono",
+  display: "swap",
+});
+
+const oswald = Oswald({
+  subsets: ["latin"],
+  variable: "--font-oswald",
+  display: "swap",
+});
+
+const orbitron = Orbitron({
+  subsets: ["latin"],
+  variable: "--font-orbitron",
+  display: "swap",
+});
+
+const notoSansJP = Noto_Sans_JP({
+  subsets: ["latin"],
+  variable: "--font-noto-sans-jp",
   display: "swap",
 });
 
@@ -55,7 +79,7 @@ export default function RootLayout({
   return (
     <html lang="ja" suppressHydrationWarning>
       <body
-        className={`${zenOldMincho.variable} ${inter.variable} antialiased font-serif`}
+        className={`${zenOldMincho.variable} ${inter.variable} ${robotoMono.variable} ${oswald.variable} ${orbitron.variable} ${notoSansJP.variable} antialiased font-serif`}
         suppressHydrationWarning
       >
         <Script

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,6 +20,7 @@ import { FaTree, FaGift, FaSnowflake, FaHollyBerry, FaStar } from 'react-icons/f
 import { PiBellFill } from 'react-icons/pi';
 import { GiCandyCanes, GiGingerbreadMan } from 'react-icons/gi';
 import { BsStars } from 'react-icons/bs';
+import { HiClock } from 'react-icons/hi';
 
 const SPLASH_DISPLAY_TIME = 3000; // スプラッシュ画面の表示時間 (ms)
 
@@ -323,6 +324,19 @@ export default function HomePage(_props: HomePageProps = {}) {
           </div>
 
           <div className="flex items-center gap-3 md:gap-4">
+            <button
+              onClick={() => router.push('/clock')}
+              className={`flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full p-2 transition-all ${
+                isChristmasMode
+                  ? 'text-[#d4af37] bg-white/5 hover:bg-[#d4af37]/20 border border-[#d4af37]/20 shadow-inner'
+                  : 'text-white hover:bg-white/10'
+              }`}
+              aria-label="デジタル時計を表示"
+              title="デジタル時計"
+            >
+              <HiClock className="h-6 w-6" />
+            </button>
+
             {isDeveloperMode && (
               <button
                 onClick={handleShowLoadingDebugModal}

--- a/components/clock/ClockSettingsModal.tsx
+++ b/components/clock/ClockSettingsModal.tsx
@@ -1,0 +1,264 @@
+'use client';
+
+import { HiXMark } from 'react-icons/hi2';
+import {
+  type ClockSettings,
+  type ClockTheme,
+  type ClockFontKey,
+  CLOCK_THEMES,
+  CLOCK_FONTS,
+  getThemeColors,
+  getFontFamily,
+} from '@/lib/clockSettings';
+
+interface ClockSettingsModalProps {
+  settings: ClockSettings;
+  onUpdate: (patch: Partial<ClockSettings>) => void;
+  onReset: () => void;
+  onClose: () => void;
+}
+
+const THEME_KEYS: ClockTheme[] = ['light', 'dark', 'coffee', 'green', 'lightblue'];
+const FONT_KEYS: ClockFontKey[] = ['inter', 'robotoMono', 'oswald', 'orbitron', 'notoSansJP'];
+
+export function ClockSettingsModal({ settings, onUpdate, onReset, onClose }: ClockSettingsModalProps) {
+  const themeColors = getThemeColors(settings.theme);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      onClick={onClose}
+    >
+      {/* 背景オーバーレイ */}
+      <div className="absolute inset-0 bg-black/50" />
+
+      {/* モーダル本体 */}
+      <div
+        className="relative w-full max-w-md max-h-[85vh] overflow-y-auto rounded-2xl shadow-2xl"
+        style={{ backgroundColor: themeColors.bg }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* ヘッダー */}
+        <div className="sticky top-0 z-10 flex items-center justify-between px-5 py-4 border-b" style={{ borderColor: themeColors.uiBg, backgroundColor: themeColors.bg }}>
+          <h2 className="text-lg font-bold" style={{ color: themeColors.text }}>
+            時計の設定
+          </h2>
+          <button
+            onClick={onClose}
+            className="flex items-center justify-center w-10 h-10 rounded-full transition-colors"
+            style={{ color: themeColors.uiText }}
+            aria-label="閉じる"
+          >
+            <HiXMark className="w-6 h-6" />
+          </button>
+        </div>
+
+        <div className="px-5 py-4 space-y-6">
+          {/* ─── テーマ選択 ─── */}
+          <section>
+            <SectionLabel color={themeColors.uiText}>テーマ</SectionLabel>
+            <div className="flex gap-3 mt-2">
+              {THEME_KEYS.map((key) => {
+                const theme = CLOCK_THEMES[key];
+                const colors = theme.colors;
+                const isSelected = settings.theme === key;
+                return (
+                  <button
+                    key={key}
+                    onClick={() => onUpdate({ theme: key })}
+                    className="flex flex-col items-center gap-1.5 min-w-[52px]"
+                    aria-label={`テーマ: ${theme.label}`}
+                  >
+                    <div
+                      className="w-10 h-10 rounded-full border-2 transition-all"
+                      style={{
+                        backgroundColor: colors.bg,
+                        borderColor: isSelected ? colors.accent : 'transparent',
+                        boxShadow: isSelected ? `0 0 0 2px ${colors.accent}40` : 'none',
+                      }}
+                    >
+                      <div
+                        className="w-full h-full rounded-full flex items-center justify-center text-xs font-bold"
+                        style={{ color: colors.text }}
+                      >
+                        Aa
+                      </div>
+                    </div>
+                    <span
+                      className="text-xs font-medium"
+                      style={{ color: isSelected ? themeColors.text : themeColors.uiText }}
+                    >
+                      {theme.label}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+
+          {/* ─── フォント選択 ─── */}
+          <section>
+            <SectionLabel color={themeColors.uiText}>フォント</SectionLabel>
+            <div className="mt-2 grid gap-2">
+              {FONT_KEYS.map((key) => {
+                const font = CLOCK_FONTS[key];
+                const isSelected = settings.fontKey === key;
+                return (
+                  <button
+                    key={key}
+                    onClick={() => onUpdate({ fontKey: key })}
+                    className="flex items-center justify-between px-4 py-3 rounded-xl transition-all text-left"
+                    style={{
+                      backgroundColor: isSelected ? `${themeColors.accent}18` : themeColors.uiBg,
+                      borderWidth: '1.5px',
+                      borderStyle: 'solid',
+                      borderColor: isSelected ? themeColors.accent : 'transparent',
+                    }}
+                  >
+                    <div className="flex items-center gap-3">
+                      <span
+                        className="text-2xl font-bold leading-none"
+                        style={{
+                          fontFamily: getFontFamily(key),
+                          color: themeColors.text,
+                          fontFeatureSettings: '"tnum"',
+                        }}
+                      >
+                        12:34
+                      </span>
+                      <div>
+                        <span className="text-sm font-medium block" style={{ color: themeColors.text }}>
+                          {font.label}
+                        </span>
+                        <span className="text-xs" style={{ color: themeColors.uiText }}>
+                          {font.description}
+                        </span>
+                      </div>
+                    </div>
+                    {isSelected && (
+                      <div
+                        className="w-5 h-5 rounded-full flex items-center justify-center text-white text-xs"
+                        style={{ backgroundColor: themeColors.accent }}
+                      >
+                        ✓
+                      </div>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+
+          {/* ─── 文字サイズ ─── */}
+          <section>
+            <div className="flex items-center justify-between">
+              <SectionLabel color={themeColors.uiText}>文字サイズ</SectionLabel>
+              <span className="text-sm font-mono" style={{ color: themeColors.uiText }}>
+                {Math.round(settings.fontScale * 100)}%
+              </span>
+            </div>
+            <div className="mt-2 flex items-center gap-3">
+              <span className="text-xs" style={{ color: themeColors.uiText }}>小</span>
+              <input
+                type="range"
+                min="0.5"
+                max="1.5"
+                step="0.05"
+                value={settings.fontScale}
+                onChange={(e) => onUpdate({ fontScale: parseFloat(e.target.value) })}
+                className="flex-1 h-2 rounded-full appearance-none cursor-pointer"
+                style={{
+                  background: `linear-gradient(to right, ${themeColors.accent} 0%, ${themeColors.accent} ${((settings.fontScale - 0.5) / 1.0) * 100}%, ${themeColors.uiBg} ${((settings.fontScale - 0.5) / 1.0) * 100}%, ${themeColors.uiBg} 100%)`,
+                  accentColor: themeColors.accent,
+                }}
+                aria-label="文字サイズ"
+              />
+              <span className="text-xs" style={{ color: themeColors.uiText }}>大</span>
+            </div>
+          </section>
+
+          {/* ─── 表示オプション ─── */}
+          <section>
+            <SectionLabel color={themeColors.uiText}>表示オプション</SectionLabel>
+            <div className="mt-2 space-y-1">
+              <ToggleRow
+                label="24時間表示"
+                checked={settings.use24Hour}
+                onChange={(v) => onUpdate({ use24Hour: v })}
+                colors={themeColors}
+              />
+              <ToggleRow
+                label="秒を表示"
+                checked={settings.showSeconds}
+                onChange={(v) => onUpdate({ showSeconds: v })}
+                colors={themeColors}
+              />
+              <ToggleRow
+                label="日付を表示"
+                checked={settings.showDate}
+                onChange={(v) => onUpdate({ showDate: v })}
+                colors={themeColors}
+              />
+            </div>
+          </section>
+
+          {/* ─── リセットボタン ─── */}
+          <div className="pt-2 pb-2">
+            <button
+              onClick={onReset}
+              className="w-full py-3 rounded-xl text-sm font-medium transition-colors"
+              style={{
+                backgroundColor: themeColors.uiBg,
+                color: themeColors.uiText,
+              }}
+            >
+              設定をリセット
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── サブコンポーネント ───
+
+function SectionLabel({ color, children }: { color: string; children: React.ReactNode }) {
+  return (
+    <h3 className="text-xs font-bold uppercase tracking-widest" style={{ color }}>
+      {children}
+    </h3>
+  );
+}
+
+function ToggleRow({
+  label,
+  checked,
+  onChange,
+  colors,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: (value: boolean) => void;
+  colors: { text: string; accent: string; uiBg: string };
+}) {
+  return (
+    <label className="flex items-center justify-between py-3 px-1 cursor-pointer min-h-[44px]">
+      <span className="text-sm font-medium" style={{ color: colors.text }}>
+        {label}
+      </span>
+      <button
+        role="switch"
+        aria-checked={checked}
+        onClick={() => onChange(!checked)}
+        className="relative w-11 h-6 rounded-full transition-colors duration-200"
+        style={{ backgroundColor: checked ? colors.accent : colors.uiBg }}
+      >
+        <span
+          className="absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white shadow-sm transition-transform duration-200"
+          style={{ transform: checked ? 'translateX(20px)' : 'translateX(0)' }}
+        />
+      </button>
+    </label>
+  );
+}

--- a/hooks/useClockSettings.ts
+++ b/hooks/useClockSettings.ts
@@ -1,0 +1,36 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import {
+  type ClockSettings,
+  DEFAULT_CLOCK_SETTINGS,
+  getClockSettings,
+  setClockSettings,
+} from '@/lib/clockSettings';
+
+function loadInitialSettings(): ClockSettings {
+  if (typeof window === 'undefined') return DEFAULT_CLOCK_SETTINGS;
+  return getClockSettings();
+}
+
+export function useClockSettings() {
+  const [settings, setSettings] = useState<ClockSettings>(loadInitialSettings);
+  const isLoaded = typeof window !== 'undefined';
+
+  // 設定更新（即座にlocalStorageに保存）
+  const updateSettings = useCallback((patch: Partial<ClockSettings>) => {
+    setSettings((prev) => {
+      const next = { ...prev, ...patch };
+      setClockSettings(next);
+      return next;
+    });
+  }, []);
+
+  // 設定リセット
+  const resetSettings = useCallback(() => {
+    setSettings(DEFAULT_CLOCK_SETTINGS);
+    setClockSettings(DEFAULT_CLOCK_SETTINGS);
+  }, []);
+
+  return { settings, isLoaded, updateSettings, resetSettings };
+}

--- a/lib/clockSettings.ts
+++ b/lib/clockSettings.ts
@@ -1,0 +1,199 @@
+// 時計ページのカスタマイズ設定
+
+// ─── テーマ定義 ───
+
+export type ClockTheme = 'light' | 'dark' | 'coffee' | 'green' | 'lightblue';
+
+export interface ThemeColors {
+  bg: string;
+  text: string;
+  accent: string;
+  accentSub: string;
+  dateText: string;
+  uiText: string;
+  uiBg: string;
+}
+
+export const CLOCK_THEMES: Record<ClockTheme, { label: string; colors: ThemeColors }> = {
+  light: {
+    label: 'ライト',
+    colors: {
+      bg: '#FFFFFF',
+      text: '#211714',
+      accent: '#D97706',
+      accentSub: 'rgba(217, 119, 6, 0.7)',
+      dateText: 'rgba(33, 23, 20, 0.6)',
+      uiText: '#6B7280',
+      uiBg: 'rgba(0, 0, 0, 0.05)',
+    },
+  },
+  dark: {
+    label: 'ダーク',
+    colors: {
+      bg: '#1A1A1A',
+      text: '#F5F5F5',
+      accent: '#FBBF24',
+      accentSub: 'rgba(251, 191, 36, 0.7)',
+      dateText: 'rgba(245, 245, 245, 0.6)',
+      uiText: '#9CA3AF',
+      uiBg: 'rgba(255, 255, 255, 0.1)',
+    },
+  },
+  coffee: {
+    label: 'コーヒー',
+    colors: {
+      bg: '#2C1810',
+      text: '#F5E6D3',
+      accent: '#D4915C',
+      accentSub: 'rgba(212, 145, 92, 0.7)',
+      dateText: 'rgba(245, 230, 211, 0.6)',
+      uiText: '#A0826D',
+      uiBg: 'rgba(255, 255, 255, 0.08)',
+    },
+  },
+  green: {
+    label: 'グリーン',
+    colors: {
+      bg: '#1A2E1A',
+      text: '#E8F5E8',
+      accent: '#6ABF6A',
+      accentSub: 'rgba(106, 191, 106, 0.7)',
+      dateText: 'rgba(232, 245, 232, 0.6)',
+      uiText: '#7DAF7D',
+      uiBg: 'rgba(255, 255, 255, 0.08)',
+    },
+  },
+  lightblue: {
+    label: 'ライトブルー',
+    colors: {
+      bg: '#FFFFFF',
+      text: '#4DA8DA',
+      accent: '#2980B9',
+      accentSub: 'rgba(41, 128, 185, 0.7)',
+      dateText: 'rgba(77, 168, 218, 0.6)',
+      uiText: '#6B7280',
+      uiBg: 'rgba(0, 0, 0, 0.05)',
+    },
+  },
+};
+
+// ─── フォント定義 ───
+
+export type ClockFontKey = 'inter' | 'robotoMono' | 'oswald' | 'orbitron' | 'notoSansJP';
+
+export interface ClockFontOption {
+  label: string;
+  cssVar: string;
+  fallback: string;
+  description: string;
+  widthFactor: number; // 幅補正係数（1.0=標準、小さいほど縮小）
+}
+
+export const CLOCK_FONTS: Record<ClockFontKey, ClockFontOption> = {
+  inter: {
+    label: 'Inter',
+    cssVar: 'var(--font-inter)',
+    fallback: 'sans-serif',
+    description: 'モダン・クリーン',
+    widthFactor: 1.0,
+  },
+  robotoMono: {
+    label: 'Roboto Mono',
+    cssVar: 'var(--font-roboto-mono)',
+    fallback: 'monospace',
+    description: '等幅・デジタル',
+    widthFactor: 0.9,
+  },
+  oswald: {
+    label: 'Oswald',
+    cssVar: 'var(--font-oswald)',
+    fallback: 'sans-serif',
+    description: '縦長・力強い',
+    widthFactor: 1.0,
+  },
+  orbitron: {
+    label: 'Orbitron',
+    cssVar: 'var(--font-orbitron)',
+    fallback: 'sans-serif',
+    description: 'SF・未来的',
+    widthFactor: 0.72,
+  },
+  notoSansJP: {
+    label: 'Noto Sans JP',
+    cssVar: 'var(--font-noto-sans-jp)',
+    fallback: 'sans-serif',
+    description: '日本語対応',
+    widthFactor: 1.0,
+  },
+};
+
+// ─── 設定型 ───
+
+export interface ClockSettings {
+  theme: ClockTheme;
+  fontKey: ClockFontKey;
+  fontScale: number;
+  use24Hour: boolean;
+  showSeconds: boolean;
+  showDate: boolean;
+}
+
+export const DEFAULT_CLOCK_SETTINGS: ClockSettings = {
+  theme: 'light',
+  fontKey: 'inter',
+  fontScale: 1.0,
+  use24Hour: true,
+  showSeconds: true,
+  showDate: true,
+};
+
+// ─── localStorage ───
+
+const CLOCK_SETTINGS_KEY = 'roastplus_clock_settings';
+
+const parseJson = <T>(value: string): T | null => {
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return null;
+  }
+};
+
+export function getClockSettings(): ClockSettings {
+  if (typeof window === 'undefined') return DEFAULT_CLOCK_SETTINGS;
+
+  const stored = localStorage.getItem(CLOCK_SETTINGS_KEY);
+  if (!stored) return DEFAULT_CLOCK_SETTINGS;
+
+  const parsed = parseJson<Partial<ClockSettings>>(stored);
+  if (!parsed) return DEFAULT_CLOCK_SETTINGS;
+
+  return { ...DEFAULT_CLOCK_SETTINGS, ...parsed };
+}
+
+export function setClockSettings(settings: ClockSettings): void {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(CLOCK_SETTINGS_KEY, JSON.stringify(settings));
+}
+
+// ─── ヘルパー ───
+
+export function getThemeColors(theme: ClockTheme): ThemeColors {
+  return CLOCK_THEMES[theme].colors;
+}
+
+export function getFontFamily(fontKey: ClockFontKey): string {
+  const font = CLOCK_FONTS[fontKey];
+  return `${font.cssVar}, ${font.fallback}`;
+}
+
+export function getFontWidthFactor(fontKey: ClockFontKey): number {
+  return CLOCK_FONTS[fontKey].widthFactor;
+}
+
+export function getScaledClamp(baseMin: number, baseVw: number, scale: number, widthFactor: number = 1.0): string {
+  const effectiveScale = scale * widthFactor;
+  const min = (baseMin * effectiveScale).toFixed(1);
+  const vw = (baseVw * effectiveScale).toFixed(1);
+  return `clamp(${min}rem, ${vw}vw, ${vw}vw)`;
+}


### PR DESCRIPTION
## Summary
- デジタル時計ページ (`/clock`) を新規追加し、遠距離からでも視認できる大型フォント表示を実装
- カスタマイズ設定モーダルを追加（テーマ5種、フォント5種、サイズスライダー、表示オプション）
- 設定はlocalStorageに永続化され、ページリロード後も保持

## 主な変更内容
- **時計ページ**: `app/clock/page.tsx` — `useSyncExternalStore` による毎秒更新、vwベースのレスポンシブサイズ
- **設定モーダル**: `components/clock/ClockSettingsModal.tsx` — テーマ・フォント・サイズ・表示トグル
- **設定管理**: `lib/clockSettings.ts` + `hooks/useClockSettings.ts` — 型定義・localStorage・Reactフック
- **フォント追加**: `app/layout.tsx` — Roboto Mono, Oswald, Orbitron, Noto Sans JP をGoogle Fontsから読み込み
- **ホーム画面**: 時計アイコンリンクを追加

## Test plan
- [ ] `/clock` ページでデジタル時計が表示される
- [ ] 右上の⚙ボタンから設定モーダルが開く
- [ ] 5つのテーマ切替が即座に反映される
- [ ] 5つのフォント切替が正しく表示される（Orbitronでもはみ出さない）
- [ ] サイズスライダーで文字サイズが変わる
- [ ] 12/24時間、秒、日付の各トグルが動作する
- [ ] ページリロード後に設定が保持される
- [ ] 「設定をリセット」でデフォルトに戻る

🤖 Generated with [Claude Code](https://claude.com/claude-code)