### PR TITLE
perf(ui): バッジ削除・ChristmasIconsメモ化・next/dynamic遅延ロード導入

### DIFF
--- a/app/drip-guide/run/page.tsx
+++ b/app/drip-guide/run/page.tsx
@@ -2,7 +2,12 @@
 
 import React, { Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { DripGuideRunner } from '@/components/drip-guide/DripGuideRunner';
+import dynamic from 'next/dynamic';
+
+const DripGuideRunner = dynamic(
+  () => import('@/components/drip-guide/DripGuideRunner').then(mod => ({ default: mod.DripGuideRunner })),
+  { ssr: false },
+);
 import { useRecipes } from '@/lib/drip-guide/useRecipes';
 import { calculateRecipeForServings } from '@/lib/drip-guide/recipeCalculator';
 import { generateRecipe46, type Taste46, type Strength46 } from '@/lib/drip-guide/recipe46';

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,7 +15,11 @@ import { useChristmasMode } from '@/hooks/useChristmasMode';
 import { useAuth } from '@/lib/auth';
 import { getUserData } from '@/lib/firestore';
 import { needsConsent } from '@/lib/consent';
-import { Snowfall } from '@/components/Snowfall';
+import dynamic from 'next/dynamic';
+
+const Snowfall = dynamic(() => import('@/components/Snowfall').then(mod => ({ default: mod.Snowfall })), {
+  ssr: false,
+});
 import { FaTree, FaGift, FaSnowflake, FaHollyBerry, FaStar } from 'react-icons/fa';
 import { PiBellFill } from 'react-icons/pi';
 import { GiCandyCanes, GiGingerbreadMan } from 'react-icons/gi';
@@ -32,6 +36,20 @@ interface Action {
   icon: IconType;
   badge?: string;
 }
+
+/** クリスマスモード時のアイコンマッピング（モジュールレベルで定義し再生成を防止） */
+const CHRISTMAS_ICONS: Record<string, IconType> = {
+  assignment: FaGift,
+  schedule: BsStars,
+  tasting: FaTree,
+  'roast-timer': PiBellFill,
+  'defect-beans': GiGingerbreadMan,
+  progress: FaSnowflake,
+  'drip-guide': GiCandyCanes,
+  'coffee-trivia': FaStar,
+  'dev-stories': FaSnowflake,
+  settings: IoSettings,
+};
 
 const ACTIONS: Action[] = [
   {
@@ -82,7 +100,7 @@ const ACTIONS: Action[] = [
     description: '淹れ方の手順',
     href: '/drip-guide',
     icon: MdCoffeeMaker,
-    badge: '新レシピ登場',
+    
   },
   {
     key: 'coffee-trivia',
@@ -97,7 +115,7 @@ const ACTIONS: Action[] = [
     description: '開発の裏話を覗く',
     href: '/dev-stories',
     icon: RiLightbulbFlashFill,
-    badge: '新エピソード登場',
+    
   },
   {
     key: 'settings',
@@ -362,20 +380,7 @@ export default function HomePage(_props: HomePageProps = {}) {
           style={cardHeight ? { gridAutoRows: `${cardHeight}px` } : { gridAutoRows: '1fr' }}
         >
           {ACTIONS.map(({ key, title, description, href, icon: DefaultIcon, badge }, index) => {
-            // クリスマスアイコンのマッピング
-            const ChristmasIcons: Record<string, IconType> = {
-              assignment: FaGift,
-              schedule: BsStars,
-              tasting: FaTree,
-              'roast-timer': PiBellFill,
-              'defect-beans': GiGingerbreadMan,
-              progress: FaSnowflake,
-              'drip-guide': GiCandyCanes,
-              'coffee-trivia': FaStar,
-              'dev-stories': FaSnowflake,
-              settings: IoSettings,
-            };
-            const Icon = isChristmasMode ? (ChristmasIcons[key] || DefaultIcon) : DefaultIcon;
+            const Icon = isChristmasMode ? (CHRISTMAS_ICONS[key] || DefaultIcon) : DefaultIcon;
 
             return (
               <button

--- a/components/DefectBeanCompare.tsx
+++ b/components/DefectBeanCompare.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import { HiX } from 'react-icons/hi';
-import { DefectBeanDetail } from './DefectBeanDetail';
+import dynamic from 'next/dynamic';
+
+const DefectBeanDetail = dynamic(
+  () => import('./DefectBeanDetail').then(mod => ({ default: mod.DefectBeanDetail })),
+);
 import type { DefectBean } from '@/types';
 
 interface DefectBeanCompareProps {

--- a/components/Snowfall.tsx
+++ b/components/Snowfall.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { memo, useState } from 'react';
 
 type Flake = {
   id: number;
@@ -13,7 +13,7 @@ type Flake = {
   depth: number;
 };
 
-export const Snowfall = () => {
+export const Snowfall = memo(function Snowfall() {
   const [snowflakes] = useState<Flake[]>(() => {
     const flakeCount = 60;
     return Array.from({ length: flakeCount }).map((_, i) => {
@@ -94,4 +94,4 @@ export const Snowfall = () => {
       ))}
     </div>
   );
-};
+});

--- a/components/TastingRecordForm.tsx
+++ b/components/TastingRecordForm.tsx
@@ -2,7 +2,11 @@
 
 import { useState } from 'react';
 import type { TastingRecord, AppData, TastingSession } from '@/types';
-import { TastingRadarChart } from './TastingRadarChart';
+import dynamic from 'next/dynamic';
+
+const TastingRadarChart = dynamic(
+  () => import('./TastingRadarChart').then(mod => ({ default: mod.TastingRadarChart })),
+);
 import {
   getRecordsBySessionId,
 } from '@/lib/tastingUtils';

--- a/components/TastingRecordList.tsx
+++ b/components/TastingRecordList.tsx
@@ -2,7 +2,11 @@
 
 import { useRouter } from 'next/navigation';
 import type { AppData } from '@/types';
-import { TastingRadarChart } from './TastingRadarChart';
+import dynamic from 'next/dynamic';
+
+const TastingRadarChart = dynamic(
+  () => import('./TastingRadarChart').then(mod => ({ default: mod.TastingRadarChart })),
+);
 import { StarRating } from './StarRating';
 import { HiTrash } from 'react-icons/hi';
 import { Card } from '@/components/ui';

--- a/components/dev-stories/DetailSection.tsx
+++ b/components/dev-stories/DetailSection.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import React from 'react';
-import { MarkdownRenderer } from '@/components/MarkdownRenderer';
+import dynamic from 'next/dynamic';
+
+const MarkdownRenderer = dynamic(
+  () => import('@/components/MarkdownRenderer').then(mod => ({ default: mod.MarkdownRenderer })),
+);
 
 interface DetailSectionProps {
   content: string;


### PR DESCRIPTION
## 概要

ホーム画面のUI整理とパフォーマンス改善をまとめて実施。

## 変更内容

### #83 バッジラベル削除
- ドリップガイドの「新レシピ登場」バッジを削除
- 開発秘話の「新エピソード登場」バッジを削除

### #71 ChristmasIcons メモ化 & Snowfall React.memo 最適化
- `ChristmasIcons` をコンポーネント内からモジュールレベル定数に移動（毎レンダリングの再生成を防止）
- `Snowfall` コンポーネントを `React.memo` でラップ

### #66 next/dynamic 遅延ロード導入
以下のコンポーネントを `next/dynamic` で遅延ロード化:
- `Snowfall`（`ssr: false`）— クリスマスモード時のみ使用
- `TastingRadarChart` — テイスティングページでのみ使用
- `MarkdownRenderer` — Markdownパーサーライブラリを含む
- `DefectBeanDetail` — 詳細表示時のみ必要
- `DripGuideRunner`（`ssr: false`）— Lottieアニメーションを含む

## テスト

- [x] `npm run lint` — 既存警告のみ（今回の変更による新規エラーなし）
- [x] `npm run build` — 全51ページ正常生成
- [ ] 実機で動作確認

Closes #83, Closes #71, Closes #66
