### PR TITLE
perf(image): next/imageへの移行 (#38)

### DIFF
--- a/app/dev-stories/page.tsx
+++ b/app/dev-stories/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-/* eslint-disable @next/next/no-img-element */
 import React from 'react';
+import Image from 'next/image';
 import Link from 'next/link';
 import { HiArrowLeft } from 'react-icons/hi';
 import { RiLightbulbFlashFill } from 'react-icons/ri';
@@ -35,24 +35,32 @@ export default function DevStoriesPage() {
             </div>
             {/* キャラクター画像 */}
             <div className="flex items-center gap-0.5 sm:gap-1">
-              <img
+              <Image
                 src="/avatars/header_characters.png"
                 alt="フカイリとアサイリ"
+                width={48}
+                height={48}
                 className="h-10 sm:h-12 w-auto object-contain animate-wobble-left"
               />
-              <img
+              <Image
                 src="/avatars/header_dori_server.png"
                 alt="ドリとサーバ"
+                width={48}
+                height={48}
                 className="h-10 sm:h-12 w-auto object-contain animate-wobble-right"
               />
-              <img
+              <Image
                 src="/avatars/header_mill_kettle.png"
                 alt="ミルとケトル"
+                width={48}
+                height={48}
                 className="h-10 sm:h-12 w-auto object-contain animate-wobble-left"
               />
-              <img
+              <Image
                 src="/avatars/header_press_siphon.png"
                 alt="プレスとサイフォン"
+                width={48}
+                height={48}
                 className="h-10 sm:h-12 w-auto object-contain animate-wobble-right"
               />
             </div>

--- a/components/CameraCapture.tsx
+++ b/components/CameraCapture.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-/* eslint-disable @next/next/no-img-element */
-
 import { useState, useRef, useEffect } from 'react';
+import Image from 'next/image';
 import { HiCamera, HiX, HiCheck } from 'react-icons/hi';
 import { useToastContext } from '@/components/Toast';
 
@@ -313,10 +312,12 @@ export function CameraCapture({ onCapture, onCancel }: CameraCaptureProps) {
       {/* カメラプレビューまたは撮影した画像 */}
       <div ref={containerRef} className="flex-1 relative flex items-center justify-center overflow-hidden">
         {capturedImage ? (
-          <img
+          <Image
             src={capturedImage}
             alt="Captured"
-            className="max-w-full max-h-full object-contain"
+            fill
+            className="object-contain"
+            unoptimized
           />
         ) : (
           <>

--- a/components/DefectBeanForm.tsx
+++ b/components/DefectBeanForm.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-/* eslint-disable @next/next/no-img-element */
-
 import { useState, useEffect } from 'react';
+import Image from 'next/image';
 import { HiX, HiCamera, HiTrash } from 'react-icons/hi';
 import { CameraCapture } from './CameraCapture';
 import type { DefectBean } from '@/types';
@@ -167,10 +166,13 @@ export function DefectBeanForm({
           {imagePreview ? (
             <div className="flex justify-center">
               <div className="relative w-full max-w-xs">
-                <img
+                <Image
                   src={imagePreview}
                   alt="Preview"
+                  width={320}
+                  height={320}
                   className="w-full aspect-square object-cover rounded-lg"
+                  unoptimized
                 />
                 <button
                   type="button"

--- a/components/ScheduleOCRModal.tsx
+++ b/components/ScheduleOCRModal.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-/* eslint-disable @next/next/no-img-element */
-
 import { useState, useRef, useEffect } from 'react';
+import Image from 'next/image';
 import { CameraCapture } from './CameraCapture';
 import { OCRConfirmModal } from './OCRConfirmModal';
 import { extractScheduleFromImage } from '@/lib/scheduleOCR';
@@ -236,10 +235,13 @@ export function ScheduleOCRModal({ selectedDate, onSuccess, onCancel }: Schedule
             {/* 画像プレビュー */}
             {imagePreview && (
               <div className="mb-6 rounded-lg overflow-hidden border-2 border-amber-200 bg-gray-50">
-                <img 
-                  src={imagePreview} 
-                  alt="解析中の画像" 
+                <Image
+                  src={imagePreview}
+                  alt="解析中の画像"
+                  width={400}
+                  height={256}
                   className="w-full max-h-64 object-contain"
+                  unoptimized
                 />
               </div>
             )}

--- a/components/coffee-quiz/QuizCard.tsx
+++ b/components/coffee-quiz/QuizCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-/* eslint-disable @next/next/no-img-element */
+import Image from 'next/image';
 import { motion, AnimatePresence } from 'framer-motion';
 import { QuizOption } from './QuizOption';
 import { QuizProgress } from './QuizProgress';
@@ -123,9 +123,11 @@ export function QuizCard({
             transition={{ delay: 0.1 }}
             className="mb-5 rounded-xl overflow-hidden"
           >
-            <img
+            <Image
               src={question.imageUrl}
               alt="問題画像"
+              width={600}
+              height={160}
               className="w-full h-40 object-cover"
             />
           </motion.div>

--- a/components/dev-stories/EpisodeCard.tsx
+++ b/components/dev-stories/EpisodeCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-/* eslint-disable @next/next/no-img-element */
 import React from 'react';
+import Image from 'next/image';
 import Link from 'next/link';
 import { RiLightbulbFlashFill } from 'react-icons/ri';
 import type { DevStoryEpisode } from '@/types';
@@ -24,12 +24,13 @@ export const EpisodeCard: React.FC<EpisodeCardProps> = ({ episode }) => {
     <Link href={`/dev-stories/${episode.id}`}>
       <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-4 hover:shadow-md transition-all hover:-translate-y-0.5 active:scale-[0.98]">
         {/* サムネイル */}
-        <div className="h-28 bg-gradient-to-br from-amber-100 to-orange-50 rounded-lg mb-3 flex items-center justify-center overflow-hidden">
+        <div className="relative h-28 bg-gradient-to-br from-amber-100 to-orange-50 rounded-lg mb-3 flex items-center justify-center overflow-hidden">
           {episode.imageUrl ? (
-            <img
+            <Image
               src={episode.imageUrl}
               alt={episode.title}
-              className="w-full h-full object-cover"
+              fill
+              className="object-cover"
             />
           ) : (
             <RiLightbulbFlashFill className="h-10 w-10 text-amber-400" />


### PR DESCRIPTION
## 概要

このPRはIssue #38 を解決します。全6ファイルで `<img>` タグを `next/image` の `<Image>` コンポーネントに移行しました。

## 変更内容

- **Data URL画像（カメラ/プレビュー系）**: `ScheduleOCRModal`, `CameraCapture`, `DefectBeanForm` の3ファイルを `unoptimized` 付きで移行
- **動的URL画像**: `QuizCard`, `EpisodeCard` の2ファイルを移行（`EpisodeCard` は `fill` レイアウト + 親要素に `relative` 追加）
- **静的ローカル画像**: `app/dev-stories/page.tsx` のアバター画像4つを `width`/`height` 指定で移行
- 全ファイルから `eslint-disable @next/next/no-img-element` コメントを削除

## 備考

- `next.config.ts` で `images: { unoptimized: true }` が設定済み（静的エクスポートのため）
- サーバーサイド画像最適化は利用不可だが、レイアウトシフト防止・遅延読み込み・コード統一性のメリットあり

## テスト

- [x] `npm run lint` が通ること（既存エラーのみ、新規エラーなし）
- [x] `npm run build` が通ること（全51ページ正常生成）
- [x] 実機で動作確認

Closes #38
