### PR TITLE
perf(pages): 静的ページの Server Component 化

### DIFF
--- a/app/privacy-policy/page.tsx
+++ b/app/privacy-policy/page.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import Link from 'next/link';
 import { HiArrowLeft } from 'react-icons/hi';
 import { PRIVACY_POLICY_SECTIONS, PRIVACY_POLICY_LAST_UPDATED } from '@/data/legal/privacy-policy';

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import Link from 'next/link';
 import { HiArrowLeft } from 'react-icons/hi';
 import { TERMS_SECTIONS, TERMS_LAST_UPDATED } from '@/data/legal/terms';


### PR DESCRIPTION
## 概要

静的ページから不要な `'use client'` ディレクティブを削除し、Server Component として最適化しました。

Issue #63 の対応です。

## 変更内容

- `app/privacy-policy/page.tsx` から `'use client'` を削除（完全に静的なコンテンツ）
- `app/terms/page.tsx` から `'use client'` を削除（完全に静的なコンテンツ）
- `app/changelog/page.tsx` は `useState`/`useMemo` を使用しているため現状維持

## 効果

- 該当ページのクライアントサイドJSバンドルが削減される
- 静的HTMLとして配信されるため、初回表示が高速化

## テスト

- [x] `npm run build` が通ること（全51ページが正常にプリレンダリング）
- [x] 変更対象ファイルにlintエラーがないこと
- [ ] 実機で動作確認

Closes #63
