### PR TITLE
fix(splash): SplashScreenのHydrationミスマッチエラーを解消

### DIFF
--- a/components/SplashScreen.tsx
+++ b/components/SplashScreen.tsx
@@ -7,16 +7,19 @@ const SPLASH_DISPLAY_TIME = 3000; // 3秒
 const SPLASH_SHOWN_KEY = 'roastplus_splash_shown'; // セッション開始時のフラグ
 
 export function SplashScreen() {
-  const [isVisible, setIsVisible] = useState(() => {
-    if (typeof window === 'undefined') return false;
-    const splashShown = sessionStorage.getItem(SPLASH_SHOWN_KEY);
-    if (splashShown === 'true') {
-      return false;
-    }
-    sessionStorage.setItem(SPLASH_SHOWN_KEY, 'true');
-    return true;
-  });
+  const [isVisible, setIsVisible] = useState(false);
   const [isFadingOut, setIsFadingOut] = useState(false);
+
+  // クライアントマウント時にsessionStorageをチェックし、初回訪問時のみスプラッシュを表示
+  // サーバー/クライアント共にisVisible=falseで開始することでHydrationミスマッチを回避
+  useEffect(() => {
+    const splashShown = sessionStorage.getItem(SPLASH_SHOWN_KEY);
+    if (splashShown !== 'true') {
+      sessionStorage.setItem(SPLASH_SHOWN_KEY, 'true');
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- sessionStorageとの初期同期のため必要
+      setIsVisible(true);
+    }
+  }, []);
   const [animationData, setAnimationData] = useState<object | null>(null);
   const [isTextVisible, setIsTextVisible] = useState(false);
 


### PR DESCRIPTION
## 概要

SplashScreenコンポーネントのReact Hydrationミスマッチエラーを解消します。

## 変更内容

- `useState`の初期化関数内で`sessionStorage`にアクセスしていたロジックを`useEffect`に移動
- サーバー/クライアント共に`isVisible = false`で開始し、クライアントマウント後にsessionStorageをチェックして初回訪問時のみスプラッシュを表示

## 原因

`useState`のlazy initializer内で`typeof window === 'undefined'`チェックを行い、サーバー側では`false`、クライアント側では`true`（初回訪問時）を返していたため、hydration時にHTML構造の不一致が発生していた。

## テスト

- [x] `npm run lint` が通ること（SplashScreen関連のエラーなし）
- [x] `npm run build` が通ること
- [ ] 初回訪問時にスプラッシュ画面が表示されること
- [ ] 2回目以降はスプラッシュがスキップされること
- [ ] コンソールにHydrationエラーが表示されないこと

Closes #95
