### PR TITLE
security: CORSドメイン制限とセキュリティヘッダーを追加

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -25,6 +25,27 @@
     ],
     "headers": [
       {
+        "source": "**",
+        "headers": [
+          {
+            "key": "X-Content-Type-Options",
+            "value": "nosniff"
+          },
+          {
+            "key": "X-Frame-Options",
+            "value": "DENY"
+          },
+          {
+            "key": "X-XSS-Protection",
+            "value": "1; mode=block"
+          },
+          {
+            "key": "Referrer-Policy",
+            "value": "strict-origin-when-cross-origin"
+          }
+        ]
+      },
+      {
         "source": "**/*.@(webmanifest)",
         "headers": [
           {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -63,7 +63,10 @@ function logDetailedError(
  */
 export const ocrScheduleFromImage = onCall(
   {
-    cors: true,
+    cors: [
+      'https://roastplus-72fa6.web.app',
+      'https://roastplus-72fa6.firebaseapp.com',
+    ],
     maxInstances: 10,
     timeoutSeconds: 300, // 5分
     memory: '512MiB',
@@ -132,7 +135,10 @@ export const ocrScheduleFromImage = onCall(
  */
 export const analyzeTastingSession = onCall(
   {
-    cors: true,
+    cors: [
+      'https://roastplus-72fa6.web.app',
+      'https://roastplus-72fa6.firebaseapp.com',
+    ],
     maxInstances: 10,
     timeoutSeconds: 60,
     memory: '256MiB',


### PR DESCRIPTION
## 概要

技術監査で検出されたセキュリティ課題を修正するPRです。

## 変更内容

### 1. Firebase Functions の CORS 制限 (#61)
`cors: true`（全オリジン許可）を本番ドメインのみに制限しました。

```typescript
// Before
cors: true

// After
cors: [
  'https://roastplus-72fa6.web.app',
  'https://roastplus-72fa6.firebaseapp.com',
]
```

**対象関数:**
- `ocrScheduleFromImage`
- `analyzeTastingSession`

### 2. セキュリティヘッダーの追加 (#68)
`firebase.json` に4種のセキュリティヘッダーを全レスポンスに適用。

| ヘッダー | 値 | 目的 |
|---------|-----|------|
| X-Content-Type-Options | nosniff | MIMEタイプスニッフィング防止 |
| X-Frame-Options | DENY | クリックジャッキング防止 |
| X-XSS-Protection | 1; mode=block | ブラウザXSSフィルター有効化 |
| Referrer-Policy | strict-origin-when-cross-origin | リファラー情報の制限 |

### 3. Firestore defectBeans ルール (#60) — 対応見送り
小規模チーム（8名）で全員が信頼できる環境のため、全ユーザー書き込み可のまま維持。Close済み。

## テスト

- [x] `npm run build` — ビルド成功
- [x] `npx tsc --noEmit` (functions) — 型チェック成功
- [ ] Firebase デプロイ後に CORS 制限が正しく動作するか確認

## 注意
CORS 変更後、`firebase deploy --only functions` が必要です。セキュリティヘッダーは `firebase deploy --only hosting` で反映されます。

Closes #61
Closes #68
