### PR TITLE
fix(hooks): React Hooks eslint-disable箇所の見直し

### DIFF
--- a/components/Snowfall.tsx
+++ b/components/Snowfall.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 type Flake = {
   id: number;
@@ -14,11 +14,9 @@ type Flake = {
 };
 
 export const Snowfall = () => {
-  const [snowflakes, setSnowflakes] = useState<Flake[]>([]);
-
-  useEffect(() => {
+  const [snowflakes] = useState<Flake[]>(() => {
     const flakeCount = 60;
-    const flakes: Flake[] = Array.from({ length: flakeCount }).map((_, i) => {
+    return Array.from({ length: flakeCount }).map((_, i) => {
       const depth = Math.floor(Math.random() * 3); // 0: back, 1: mid, 2: front
       let size = '2px';
       let duration = '15s';
@@ -53,9 +51,7 @@ export const Snowfall = () => {
         depth,
       };
     });
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- 初期化時の1回のみ実行
-    setSnowflakes(flakes);
-  }, []);
+  });
 
   return (
     <div className="fixed inset-0 pointer-events-none z-[1] overflow-hidden">

--- a/components/TastingSessionList.tsx
+++ b/components/TastingSessionList.tsx
@@ -96,7 +96,7 @@ export function TastingSessionList({ data, onUpdate, filterButtonContainerId, fi
   }>({ desktop: null, mobile: null });
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- ハイドレーション後の初期化
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setMounted(true);
     const updateContainers = () => {
       const desktopEl = filterButtonContainerId ? document.getElementById(filterButtonContainerId) : null;

--- a/components/coffee-quiz/DebugPanel.tsx
+++ b/components/coffee-quiz/DebugPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { motion } from 'framer-motion';
 import {
   isDebugMode,
@@ -51,19 +51,9 @@ interface DebugPanelProps {
 }
 
 export function DebugPanel({ onDateChange }: DebugPanelProps) {
-  const [debugEnabled, setDebugEnabled] = useState(false);
-  const [dateOffset, setDateOffsetState] = useState(0);
-  const [debugInfo, setDebugInfo] = useState<ReturnType<typeof getDebugInfo> | null>(null);
-
-  // 初期化時にデバッグ状態を読み込み
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- 初期化時の1回のみ実行
-    setDebugEnabled(isDebugMode());
-     
-    setDateOffsetState(getDebugDateOffset());
-     
-    setDebugInfo(getDebugInfo());
-  }, []);
+  const [debugEnabled, setDebugEnabled] = useState(() => isDebugMode());
+  const [dateOffset, setDateOffsetState] = useState(() => getDebugDateOffset());
+  const [debugInfo, setDebugInfo] = useState<ReturnType<typeof getDebugInfo> | null>(() => getDebugInfo());
 
   // デバッグモード切り替え
   const handleToggleDebug = () => {

--- a/components/coffee-quiz/XPGainAnimation.tsx
+++ b/components/coffee-quiz/XPGainAnimation.tsx
@@ -21,7 +21,7 @@ export function XPGainAnimation({ xp, show, onComplete }: XPGainAnimationProps) 
 
   useEffect(() => {
     if (show && xp > 0) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- アニメーション表示制御
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setIsVisible(true);
       const timer = setTimeout(() => {
         setIsVisible(false);

--- a/components/drip-guide/Start46Dialog.tsx
+++ b/components/drip-guide/Start46Dialog.tsx
@@ -57,11 +57,7 @@ export const Start46Dialog: React.FC<Start46DialogProps> = ({
 
     // 人前が変更された場合に更新
     useEffect(() => {
-        if (initialServings !== servings) {
-             
-            setServings(initialServings);
-        }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- initialServings変更時のみ実行
+        setServings(initialServings);
     }, [initialServings]);
 
     const handleKeyDown = useCallback(

--- a/components/drip-guide/StartHoffmannDialog.tsx
+++ b/components/drip-guide/StartHoffmannDialog.tsx
@@ -45,11 +45,7 @@ export const StartHoffmannDialog: React.FC<StartHoffmannDialogProps> = ({
 
     // 人前が変更された場合に更新
     useEffect(() => {
-        if (initialServings !== servings) {
-             
-            setServings(initialServings);
-        }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- initialServings変更時のみ実行
+        setServings(initialServings);
     }, [initialServings]);
 
     const handleKeyDown = useCallback(

--- a/hooks/useChristmasMode.ts
+++ b/hooks/useChristmasMode.ts
@@ -1,38 +1,31 @@
 'use client';
 
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback } from 'react';
 
 const STORAGE_KEY = 'roastplus_christmas_mode';
 const MIGRATION_FLAG_KEY = 'roastplus_christmas_mode_migrated';
 
 export function useChristmasMode() {
-    const [isChristmasMode, setIsChristmasMode] = useState<boolean>(false);
+    const [isChristmasMode, setIsChristmasMode] = useState<boolean>(() => {
+        if (typeof window === 'undefined') return false;
 
-    // 初期読み込み
-    useEffect(() => {
-        if (typeof window !== 'undefined') {
-            // マイグレーション処理（一度だけ実行）
-            const migrationDone = localStorage.getItem(MIGRATION_FLAG_KEY) === 'true';
+        // マイグレーション処理（一度だけ実行）
+        const migrationDone = localStorage.getItem(MIGRATION_FLAG_KEY) === 'true';
 
-            if (!migrationDone) {
-                // 既存のlocalStorageキーを削除して、新しいデフォルト（オフ）を適用
-                // これにより、デプロイ後に既存端末でもオフになる
-                if (localStorage.getItem(STORAGE_KEY) !== null) {
-                    localStorage.removeItem(STORAGE_KEY);
-                }
-                localStorage.setItem(MIGRATION_FLAG_KEY, 'true');
-                // デフォルトはfalse（オフ）
-                // eslint-disable-next-line react-hooks/set-state-in-effect -- localStorageからの初期化
-                setIsChristmasMode(false);
-            } else {
-                // マイグレーション済みの場合は、localStorageから読み込む
-                const stored = localStorage.getItem(STORAGE_KEY);
-                const value = stored === null ? false : stored === 'true';
-                 
-                setIsChristmasMode(value);
+        if (!migrationDone) {
+            // 既存のlocalStorageキーを削除して、新しいデフォルト（オフ）を適用
+            // これにより、デプロイ後に既存端末でもオフになる
+            if (localStorage.getItem(STORAGE_KEY) !== null) {
+                localStorage.removeItem(STORAGE_KEY);
             }
+            localStorage.setItem(MIGRATION_FLAG_KEY, 'true');
+            return false;
         }
-    }, []);
+
+        // マイグレーション済みの場合は、localStorageから読み込む
+        const stored = localStorage.getItem(STORAGE_KEY);
+        return stored === null ? false : stored === 'true';
+    });
 
     // 切り替え
     const setChristmasMode = useCallback((enabled: boolean) => {

--- a/hooks/useQuizData.ts
+++ b/hooks/useQuizData.ts
@@ -67,8 +67,9 @@ export function useQuizData() {
   const pendingSaveRef = useRef<QuizProgress | null>(null);
 
   // SSR対策: クライアントサイドでのみlocalStorageを使用
+  // useEffect内でのsetStateはハイドレーション完了を検知する標準パターン
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- ハイドレーション検知
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setIsHydrated(true);
   }, []);
 
@@ -90,7 +91,7 @@ export function useQuizData() {
     try {
       const stored = getQuizProgress();
       if (stored) {
-        // eslint-disable-next-line react-hooks/set-state-in-effect -- localStorageからの初期化
+        // eslint-disable-next-line react-hooks/set-state-in-effect
         setProgress(stored);
       } else {
         // 初期データを作成


### PR DESCRIPTION
## 概要

React Hooks ルールの `eslint-disable` 箇所を見直し、可能な箇所はリファクタリングで解消しました。

## 変更内容

### リファクタリングで eslint-disable を完全削除（5箇所）
- **`Snowfall.tsx`**: `useEffect` + `setState` → `useState` の lazy initializer に変更
- **`DebugPanel.tsx`**: `useEffect` + `setState` → `useState` の lazy initializer に変更（3つの state を一括）
- **`useChristmasMode.ts`**: `useEffect` + `setState` → `useState` の lazy initializer に変更（マイグレーションロジック含む）
- **`StartHoffmannDialog.tsx`**: `exhaustive-deps` 抑制を削除、不要な条件分岐を簡素化
- **`Start46Dialog.tsx`**: 同上

### eslint-disable コメントの整理（5箇所）
- **`useQuizData.ts`** (2箇所): ハイドレーション検知・localStorage初期化（useEffect内setStateが不可避）
- **`TastingSessionList.tsx`**: ハイドレーション後の初期化（同上）
- **`app/page.tsx`**: ローディング状態の解除（同上）
- **`XPGainAnimation.tsx`**: アニメーション表示制御（同上）

→ 冗長だったコメント (`-- ハイドレーション検知` 等) を削除してクリーンに

## テスト

- [x] `npm run lint` が通ること（Issue #37 対象箇所のエラー解消を確認）
- [x] `npm run build` が正常完了

Closes #37
