### PR TITLE
[Issue #39] エラーハンドリング改善（alert→Toast統一）

### DIFF
--- a/app/defect-beans/page.tsx
+++ b/app/defect-beans/page.tsx
@@ -10,6 +10,7 @@ import LoginPage from '@/app/login/page';
 import { useDefectBeans } from '@/hooks/useDefectBeans';
 import { useDefectBeanSettings } from '@/hooks/useDefectBeanSettings';
 import { useDeveloperMode } from '@/hooks/useDeveloperMode';
+import { useToastContext } from '@/components/Toast';
 import { DefectBeanCard } from '@/components/DefectBeanCard';
 import { DefectBeanForm } from '@/components/DefectBeanForm';
 import { DefectBeanCompare } from '@/components/DefectBeanCompare';
@@ -24,6 +25,7 @@ export default function DefectBeansPage() {
   const { allDefectBeans, isLoading, addDefectBean, updateDefectBean, removeDefectBean } = useDefectBeans();
   const { settings, updateSetting } = useDefectBeanSettings();
   const { isEnabled: isDeveloperModeEnabled } = useDeveloperMode();
+  const { showToast } = useToastContext();
   const [searchQuery, setSearchQuery] = useState('');
   const [filterOption, setFilterOption] = useState<FilterOption>('all');
   const [showAddForm, setShowAddForm] = useState(false);
@@ -200,7 +202,7 @@ export default function DefectBeansPage() {
       setEditingDefectBeanId(null);
     } catch (error) {
       console.error('Failed to update defect bean:', error);
-      alert('欠点豆の更新に失敗しました。');
+      showToast('欠点豆の更新に失敗しました。', 'error');
       throw error;
     }
   };
@@ -219,7 +221,7 @@ export default function DefectBeansPage() {
       setEditingDefectBeanId(null);
     } catch (error) {
       console.error('Failed to delete defect bean:', error);
-      alert('欠点豆の削除に失敗しました。');
+      showToast('欠点豆の削除に失敗しました。', 'error');
       throw error;
     }
   };
@@ -230,7 +232,7 @@ export default function DefectBeansPage() {
       await updateSetting(id, shouldRemove);
     } catch (error) {
       console.error('Failed to update setting:', error);
-      alert('設定の更新に失敗しました。');
+      showToast('設定の更新に失敗しました。', 'error');
     }
   };
 

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -8,6 +8,7 @@ import { useDeveloperMode } from '@/hooks/useDeveloperMode';
 import { useChristmasMode } from '@/hooks/useChristmasMode';
 import { useAppVersion } from '@/hooks/useAppVersion';
 import { Loading } from '@/components/Loading';
+import { useToastContext } from '@/components/Toast';
 import { HiArrowLeft, HiDocumentText, HiShieldCheck, HiLogout, HiMail } from 'react-icons/hi';
 import { MdHistory } from 'react-icons/md';
 import LoginPage from '@/app/login/page';
@@ -21,6 +22,7 @@ export default function SettingsPage() {
     const router = useRouter();
     const { user, loading: authLoading } = useAuth();
     const { isEnabled, isLoading: devModeLoading, enableDeveloperMode, disableDeveloperMode } = useDeveloperMode();
+    const { showToast } = useToastContext();
     const { version, isUpdateAvailable, isChecking, checkForUpdates, applyUpdate } = useAppVersion();
     const [showPasswordModal, setShowPasswordModal] = useState(false);
     const [password, setPassword] = useState('');
@@ -40,10 +42,11 @@ export default function SettingsPage() {
                 }
             } catch (error) {
                 console.error('同意情報の取得に失敗:', error);
+                showToast('同意情報の取得に失敗しました。', 'error');
             }
         }
         fetchUserConsent();
-    }, [user]);
+    }, [user, showToast]);
 
     if (authLoading || devModeLoading) {
         return <Loading />;
@@ -89,6 +92,7 @@ export default function SettingsPage() {
             router.push('/login');
         } catch (error) {
             console.error('ログアウトエラー:', error);
+            showToast('ログアウトに失敗しました。', 'error');
         }
     };
 

--- a/components/CameraCapture.tsx
+++ b/components/CameraCapture.tsx
@@ -4,6 +4,7 @@
 
 import { useState, useRef, useEffect } from 'react';
 import { HiCamera, HiX, HiCheck } from 'react-icons/hi';
+import { useToastContext } from '@/components/Toast';
 
 interface CameraCaptureProps {
   onCapture: (file: File) => void;
@@ -11,6 +12,7 @@ interface CameraCaptureProps {
 }
 
 export function CameraCapture({ onCapture, onCancel }: CameraCaptureProps) {
+  const { showToast } = useToastContext();
   const [capturedImage, setCapturedImage] = useState<string | null>(null);
   const [isVideoReady, setIsVideoReady] = useState(false);
   const [guideSize, setGuideSize] = useState({ width: 0, height: 0, top: 0, left: 0, containerHeight: 0, containerWidth: 0 });
@@ -94,7 +96,7 @@ export function CameraCapture({ onCapture, onCancel }: CameraCaptureProps) {
         }
       } catch (error) {
         console.error('Failed to access camera:', error);
-        alert('カメラへのアクセスに失敗しました。カメラの権限を確認してください。');
+        showToast('カメラへのアクセスに失敗しました。カメラの権限を確認してください。', 'error');
         onCancelRef.current?.();
       }
     };
@@ -108,7 +110,7 @@ export function CameraCapture({ onCapture, onCancel }: CameraCaptureProps) {
       }
       stopCurrentStream();
     };
-  }, []);
+  }, [showToast]);
 
   const handleVideoReady = () => {
     const video = videoRef.current;
@@ -135,7 +137,7 @@ export function CameraCapture({ onCapture, onCancel }: CameraCaptureProps) {
         videoHeight: videoRef.current?.videoHeight,
         guideSize,
       });
-      alert('カメラの準備中です。少し待ってから撮影してください。');
+      showToast('カメラの準備中です。少し待ってから撮影してください。', 'warning');
       return;
     }
 
@@ -152,7 +154,7 @@ export function CameraCapture({ onCapture, onCancel }: CameraCaptureProps) {
     const videoHeight = video.videoHeight;
     if (videoWidth === 0 || videoHeight === 0) {
       console.error('Video metadata is not ready', { videoWidth, videoHeight });
-      alert('カメラの準備中です。少し待ってから撮影してください。');
+      showToast('カメラの準備中です。少し待ってから撮影してください。', 'warning');
       return;
     }
     tempCanvas.width = videoWidth;
@@ -278,7 +280,7 @@ export function CameraCapture({ onCapture, onCancel }: CameraCaptureProps) {
         }
       } catch (error) {
         console.error('Failed to restart camera:', error);
-        alert('カメラの再起動に失敗しました。');
+        showToast('カメラの再起動に失敗しました。', 'error');
       }
     } else if (videoRef.current && videoRef.current.videoWidth > 0 && videoRef.current.videoHeight > 0) {
       // 既存ストリームですでにメタデータが揃っている場合は即座に撮影可能にする

--- a/components/DefectBeanForm.tsx
+++ b/components/DefectBeanForm.tsx
@@ -7,6 +7,7 @@ import { HiX, HiCamera, HiTrash } from 'react-icons/hi';
 import { CameraCapture } from './CameraCapture';
 import type { DefectBean } from '@/types';
 import { Input, Textarea, Button } from '@/components/ui';
+import { useToastContext } from '@/components/Toast';
 
 interface DefectBeanFormProps {
   mode?: 'add' | 'edit';
@@ -31,6 +32,7 @@ export function DefectBeanForm({
   onDelete,
   onCancel,
 }: DefectBeanFormProps) {
+  const { showToast } = useToastContext();
   const [showCamera, setShowCamera] = useState(false);
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
@@ -79,12 +81,12 @@ export function DefectBeanForm({
 
     // 追加モード時は画像が必須
     if (mode === 'add' && !imageFile) {
-      alert('画像を選択してください。');
+      showToast('画像を選択してください。', 'warning');
       return;
     }
 
     if (!name.trim()) {
-      alert('名称を入力してください。');
+      showToast('名称を入力してください。', 'warning');
       return;
     }
 
@@ -101,14 +103,14 @@ export function DefectBeanForm({
         await onUpdate(defectBeanData, imageFile);
       } else {
         if (!imageFile) {
-          alert('画像を選択してください。');
+          showToast('画像を選択してください。', 'warning');
           return;
         }
         await onSubmit(defectBeanData, imageFile);
       }
     } catch (error) {
       console.error(`Failed to ${mode === 'edit' ? 'update' : 'submit'} defect bean:`, error);
-      alert(`欠点豆の${mode === 'edit' ? '更新' : '追加'}に失敗しました。`);
+      showToast(`欠点豆の${mode === 'edit' ? '更新' : '追加'}に失敗しました。`, 'error');
     } finally {
       setIsSubmitting(false);
     }
@@ -126,7 +128,7 @@ export function DefectBeanForm({
       await onDelete();
     } catch (error) {
       console.error('Failed to delete defect bean:', error);
-      alert('欠点豆の削除に失敗しました。');
+      showToast('欠点豆の削除に失敗しました。', 'error');
     } finally {
       setIsDeleting(false);
     }

--- a/components/RoastTimerSettings.tsx
+++ b/components/RoastTimerSettings.tsx
@@ -10,12 +10,14 @@ import {
 import { playTimerSound, stopTimerSound } from '@/lib/sounds';
 import { roastTimerSoundFiles } from '@/lib/soundFiles';
 import type { RoastTimerSettings } from '@/types';
+import { useToastContext } from '@/components/Toast';
 
 interface RoastTimerSettingsProps {
   onClose: () => void;
 }
 
 export function RoastTimerSettings({ onClose }: RoastTimerSettingsProps) {
+  const { showToast } = useToastContext();
   const [settings, setSettings] = useState<RoastTimerSettings | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
@@ -51,7 +53,7 @@ export function RoastTimerSettings({ onClose }: RoastTimerSettingsProps) {
       onClose();
     } catch (error) {
       console.error('Failed to save settings:', error);
-      alert('設定の保存に失敗しました');
+      showToast('設定の保存に失敗しました', 'error');
     } finally {
       setIsSaving(false);
     }
@@ -82,13 +84,13 @@ export function RoastTimerSettings({ onClose }: RoastTimerSettingsProps) {
         headStatus = `${headRes.status} ${headRes.statusText}`;
         if (!headRes.ok) {
           setTestResult(`音源取得に失敗: ${headStatus}`);
-          alert(`音源取得に失敗: ${headStatus}`);
+          showToast(`音源取得に失敗: ${headStatus}`, 'error');
           setIsTestingSound(false);
           return;
         }
       } catch (err) {
         setTestResult(`音源取得でエラー: ${String(err)}`);
-        alert(`音源取得でエラー: ${String(err)}`);
+        showToast(`音源取得でエラー: ${String(err)}`, 'error');
         setIsTestingSound(false);
         return;
       }
@@ -100,7 +102,7 @@ export function RoastTimerSettings({ onClose }: RoastTimerSettingsProps) {
           if (settled) return;
           settled = true;
           setTestResult(msg);
-          alert(msg);
+          showToast(msg, 'info');
           setIsTestingSound(false);
         };
 
@@ -127,14 +129,14 @@ export function RoastTimerSettings({ onClose }: RoastTimerSettingsProps) {
       } else {
         const msg = '再生開始に失敗（playTimerSoundからnullが返却）';
         setTestResult(msg);
-        alert(msg);
+        showToast(msg, 'error');
         setIsTestingSound(false);
       }
     } catch (error) {
       console.error('Failed to play test sound:', error);
       const msg = `再生に失敗: ${String(error)}`;
       setTestResult(msg);
-      alert(msg);
+      showToast(msg, 'error');
       setIsTestingSound(false);
     }
   };

--- a/components/TastingSessionDetail.tsx
+++ b/components/TastingSessionDetail.tsx
@@ -7,6 +7,7 @@ import type { TastingSession, TastingRecord, AppData } from '@/types';
 import { TastingRecordForm } from './TastingRecordForm';
 import { getRecordsBySessionId } from '@/lib/tastingUtils';
 import { Coffee } from 'phosphor-react';
+import { useToastContext } from '@/components/Toast';
 
 interface TastingSessionDetailProps {
   session: TastingSession;
@@ -21,6 +22,7 @@ export function TastingSessionDetail({
 }: TastingSessionDetailProps) {
   const router = useRouter();
   const { user } = useAuth();
+  const { showToast } = useToastContext();
   const [editingRecordId, setEditingRecordId] = useState<string | null>(null);
 
   const tastingRecords = Array.isArray(data.tastingRecords)
@@ -83,7 +85,7 @@ export function TastingSessionDetail({
       router.push('/tasting');
     } catch (error) {
       console.error('Failed to save tasting record:', error);
-      alert('記録の保存に失敗しました。もう一度お試しください。');
+      showToast('記録の保存に失敗しました。もう一度お試しください。', 'error');
     }
   };
 
@@ -106,7 +108,7 @@ export function TastingSessionDetail({
       router.push('/tasting');
     } catch (error) {
       console.error('Failed to delete tasting record:', error);
-      alert('記録の削除に失敗しました。もう一度お試しください。');
+      showToast('記録の削除に失敗しました。もう一度お試しください。', 'error');
     }
   };
 

--- a/components/roast-timer/SetupPanel.tsx
+++ b/components/roast-timer/SetupPanel.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '@/lib/auth';
 import { useAppData } from '@/hooks/useAppData';
 import { HiPlay } from 'react-icons/hi';
 import { MdTimer, MdLightbulb } from 'react-icons/md';
+import { useToastContext } from '@/components/Toast';
 import { ALL_BEANS, type BeanName } from '@/lib/beanConfig';
 import { loadRoastTimerSettings } from '@/lib/roastTimerSettings';
 import { getAllRoastTimerRecords } from '@/lib/roastTimerRecords';
@@ -31,6 +32,7 @@ interface SetupPanelProps {
 export function SetupPanel({ onStart, isLoading }: SetupPanelProps) {
   const { user } = useAuth();
   const { data } = useAppData();
+  const { showToast } = useToastContext();
 
   // 入力状態
   const [inputMode, setInputMode] = useState<'manual' | 'recommended' | null>(null);
@@ -203,11 +205,11 @@ export function SetupPanel({ onStart, isLoading }: SetupPanelProps) {
   const handleStart = async () => {
     try {
       if (!user) {
-        alert('ログインが必要です');
+        showToast('ログインが必要です', 'warning');
         return;
       }
       if (isLoading) {
-        alert('データを読み込み中です。しばらくお待ちください。');
+        showToast('データを読み込み中です。しばらくお待ちください。', 'info');
         return;
       }
 
@@ -218,7 +220,7 @@ export function SetupPanel({ onStart, isLoading }: SetupPanelProps) {
         const hasSeconds = durationSeconds && durationSeconds.trim() !== '';
 
         if (!hasMinutes && !hasSeconds) {
-          alert('分または秒を入力してください');
+          showToast('分または秒を入力してください', 'warning');
           return;
         }
 
@@ -227,17 +229,17 @@ export function SetupPanel({ onStart, isLoading }: SetupPanelProps) {
         finalDuration = minutes * 60 + seconds;
       } else {
         if (weight === '') {
-          alert('重さを選択してください');
+          showToast('重さを選択してください', 'warning');
           return;
         }
 
         if (recommendedMode === 'history') {
           if (!beanName) {
-            alert('豆の名前を選択してください');
+            showToast('豆の名前を選択してください', 'warning');
             return;
           }
           if (!roastLevel) {
-            alert('焙煎度合いを選択してください');
+            showToast('焙煎度合いを選択してください', 'warning');
             return;
           }
 
@@ -258,7 +260,7 @@ export function SetupPanel({ onStart, isLoading }: SetupPanelProps) {
       }
 
       if (finalDuration <= 0) {
-        alert('有効な時間を入力してください');
+        showToast('有効な時間を入力してください', 'warning');
         return;
       }
 
@@ -270,7 +272,7 @@ export function SetupPanel({ onStart, isLoading }: SetupPanelProps) {
       );
     } catch (error) {
       console.error('Failed to start timer:', error);
-      alert('タイマーの開始に失敗しました。もう一度お試しください。');
+      showToast('タイマーの開始に失敗しました。もう一度お試しください。', 'error');
     }
   };
 
@@ -278,11 +280,11 @@ export function SetupPanel({ onStart, isLoading }: SetupPanelProps) {
   const handleManualStart = async () => {
     try {
       if (!user) {
-        alert('ログインが必要です');
+        showToast('ログインが必要です', 'warning');
         return;
       }
       if (isLoading) {
-        alert('データを読み込み中です。しばらくお待ちください。');
+        showToast('データを読み込み中です。しばらくお待ちください。', 'info');
         return;
       }
       const hasMinutes = durationMinutes && durationMinutes.trim() !== '';
@@ -298,13 +300,13 @@ export function SetupPanel({ onStart, isLoading }: SetupPanelProps) {
       const duration = minutes * 60 + seconds;
 
       if (duration <= 0) {
-        alert('有効な時間を入力してください');
+        showToast('有効な時間を入力してください', 'warning');
         return;
       }
       await onStart(duration);
     } catch (error) {
       console.error('Failed to start timer:', error);
-      alert('タイマーの開始に失敗しました。もう一度お試しください。');
+      showToast('タイマーの開始に失敗しました。もう一度お試しください。', 'error');
     }
   };
 

--- a/components/work-progress/ProgressHistoryEditDialog.tsx
+++ b/components/work-progress/ProgressHistoryEditDialog.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { HiX, HiCheck, HiTrash } from 'react-icons/hi';
 import { ProgressEntry } from '@/types';
+import { useToastContext } from '@/components/Toast';
 
 interface ProgressHistoryEditDialogProps {
     isOpen: boolean;
@@ -21,6 +22,7 @@ export const ProgressHistoryEditDialog: React.FC<ProgressHistoryEditDialogProps>
     onUpdate,
     onDelete,
 }) => {
+    const { showToast } = useToastContext();
     const [amount, setAmount] = useState<string>('');
     const [memo, setMemo] = useState<string>('');
     const [isSubmitting, setIsSubmitting] = useState(false);
@@ -61,7 +63,7 @@ export const ProgressHistoryEditDialog: React.FC<ProgressHistoryEditDialogProps>
             onClose();
         } catch (error) {
             console.error('Failed to update progress history:', error);
-            alert('履歴の更新に失敗しました');
+            showToast('履歴の更新に失敗しました', 'error');
         } finally {
             setIsSubmitting(false);
         }
@@ -79,7 +81,7 @@ export const ProgressHistoryEditDialog: React.FC<ProgressHistoryEditDialogProps>
             onClose();
         } catch (error) {
             console.error('Failed to delete progress history:', error);
-            alert('履歴の削除に失敗しました');
+            showToast('履歴の削除に失敗しました', 'error');
         } finally {
             setIsSubmitting(false);
         }

--- a/components/work-progress/QuickAddModal.tsx
+++ b/components/work-progress/QuickAddModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { HiX, HiCheck } from 'react-icons/hi';
 import { WorkProgress } from '@/types';
+import { useToastContext } from '@/components/Toast';
 
 interface QuickAddModalProps {
     isOpen: boolean;
@@ -17,6 +18,7 @@ export const QuickAddModal: React.FC<QuickAddModalProps> = ({
     onAdd,
     unit,
 }) => {
+    const { showToast } = useToastContext();
     const [amount, setAmount] = useState<string>('');
     const [memo, setMemo] = useState<string>('');
     const [isSubmitting, setIsSubmitting] = useState(false);
@@ -55,7 +57,7 @@ export const QuickAddModal: React.FC<QuickAddModalProps> = ({
             onClose();
         } catch (error) {
             console.error('Failed to add progress:', error);
-            alert('進捗の追加に失敗しました');
+            showToast('進捗の追加に失敗しました', 'error');
         } finally {
             setIsSubmitting(false);
         }


### PR DESCRIPTION
## 概要

このPRはIssue #39 を解決します。

エラー発生時に `alert()` のみ、または `console.error` のみでユーザーフィードバックがない箇所を、既存のToast通知システム（`useToastContext`）に統一しました。

## 変更内容

### alert → Toast 置換（7コンポーネント）
- `QuickAddModal` - 進捗追加エラー
- `TastingSessionDetail` - 記録の保存/削除エラー
- `ProgressHistoryEditDialog` - 履歴の更新/削除エラー
- `CameraCapture` - カメラアクセスエラー、準備中警告
- `DefectBeanForm` - バリデーション（warning）、追加/更新/削除エラー
- `SetupPanel` - バリデーション（warning）、タイマー開始エラー
- `RoastTimerSettings` - 設定保存エラー、音源テスト結果

### console.errorのみ → Toast追加（2ページ）
- `defect-beans/page.tsx` - CRUD操作エラー、設定更新エラー
- `settings/page.tsx` - ログアウトエラー、同意情報取得エラー

## 設計方針

- 既存の `useToastContext` / `showToast()` をそのまま活用（新規ライブラリ不要）
- Toastタイプの使い分け: `error`（操作失敗）、`warning`（バリデーション）、`info`（情報通知）
- `console.error` は開発デバッグ用に残置
- バックグラウンド処理（Lottie読込、音声再生、Service Worker等）は対象外

## テスト

- [x] npm run lint が通ること（新規warning/errorなし）
- [x] npm run build が通ること
- [ ] 実機で動作確認

Closes #39
