### PR TITLE
refactor: progress/page.tsx と TodaySchedule.tsx のモジュール分割 (#62)

### DIFF
--- a/app/progress/components/ArchivedView.tsx
+++ b/app/progress/components/ArchivedView.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { HiArchive } from 'react-icons/hi';
+import type { WorkProgress } from '@/types';
+import { calculateProgressPercentage, formatAmount, extractUnit } from '../utils';
+
+interface ArchivedGroup {
+  date: string;
+  workProgresses: WorkProgress[];
+}
+
+interface ArchivedViewProps {
+  archivedWorkProgressesByDate: ArchivedGroup[];
+  onUnarchive: (id: string) => Promise<void>;
+}
+
+export function ArchivedView({ archivedWorkProgressesByDate, onUnarchive }: ArchivedViewProps) {
+  return (
+    <div className="space-y-8 animate-fade-in">
+      {archivedWorkProgressesByDate.length === 0 ? (
+        <div className="text-center py-12 bg-white rounded-xl shadow-sm border border-gray-200">
+          <div className="text-gray-300 mb-4">
+            <HiArchive className="h-16 w-16 mx-auto" />
+          </div>
+          <p className="text-gray-500 font-medium">アーカイブされた作業はありません</p>
+        </div>
+      ) : (
+        archivedWorkProgressesByDate.map((group) => (
+          <div key={group.date} className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+            <div className="bg-gray-50 px-4 py-3 border-b border-gray-200">
+              <h2 className="font-bold text-gray-800 flex items-center gap-2">
+                <span className="text-amber-600">{new Date(group.date).toLocaleDateString('ja-JP', { year: 'numeric', month: 'long', day: 'numeric' })}</span>
+                <span className="text-xs font-normal text-gray-500 bg-white px-2 py-0.5 rounded-full border border-gray-200">
+                  {group.workProgresses.length}件
+                </span>
+              </h2>
+            </div>
+            <div className="divide-y divide-gray-100">
+              {group.workProgresses.map((wp) => {
+                const unit = extractUnit(wp.weight);
+                return (
+                  <div key={wp.id} className="p-4 hover:bg-gray-50 transition-colors">
+                    <div className="flex justify-between items-start gap-4">
+                      <div className="flex-1">
+                        <div className="flex items-center gap-2 mb-1">
+                          <h3 className="font-bold text-gray-800">{wp.taskName || '名称未設定'}</h3>
+                          {wp.groupName && (
+                            <span className="text-[10px] px-1.5 py-0.5 bg-gray-100 text-gray-600 rounded">
+                              {wp.groupName}
+                            </span>
+                          )}
+                        </div>
+                        <div className="text-sm text-gray-600 mb-2">
+                          {wp.targetAmount !== undefined ? (
+                            <span>
+                              {formatAmount(wp.currentAmount || 0, unit)} / {formatAmount(wp.targetAmount, unit)}{unit}
+                              <span className="text-gray-400 mx-2">|</span>
+                              達成率: {calculateProgressPercentage(wp).toFixed(0)}%
+                            </span>
+                          ) : (
+                            <span>完成数: {wp.completedCount || 0}個</span>
+                          )}
+                        </div>
+                        {wp.memo && (
+                          <p className="text-xs text-gray-500 bg-gray-50 p-2 rounded border border-gray-100 inline-block max-w-full">
+                            {wp.memo}
+                          </p>
+                        )}
+                      </div>
+                      <button
+                        onClick={() => onUnarchive(wp.id)}
+                        className="px-3 py-1.5 text-xs font-medium text-amber-600 bg-amber-50 border border-amber-200 rounded hover:bg-amber-100 transition-colors whitespace-nowrap"
+                      >
+                        戻す
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}

--- a/app/progress/components/FilterDialog.tsx
+++ b/app/progress/components/FilterDialog.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { HiX, HiSearch } from 'react-icons/hi';
+import { Button } from '@/components/ui';
+import type { WorkProgressStatus } from '@/types';
+
+type SortOption = 'createdAt' | 'beanName' | 'status';
+
+interface FilterDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  filterTaskName: string;
+  setFilterTaskName: (val: string) => void;
+  filterStatus: WorkProgressStatus | 'all';
+  setFilterStatus: (val: WorkProgressStatus | 'all') => void;
+  sortOption: SortOption;
+  setSortOption: (val: SortOption) => void;
+}
+
+export function FilterDialog({
+  isOpen, onClose, filterTaskName, setFilterTaskName, filterStatus, setFilterStatus, sortOption, setSortOption
+}: FilterDialogProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 animate-fade-in">
+      <div className="bg-white rounded-2xl shadow-xl w-full max-w-sm overflow-hidden animate-scale-in">
+        <div className="px-6 py-4 border-b border-gray-100 flex justify-between items-center bg-gray-50">
+          <h3 className="font-bold text-gray-800 text-lg">表示設定</h3>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 p-1 rounded-full hover:bg-gray-200 transition-colors">
+            <HiX className="h-6 w-6" />
+          </button>
+        </div>
+
+        <div className="p-6 space-y-6">
+          <div>
+            <label className="block text-sm font-bold text-gray-700 mb-2">キーワード検索</label>
+            <div className="relative">
+              <HiSearch className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 h-5 w-5" />
+              <input
+                type="text"
+                value={filterTaskName}
+                onChange={(e) => setFilterTaskName(e.target.value)}
+                className="w-full pl-10 pr-4 py-2.5 rounded-lg border border-gray-300 focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all text-gray-900 bg-white"
+                placeholder="作業名で検索..."
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-bold text-gray-700 mb-2">ステータス</label>
+            <div className="flex flex-wrap gap-2">
+              {[
+                { value: 'all', label: 'すべて' },
+                { value: 'pending', label: '作業前' },
+                { value: 'in_progress', label: '作業中' },
+                { value: 'completed', label: '完了' },
+              ].map((option) => (
+                <button
+                  key={option.value}
+                  onClick={() => setFilterStatus(option.value as WorkProgressStatus | 'all')}
+                  className={`px-3 py-1.5 text-sm font-medium rounded-lg border transition-all ${filterStatus === option.value
+                    ? 'bg-amber-50 text-amber-700 border-amber-300 ring-1 ring-amber-300'
+                    : 'bg-white text-gray-600 border-gray-200 hover:bg-gray-50'
+                    }`}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-bold text-gray-700 mb-2">並び替え</label>
+            <select
+              value={sortOption}
+              onChange={(e) => setSortOption(e.target.value as SortOption)}
+              className="w-full px-4 py-2.5 rounded-lg border border-gray-300 focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all text-gray-900 bg-white"
+            >
+              <option value="createdAt">作成日順</option>
+              <option value="beanName">名前順</option>
+              <option value="status">ステータス順</option>
+            </select>
+          </div>
+        </div>
+
+        <div className="bg-gray-50 px-6 py-4 border-t border-gray-100">
+          <Button
+            variant="primary"
+            size="md"
+            fullWidth
+            onClick={onClose}
+            className="shadow-md !rounded-xl"
+          >
+            完了
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/progress/components/GroupFormDialog.tsx
+++ b/app/progress/components/GroupFormDialog.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui';
+
+interface GroupFormDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (name: string) => void;
+  initialGroupName?: string;
+  isEditing?: boolean;
+}
+
+export function GroupFormDialog({
+  isOpen, onClose, onSubmit, initialGroupName, isEditing
+}: GroupFormDialogProps) {
+  const [groupName, setGroupName] = useState(initialGroupName || '');
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 animate-fade-in">
+      <div className="bg-white rounded-2xl shadow-xl w-full max-w-sm overflow-hidden animate-scale-in">
+        <div className="px-6 py-4 border-b border-gray-100 bg-gray-50">
+          <h3 className="font-bold text-gray-800 text-lg">
+            {isEditing ? 'グループ名を編集' : '新しいグループを作成'}
+          </h3>
+        </div>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (groupName.trim()) onSubmit(groupName);
+          }}
+          className="p-6"
+        >
+          <div className="mb-6">
+            <label className="block text-sm font-bold text-gray-700 mb-1.5">グループ名</label>
+            <input
+              type="text"
+              value={groupName}
+              onChange={(e) => setGroupName(e.target.value)}
+              className="w-full px-4 py-2.5 rounded-lg border border-gray-300 focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all text-gray-900 bg-white"
+              placeholder="例: ブラジル No.2"
+              autoFocus
+              required
+            />
+          </div>
+          <div className="flex gap-3">
+            <Button
+              type="button"
+              variant="secondary"
+              size="md"
+              onClick={onClose}
+              className="flex-1 !rounded-xl"
+            >
+              キャンセル
+            </Button>
+            <Button
+              type="submit"
+              variant="primary"
+              size="md"
+              disabled={!groupName.trim()}
+              className="flex-1 shadow-md !rounded-xl"
+            >
+              {isEditing ? '更新' : '作成'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/progress/components/ModeSelectDialog.tsx
+++ b/app/progress/components/ModeSelectDialog.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { HiPlus } from 'react-icons/hi';
+import { HiOutlineCollection } from 'react-icons/hi';
+import { Button } from '@/components/ui';
+
+interface ModeSelectDialogProps {
+  onClose: () => void;
+  onAddWork: () => void;
+  onAddGroup: () => void;
+}
+
+export function ModeSelectDialog({ onClose, onAddWork, onAddGroup }: ModeSelectDialogProps) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 animate-fade-in">
+      <div className="bg-white rounded-2xl shadow-xl w-full max-w-sm overflow-hidden animate-scale-in">
+        <div className="p-6 text-center">
+          <h3 className="text-xl font-bold text-gray-800 mb-2">追加する項目を選択</h3>
+          <p className="text-gray-500 text-sm mb-6">
+            新しい作業を追加するか、作業をまとめるグループを作成するか選択してください。
+          </p>
+          <div className="space-y-3">
+            <Button
+              variant="primary"
+              size="md"
+              fullWidth
+              onClick={onAddWork}
+              className="shadow-md !rounded-xl !py-3"
+            >
+              <div className="bg-white/20 p-2 rounded-full shadow-sm mr-3">
+                <HiPlus className="h-5 w-5" />
+              </div>
+              <span>作業を追加</span>
+            </Button>
+            <Button
+              variant="secondary"
+              size="md"
+              fullWidth
+              onClick={onAddGroup}
+              className="!bg-gray-50 hover:!bg-gray-100 !text-gray-700 !border !border-gray-200 !rounded-xl !py-3"
+            >
+              <div className="bg-white p-2 rounded-full shadow-sm mr-3">
+                <HiOutlineCollection className="h-5 w-5" />
+              </div>
+              <span>グループを作成</span>
+            </Button>
+          </div>
+        </div>
+        <div className="bg-gray-50 px-6 py-4 border-t border-gray-100">
+          <button
+            onClick={onClose}
+            className="w-full py-2 text-gray-600 font-medium hover:text-gray-800 transition-colors"
+          >
+            キャンセル
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/progress/components/NormalView.tsx
+++ b/app/progress/components/NormalView.tsx
@@ -1,0 +1,228 @@
+'use client';
+
+import { HiPlus, HiSearch, HiPencil, HiTrash, HiArchive } from 'react-icons/hi';
+import { HiOutlineCollection } from 'react-icons/hi';
+import { MdTimeline } from 'react-icons/md';
+import { Button } from '@/components/ui';
+import { WorkProgressCard } from '@/components/work-progress/WorkProgressCard';
+import type { WorkProgress, WorkProgressStatus } from '@/types';
+import {
+  getProgressBarColor,
+  calculateProgressPercentage,
+  calculateRemaining,
+  formatAmount,
+  extractUnit,
+  formatDateTime,
+} from '../utils';
+
+interface GroupedWorkProgress {
+  groupName: string;
+  taskName: string;
+  weight: string;
+  workProgresses: WorkProgress[];
+}
+
+interface NormalViewProps {
+  showEmptyState: boolean;
+  isEmpty: boolean;
+  hasFilters: boolean;
+  groupedWorkProgresses: { groups: GroupedWorkProgress[]; ungrouped: WorkProgress[] };
+  archivedCount: number;
+  expandedHistoryIds: Set<string>;
+  onSetShowAddForm: () => void;
+  onSetShowAddGroupForm: () => void;
+  onClearFilters: () => void;
+  onEditWorkProgress: (id: string) => void;
+  onStatusChange: (id: string, status: WorkProgressStatus) => Promise<void>;
+  onArchive: (id: string) => Promise<void>;
+  onAddProgress: (id: string | null) => void;
+  onToggleHistory: (id: string) => void;
+  onEditHistory: (workProgressId: string, entryId: string) => void;
+  onEditGroupName: (groupName: string) => void;
+  onDeleteGroup: (groupName: string) => void;
+  onAddToGroup: (groupName: string) => void;
+  onShowArchived: () => void;
+}
+
+export function NormalView({
+  showEmptyState,
+  isEmpty,
+  hasFilters,
+  groupedWorkProgresses,
+  archivedCount,
+  expandedHistoryIds,
+  onSetShowAddForm,
+  onSetShowAddGroupForm,
+  onClearFilters,
+  onEditWorkProgress,
+  onStatusChange,
+  onArchive,
+  onAddProgress,
+  onToggleHistory,
+  onEditHistory,
+  onEditGroupName,
+  onDeleteGroup,
+  onAddToGroup,
+  onShowArchived,
+}: NormalViewProps) {
+  return (
+    <>
+      {/* エンプティステート */}
+      {showEmptyState && (
+        <div className="flex flex-col items-center justify-center py-12 sm:py-20 text-center">
+          <div className="bg-white p-6 rounded-full shadow-lg mb-6">
+            <MdTimeline className="h-16 w-16 text-amber-500" />
+          </div>
+          <h2 className="text-xl sm:text-2xl font-bold text-gray-800 mb-2">作業進捗を管理しましょう</h2>
+          <p className="text-gray-600 mb-8 max-w-md mx-auto">
+            日々の作業の進捗状況を記録・可視化できます。<br />
+            まずは新しい作業を追加してみましょう。
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4">
+            <Button
+              variant="primary"
+              size="lg"
+              onClick={onSetShowAddForm}
+              className="shadow-lg hover:shadow-xl !rounded-xl"
+            >
+              <HiPlus className="h-5 w-5 mr-2" />
+              作業を追加
+            </Button>
+            <Button
+              variant="outline"
+              size="lg"
+              onClick={onSetShowAddGroupForm}
+              className="shadow-md hover:shadow-lg !rounded-xl"
+            >
+              <HiOutlineCollection className="h-5 w-5 mr-2" />
+              グループを作成
+            </Button>
+          </div>
+          {archivedCount > 0 && (
+            <button
+              onClick={onShowArchived}
+              className="mt-8 text-gray-500 hover:text-gray-700 text-sm flex items-center gap-1"
+            >
+              <HiArchive className="h-4 w-4" />
+              アーカイブ済みの作業を見る
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* フィルタ適用時のエンプティステート */}
+      {isEmpty && hasFilters && (
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <div className="text-gray-400 mb-4">
+            <HiSearch className="h-12 w-12 mx-auto" />
+          </div>
+          <p className="text-gray-600 font-medium">条件に一致する作業が見つかりませんでした</p>
+          <button
+            onClick={onClearFilters}
+            className="mt-4 text-amber-600 hover:text-amber-700 font-medium"
+          >
+            フィルタを解除
+          </button>
+        </div>
+      )}
+
+      {/* グループ化された作業 */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+        {groupedWorkProgresses.groups.map((group) => (
+          <div key={group.groupName} className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+            <div className="bg-gray-50 px-4 py-3 border-b border-gray-200 flex justify-between items-center">
+              <div className="flex items-center gap-2">
+                <HiOutlineCollection className="text-gray-400 h-5 w-5" />
+                <h2 className="font-bold text-gray-800 text-lg">{group.groupName}</h2>
+                <span className="text-xs font-medium bg-gray-200 text-gray-600 px-2 py-0.5 rounded-full">
+                  {group.workProgresses.length}件
+                </span>
+              </div>
+              <div className="flex items-center gap-1">
+                <button
+                  onClick={() => onEditGroupName(group.groupName)}
+                  className="p-2 text-gray-400 hover:text-amber-600 hover:bg-amber-50 rounded-full transition-colors"
+                  title="グループ名を編集"
+                >
+                  <HiPencil className="h-4 w-4" />
+                </button>
+                <button
+                  onClick={() => onDeleteGroup(group.groupName)}
+                  className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-full transition-colors"
+                  title="グループを削除"
+                >
+                  <HiTrash className="h-4 w-4" />
+                </button>
+              </div>
+            </div>
+
+            <div className="p-4 flex flex-col gap-4">
+              {group.workProgresses.map((wp) => (
+                <WorkProgressCard
+                  key={wp.id}
+                  workProgress={wp}
+                  isInGroup={true}
+                  onEdit={onEditWorkProgress}
+                  onStatusChange={onStatusChange}
+                  onArchive={onArchive}
+                  onAddProgress={onAddProgress}
+                  onToggleHistory={onToggleHistory}
+                  onEditHistory={onEditHistory}
+                  isHistoryExpanded={expandedHistoryIds.has(wp.id)}
+                  getProgressBarColor={getProgressBarColor}
+                  calculateProgressPercentage={calculateProgressPercentage}
+                  calculateRemaining={calculateRemaining}
+                  formatAmount={formatAmount}
+                  extractUnit={extractUnit}
+                  formatDateTime={formatDateTime}
+                />
+              ))}
+            </div>
+
+            {/* グループ内追加ボタン */}
+            <div className="px-4 pb-4">
+              <button
+                onClick={() => onAddToGroup(group.groupName)}
+                className="w-full py-2 border-2 border-dashed border-gray-200 rounded-lg text-gray-400 hover:text-amber-600 hover:border-amber-300 hover:bg-amber-50 transition-all flex items-center justify-center gap-2 text-sm font-medium"
+              >
+                <HiPlus className="h-4 w-4" />
+                作業を追加
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* グループ化されていない作業 */}
+      {groupedWorkProgresses.ungrouped.length > 0 && (
+        <div className="mb-8">
+          {groupedWorkProgresses.groups.length > 0 && (
+            <h2 className="text-lg font-bold text-gray-700 mb-4 px-2 border-l-4 border-gray-400">その他の作業</h2>
+          )}
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {groupedWorkProgresses.ungrouped.map((wp) => (
+              <WorkProgressCard
+                key={wp.id}
+                workProgress={wp}
+                isInGroup={false}
+                onEdit={onEditWorkProgress}
+                onStatusChange={onStatusChange}
+                onArchive={onArchive}
+                onAddProgress={onAddProgress}
+                onToggleHistory={onToggleHistory}
+                onEditHistory={onEditHistory}
+                isHistoryExpanded={expandedHistoryIds.has(wp.id)}
+                getProgressBarColor={getProgressBarColor}
+                calculateProgressPercentage={calculateProgressPercentage}
+                calculateRemaining={calculateRemaining}
+                formatAmount={formatAmount}
+                extractUnit={extractUnit}
+                formatDateTime={formatDateTime}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/progress/components/ProgressHeader.tsx
+++ b/app/progress/components/ProgressHeader.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import Link from 'next/link';
+import { HiArrowLeft, HiPlus, HiFilter, HiArchive } from 'react-icons/hi';
+import { MdTimeline } from 'react-icons/md';
+import { Button } from '@/components/ui';
+
+interface ProgressHeaderProps {
+  viewMode: 'normal' | 'archived';
+  showEmptyState: boolean;
+  hasArchivedItems: boolean;
+  onShowFilter: () => void;
+  onShowArchived: () => void;
+  onShowModeSelect: () => void;
+  onBackToNormal: () => void;
+}
+
+export function ProgressHeader({
+  viewMode,
+  showEmptyState,
+  hasArchivedItems,
+  onShowFilter,
+  onShowArchived,
+  onShowModeSelect,
+  onBackToNormal,
+}: ProgressHeaderProps) {
+  return (
+    <header>
+      <div className="grid grid-cols-2 sm:grid-cols-3 items-center mb-4">
+        {/* 左側: 戻る */}
+        <div className="flex justify-start">
+          <Link
+            href="/"
+            className="px-3 py-2 text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded transition-colors flex items-center justify-center min-h-[44px] min-w-[44px]"
+            title="戻る"
+            aria-label="戻る"
+          >
+            <HiArrowLeft className="h-6 w-6 flex-shrink-0" />
+          </Link>
+        </div>
+
+        {/* 中央: タイトル */}
+        <div className="hidden sm:flex justify-center items-center gap-2 sm:gap-4 min-w-0">
+          {viewMode === 'archived' ? (
+            <>
+              <HiArchive className="h-8 w-8 sm:h-10 sm:w-10 text-amber-600 flex-shrink-0" />
+              <h1 className="text-lg sm:text-xl lg:text-3xl font-bold text-gray-800 whitespace-nowrap">アーカイブ済み作業</h1>
+            </>
+          ) : (
+            <>
+              <MdTimeline className="h-8 w-8 sm:h-10 sm:w-10 text-amber-600 flex-shrink-0" />
+              <h1 className="text-lg sm:text-xl lg:text-3xl font-bold text-gray-800 whitespace-nowrap">作業進捗</h1>
+            </>
+          )}
+        </div>
+
+        {/* 右側: アクションボタン */}
+        <div className="flex justify-end items-center gap-2 sm:gap-3 flex-shrink-0">
+          {viewMode === 'normal' && !showEmptyState && (
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onShowFilter}
+                className="shadow-md !bg-white !text-gray-700 hover:!bg-gray-50"
+                aria-label="フィルタと並び替え"
+                title="フィルタと並び替え"
+              >
+                <HiFilter className="h-4 w-4" />
+                <span className="hidden md:inline ml-2 text-sm font-medium whitespace-nowrap">フィルター</span>
+              </Button>
+              {hasArchivedItems && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={onShowArchived}
+                  className="shadow-md !bg-white !text-gray-700 hover:!bg-gray-50"
+                  aria-label="アーカイブ一覧"
+                  title="アーカイブ一覧"
+                >
+                  <HiArchive className="h-4 w-4" />
+                </Button>
+              )}
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={onShowModeSelect}
+                className="shadow-md"
+              >
+                <HiPlus className="h-4 w-4" />
+                <span className="hidden sm:inline ml-2">追加</span>
+              </Button>
+            </>
+          )}
+          {viewMode === 'archived' && (
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={onBackToNormal}
+              className="shadow-sm !bg-white !text-gray-700 !border !border-gray-300 hover:!bg-gray-50"
+            >
+              <MdTimeline className="h-4 w-4" />
+              <span className="hidden sm:inline ml-2">一覧に戻る</span>
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* モバイル用タイトル */}
+      <div className="sm:hidden flex justify-center items-center gap-2 mb-4">
+        {viewMode === 'archived' ? (
+          <>
+            <HiArchive className="h-6 w-6 text-amber-600 flex-shrink-0" />
+            <h1 className="text-lg font-bold text-gray-800">アーカイブ済み作業</h1>
+          </>
+        ) : (
+          <>
+            <MdTimeline className="h-6 w-6 text-amber-600 flex-shrink-0" />
+            <h1 className="text-lg font-bold text-gray-800">作業進捗</h1>
+          </>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/app/progress/components/WorkProgressFormDialog.tsx
+++ b/app/progress/components/WorkProgressFormDialog.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { useState } from 'react';
+import { HiX, HiTrash } from 'react-icons/hi';
+import { Button } from '@/components/ui';
+import { extractTargetAmount, extractUnitFromWeight } from '@/lib/firestore';
+import type { WorkProgressStatus } from '@/types';
+import type { WorkProgressInput } from '@/hooks/useWorkProgressActions';
+
+interface WorkProgressFormDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (data: WorkProgressInput) => Promise<void>;
+  onDelete?: () => void;
+  initialData?: WorkProgressInput;
+  isEditing: boolean;
+  defaultGroupName?: string | null;
+}
+
+export function WorkProgressFormDialog({
+  isOpen, onClose, onSubmit, onDelete, initialData, isEditing, defaultGroupName
+}: WorkProgressFormDialogProps) {
+  const initialWeight = initialData?.weight || '';
+  const initialAmount = initialWeight ? extractTargetAmount(initialWeight) : undefined;
+  const initialUnit = initialWeight ? extractUnitFromWeight(initialWeight) : '';
+  const validUnits = ['kg', 'g', '個', '枚', '袋', '箱'];
+  const initialUnitValid = validUnits.includes(initialUnit) ? initialUnit : '';
+
+  const [formData, setFormData] = useState({
+    groupName: defaultGroupName || initialData?.groupName || '',
+    taskName: initialData?.taskName || '',
+    targetAmount: initialAmount !== undefined ? initialAmount.toString() : '',
+    targetUnit: initialUnitValid,
+    memo: initialData?.memo || '',
+    status: initialData?.status || 'pending',
+  });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    try {
+      let weight = '';
+      if (formData.targetAmount.trim()) {
+        const amount = formData.targetAmount.trim();
+        const unit = formData.targetUnit.trim();
+        weight = unit ? `${amount}${unit}` : amount;
+      }
+
+      const payload: WorkProgressInput = {
+        groupName: formData.groupName || undefined,
+        taskName: formData.taskName,
+        memo: formData.memo || undefined,
+        status: formData.status,
+        weight: weight || undefined,
+      };
+      await onSubmit(payload);
+      onClose();
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 animate-fade-in">
+      <div className="bg-white rounded-2xl shadow-xl w-full max-w-md overflow-hidden flex flex-col max-h-[90vh] animate-scale-in">
+        <div className="px-6 py-4 border-b border-gray-100 flex justify-between items-center bg-gray-50">
+          <h3 className="font-bold text-gray-800 text-lg">
+            {isEditing ? '作業を編集' : '新しい作業を追加'}
+          </h3>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 p-1 rounded-full hover:bg-gray-200 transition-colors">
+            <HiX className="h-6 w-6" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="p-6 overflow-y-auto flex-1">
+          <div className="space-y-5">
+            <div>
+              <label className="block text-sm font-bold text-gray-700 mb-1.5">グループ名 (任意)</label>
+              <input
+                type="text"
+                value={formData.groupName}
+                onChange={(e) => setFormData({ ...formData, groupName: e.target.value })}
+                className="w-full px-4 py-2.5 rounded-lg border border-gray-300 focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all text-gray-900 bg-white"
+                placeholder="例: ブラジル No.2"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-bold text-gray-700 mb-1.5">作業名</label>
+              <input
+                type="text"
+                value={formData.taskName}
+                onChange={(e) => setFormData({ ...formData, taskName: e.target.value })}
+                className="w-full px-4 py-2.5 rounded-lg border border-gray-300 focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all text-gray-900 bg-white"
+                placeholder="例: ハンドピック"
+                required
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-bold text-gray-700 mb-1.5">目標量 (任意)</label>
+              <div className="flex gap-2">
+                <input
+                  type="number"
+                  value={formData.targetAmount}
+                  onChange={(e) => setFormData({ ...formData, targetAmount: e.target.value })}
+                  className="flex-1 px-4 py-2.5 rounded-lg border border-gray-300 focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all text-gray-900 bg-white"
+                  placeholder="数値"
+                  step="0.1"
+                  min="0"
+                />
+                <select
+                  value={formData.targetUnit}
+                  onChange={(e) => setFormData({ ...formData, targetUnit: e.target.value })}
+                  className="px-4 py-2.5 rounded-lg border border-gray-300 focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all text-gray-900 bg-white"
+                >
+                  <option value="">単位なし</option>
+                  <option value="kg">kg</option>
+                  <option value="g">g</option>
+                  <option value="個">個</option>
+                  <option value="枚">枚</option>
+                  <option value="袋">袋</option>
+                  <option value="箱">箱</option>
+                </select>
+              </div>
+              <p className="text-xs text-gray-500 mt-1.5">
+                ※ 数値と単位を入力すると進捗バーが表示されます（例: 10kg）。<br />
+                ※ 空欄の場合は完成数のみをカウントするモードになります。
+              </p>
+            </div>
+
+            <div>
+              <label className="block text-sm font-bold text-gray-700 mb-1.5">メモ (任意)</label>
+              <textarea
+                value={formData.memo}
+                onChange={(e) => setFormData({ ...formData, memo: e.target.value })}
+                className="w-full px-4 py-2.5 rounded-lg border border-gray-300 focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all resize-none text-gray-900 bg-white"
+                rows={3}
+                placeholder="備考があれば入力してください"
+              />
+            </div>
+
+            {isEditing && (
+              <div>
+                <label className="block text-sm font-bold text-gray-700 mb-1.5">状態</label>
+                <select
+                  value={formData.status}
+                  onChange={(e) => setFormData({ ...formData, status: e.target.value as WorkProgressStatus })}
+                  className="w-full px-4 py-2.5 rounded-lg border border-gray-300 focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all text-gray-900 bg-white"
+                >
+                  <option value="pending">作業前</option>
+                  <option value="in_progress">作業中</option>
+                  <option value="completed">完了</option>
+                </select>
+              </div>
+            )}
+          </div>
+
+          <div className="mt-8 flex gap-3">
+            {isEditing && onDelete && (
+              <Button
+                type="button"
+                variant="danger"
+                size="md"
+                onClick={onDelete}
+                className="!bg-red-50 !text-red-600 hover:!bg-red-100 !rounded-xl"
+                title="削除"
+              >
+                <HiTrash className="h-5 w-5" />
+              </Button>
+            )}
+            <Button
+              type="submit"
+              variant="primary"
+              size="md"
+              disabled={isSubmitting}
+              loading={isSubmitting}
+              className="flex-1 shadow-md hover:shadow-lg !rounded-xl"
+            >
+              {isSubmitting ? '保存中...' : (isEditing ? '更新する' : '追加する')}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/progress/page.tsx
+++ b/app/progress/page.tsx
@@ -1,17 +1,20 @@
 'use client';
 
 import { useState, useMemo } from 'react';
-import Link from 'next/link';
 import { useAuth } from '@/lib/auth';
 import { useAppData } from '@/hooks/useAppData';
 import { Loading } from '@/components/Loading';
-import { addWorkProgress, updateWorkProgress, updateWorkProgresses, deleteWorkProgress, addProgressToWorkProgress, addCompletedCountToWorkProgress, archiveWorkProgress, unarchiveWorkProgress, updateProgressHistoryEntry, deleteProgressHistoryEntry, extractTargetAmount, extractUnitFromWeight } from '@/lib/firestore';
-import { HiArrowLeft, HiPlus, HiX, HiPencil, HiTrash, HiFilter, HiSearch, HiOutlineCollection, HiArchive } from 'react-icons/hi';
-import { MdTimeline } from 'react-icons/md';
 import LoginPage from '@/app/login/page';
-import { Button } from '@/components/ui';
 import type { WorkProgress, WorkProgressStatus } from '@/types';
-import { WorkProgressCard } from '@/components/work-progress/WorkProgressCard';
+import { useWorkProgressActions } from '@/hooks/useWorkProgressActions';
+import { extractUnit } from './utils';
+import { ProgressHeader } from './components/ProgressHeader';
+import { NormalView } from './components/NormalView';
+import { ArchivedView } from './components/ArchivedView';
+import { ModeSelectDialog } from './components/ModeSelectDialog';
+import { WorkProgressFormDialog } from './components/WorkProgressFormDialog';
+import { GroupFormDialog } from './components/GroupFormDialog';
+import { FilterDialog } from './components/FilterDialog';
 import { QuickAddModal } from '@/components/work-progress/QuickAddModal';
 import { ProgressHistoryEditDialog } from '@/components/work-progress/ProgressHistoryEditDialog';
 
@@ -23,8 +26,6 @@ interface GroupedWorkProgress {
   weight: string;
   workProgresses: WorkProgress[];
 }
-
-type WorkProgressInput = Partial<Omit<WorkProgress, 'id' | 'createdAt' | 'updatedAt'>>;
 
 export default function ProgressPage() {
   const { user, loading: authLoading } = useAuth();
@@ -40,120 +41,50 @@ export default function ProgressPage() {
   const [editingGroupName, setEditingGroupName] = useState<string | null>(null);
   const [showModeSelectDialog, setShowModeSelectDialog] = useState(false);
   const [showAddGroupForm, setShowAddGroupForm] = useState(false);
-  const [expandedHistoryIds, setExpandedHistoryIds] = useState<Set<string>>(new Set());
   const [viewMode, setViewMode] = useState<'normal' | 'archived'>('normal');
-  const [editingHistoryEntryId, setEditingHistoryEntryId] = useState<string | null>(null);
-  const [editingHistoryWorkProgressId, setEditingHistoryWorkProgressId] = useState<string | null>(null);
 
-  // 作業をグループ化（groupNameが設定されている場合のみグループ化、未入力の場合は個別カードとして表示）
+  const actions = useWorkProgressActions(user?.uid, data);
+
+  // 作業をグループ化
   const groupedWorkProgresses = useMemo(() => {
     const workProgresses = data?.workProgresses || [];
 
-    // フィルタリング（アーカイブ済み作業は除外）
     const filtered = workProgresses.filter((wp) => {
-      // アーカイブ済み作業は除外
-      if (wp.archivedAt) {
-        return false;
-      }
-      if (filterTaskName && wp.taskName && !wp.taskName.toLowerCase().includes(filterTaskName.toLowerCase())) {
-        return false;
-      }
-      if (filterStatus !== 'all' && wp.status !== filterStatus) {
-        return false;
-      }
+      if (wp.archivedAt) return false;
+      if (filterTaskName && wp.taskName && !wp.taskName.toLowerCase().includes(filterTaskName.toLowerCase())) return false;
+      if (filterStatus !== 'all' && wp.status !== filterStatus) return false;
       return true;
     });
 
-    // グループ化（groupNameが設定されている場合のみ）
     const groups = new Map<string, GroupedWorkProgress>();
     const ungroupedWorkProgresses: WorkProgress[] = [];
 
     filtered.forEach((wp) => {
       if (wp.groupName) {
-        // groupNameが設定されている場合はグループ化（weightはグループ化のキーに含めない）
         const key = wp.groupName;
-
         if (!groups.has(key)) {
-          groups.set(key, {
-            groupName: wp.groupName,
-            taskName: wp.taskName || '',
-            weight: wp.weight || '', // 表示用（最初の作業のweightを表示）
-            workProgresses: [],
-          });
+          groups.set(key, { groupName: wp.groupName, taskName: wp.taskName || '', weight: wp.weight || '', workProgresses: [] });
         }
         groups.get(key)!.workProgresses.push(wp);
       } else {
-        // groupNameが未入力の場合は個別カードとして扱う
         ungroupedWorkProgresses.push(wp);
       }
     });
 
-    // ソート
+    const sortFn = (a: WorkProgress, b: WorkProgress) => {
+      if (sortOption === 'createdAt') return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+      if (sortOption === 'beanName') return (a.groupName || a.taskName || '').localeCompare(b.groupName || b.taskName || '', 'ja');
+      if (sortOption === 'status') {
+        const order: Record<WorkProgressStatus, number> = { pending: 0, in_progress: 1, completed: 2 };
+        return order[a.status] - order[b.status];
+      }
+      return 0;
+    };
+
     const sortedGroups = Array.from(groups.values());
-
-    sortedGroups.forEach((group) => {
-      group.workProgresses.sort((a, b) => {
-        if (sortOption === 'createdAt') {
-          return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
-        } else if (sortOption === 'beanName') {
-          // 優先順位: groupName > taskName
-          const aName = a.groupName || a.taskName || '';
-          const bName = b.groupName || b.taskName || '';
-          return aName.localeCompare(bName, 'ja');
-        } else if (sortOption === 'status') {
-          const statusOrder: Record<WorkProgressStatus, number> = {
-            pending: 0,
-            in_progress: 1,
-            completed: 2,
-          };
-          return statusOrder[a.status] - statusOrder[b.status];
-        }
-        return 0;
-      });
-    });
-
-    // グループ全体のソート
-    sortedGroups.sort((a, b) => {
-      if (sortOption === 'createdAt') {
-        const aLatest = a.workProgresses[0]?.createdAt || '';
-        const bLatest = b.workProgresses[0]?.createdAt || '';
-        return new Date(aLatest).getTime() - new Date(bLatest).getTime();
-      } else if (sortOption === 'beanName') {
-        // 優先順位: groupName > taskName
-        const aName = a.groupName || a.taskName || '';
-        const bName = b.groupName || b.taskName || '';
-        return aName.localeCompare(bName, 'ja');
-      } else if (sortOption === 'status') {
-        const statusOrder: Record<WorkProgressStatus, number> = {
-          pending: 0,
-          in_progress: 1,
-          completed: 2,
-        };
-        const aStatus = a.workProgresses[0]?.status || 'pending';
-        const bStatus = b.workProgresses[0]?.status || 'pending';
-        return statusOrder[aStatus] - statusOrder[bStatus];
-      }
-      return 0;
-    });
-
-    // グループ化されていない作業のソート
-    ungroupedWorkProgresses.sort((a, b) => {
-      if (sortOption === 'createdAt') {
-        return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
-      } else if (sortOption === 'beanName') {
-        const aName = a.taskName || '';
-        const bName = b.taskName || '';
-        return aName.localeCompare(bName, 'ja');
-      } else if (sortOption === 'status') {
-        const statusOrder: Record<WorkProgressStatus, number> = {
-          pending: 0,
-          in_progress: 1,
-          completed: 2,
-        };
-        return statusOrder[a.status] - statusOrder[b.status];
-      }
-      return 0;
-    });
+    sortedGroups.forEach((g) => g.workProgresses.sort(sortFn));
+    sortedGroups.sort((a, b) => sortFn(a.workProgresses[0], b.workProgresses[0]));
+    ungroupedWorkProgresses.sort(sortFn);
 
     return { groups: sortedGroups, ungrouped: ungroupedWorkProgresses };
   }, [data, filterTaskName, filterStatus, sortOption]);
@@ -162,533 +93,74 @@ export default function ProgressPage() {
   const archivedWorkProgressesByDate = useMemo(() => {
     const workProgresses = data?.workProgresses || [];
     const archived = workProgresses.filter((wp) => wp.archivedAt);
-
     const grouped = archived.reduce((acc, wp) => {
       const date = new Date(wp.archivedAt!).toLocaleDateString('ja-JP');
-      if (!acc[date]) {
-        acc[date] = [];
-      }
+      if (!acc[date]) acc[date] = [];
       acc[date].push(wp);
       return acc;
     }, {} as Record<string, WorkProgress[]>);
 
     return Object.entries(grouped)
-      .map(([date, workProgresses]) => ({
+      .map(([date, wps]) => ({
         date,
-        workProgresses: workProgresses.sort((a, b) =>
-          new Date(b.archivedAt!).getTime() - new Date(a.archivedAt!).getTime()
-        ),
+        workProgresses: wps.sort((a, b) => new Date(b.archivedAt!).getTime() - new Date(a.archivedAt!).getTime()),
       }))
       .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
   }, [data]);
 
-  // エンプティステートの判定
-  const showEmptyState = useMemo(() => {
-    return groupedWorkProgresses.groups.length === 0 && groupedWorkProgresses.ungrouped.length === 0 && !filterTaskName && filterStatus === 'all';
-  }, [groupedWorkProgresses, filterTaskName, filterStatus]);
+  const showEmptyState = groupedWorkProgresses.groups.length === 0 && groupedWorkProgresses.ungrouped.length === 0 && !filterTaskName && filterStatus === 'all';
+  const isEmpty = groupedWorkProgresses.groups.length === 0 && groupedWorkProgresses.ungrouped.length === 0;
+  const hasFilters = filterTaskName !== '' || filterStatus !== 'all';
 
-  const isEmpty = useMemo(() => {
-    return groupedWorkProgresses.groups.length === 0 && groupedWorkProgresses.ungrouped.length === 0;
-  }, [groupedWorkProgresses]);
-
-  const hasFilters = useMemo(() => {
-    return filterTaskName !== '' || filterStatus !== 'all';
-  }, [filterTaskName, filterStatus]);
-
-  // アクティブな作業進捗を取得
   const activeWorkProgress = useMemo(() => {
     if (!addingProgressWorkProgressId || !data?.workProgresses) return null;
     return data.workProgresses.find((wp) => wp.id === addingProgressWorkProgressId) || null;
   }, [addingProgressWorkProgressId, data]);
 
-  // 各種ハンドラー関数（簡易実装、必要に応じて実装）
-  const handleAddWorkProgress = async (workProgressData: WorkProgressInput) => {
-    if (!user || !data) return;
-    const payload: Omit<WorkProgress, 'id' | 'createdAt' | 'updatedAt'> = {
-      ...workProgressData,
-      status: workProgressData.status ?? 'pending',
-    };
-    await addWorkProgress(user.uid, payload, data);
-  };
-
-  const handleUpdateWorkProgress = async (id: string, updates: Partial<WorkProgress>) => {
-    if (!user || !data) return;
-    await updateWorkProgress(user.uid, id, updates, data);
-  };
-
-  const handleDeleteWorkProgress = async (id: string) => {
-    if (!user || !data) return;
-    await deleteWorkProgress(user.uid, id, data);
-  };
-
-  const handleStatusChange = async (id: string, status: WorkProgressStatus) => {
-    if (!user || !data) return;
-    await updateWorkProgress(user.uid, id, { status }, data);
-  };
-
-  const handleArchiveWorkProgress = async (id: string) => {
-    if (!user || !data) return;
-    await archiveWorkProgress(user.uid, id, data);
-  };
-
-  const handleUnarchiveWorkProgress = async (id: string) => {
-    if (!user || !data) return;
-    await unarchiveWorkProgress(user.uid, id, data);
-  };
-
-  const handleAddProgress = async (id: string, amount: number, memo?: string) => {
-    if (!user || !data) return;
-    const workProgress = data.workProgresses?.find((wp) => wp.id === id);
-    if (!workProgress) return;
-
-    // targetAmountが設定されている場合は進捗量を追加、設定されていない場合は完成数を追加
-    if (workProgress.targetAmount !== undefined) {
-      await addProgressToWorkProgress(user.uid, id, amount, data, memo);
-    } else {
-      // 完成数モードの場合、amountを完成数として扱う（整数に変換）
-      await addCompletedCountToWorkProgress(user.uid, id, Math.floor(amount), data, memo);
-    }
-  };
-
-  const handleUpdateGroup = async (oldGroupName: string, newData: { groupName: string }) => {
-    if (!user || !data?.workProgresses) return;
-    const workProgresses = data.workProgresses.filter((wp) => wp.groupName === oldGroupName);
-    const updates = new Map<string, Partial<Omit<WorkProgress, 'id' | 'createdAt'>>>();
-    workProgresses.forEach((wp) => {
-      updates.set(wp.id, { groupName: newData.groupName });
-    });
-    await updateWorkProgresses(user.uid, updates, data);
-  };
-
-  const handleDeleteGroup = async (groupName: string) => {
-    if (!user || !data?.workProgresses) return;
-    const workProgresses = data.workProgresses.filter((wp) => wp.groupName === groupName);
-    for (const wp of workProgresses) {
-      await deleteWorkProgress(user.uid, wp.id, data);
-    }
-  };
-
-  const handleEditHistory = (workProgressId: string, entryId: string) => {
-    setEditingHistoryWorkProgressId(workProgressId);
-    setEditingHistoryEntryId(entryId);
-  };
-
-  const handleUpdateProgressHistory = async (workProgressId: string, entryId: string, amount: number, memo?: string) => {
-    if (!user || !data) return;
-    await updateProgressHistoryEntry(user.uid, workProgressId, entryId, { amount, memo }, data);
-    setEditingHistoryWorkProgressId(null);
-    setEditingHistoryEntryId(null);
-  };
-
-  const handleDeleteProgressHistory = async (workProgressId: string, entryId: string) => {
-    if (!user || !data) return;
-    await deleteProgressHistoryEntry(user.uid, workProgressId, entryId, data);
-    setEditingHistoryWorkProgressId(null);
-    setEditingHistoryEntryId(null);
-  };
-
-  const toggleHistory = (id: string) => {
-    setExpandedHistoryIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
-      }
-      return next;
-    });
-  };
-
-  // ユーティリティ関数
-  const getProgressBarColor = (percentage: number) => {
-    if (percentage >= 100) return 'bg-green-500';
-    if (percentage >= 50) return 'bg-amber-500';
-    return 'bg-gray-400';
-  };
-
-  const calculateProgressPercentage = (wp: WorkProgress) => {
-    if (wp.targetAmount !== undefined && wp.targetAmount > 0) {
-      return ((wp.currentAmount || 0) / wp.targetAmount) * 100;
-    }
-    return 0;
-  };
-
-  const calculateRemaining = (wp: WorkProgress) => {
-    if (wp.targetAmount !== undefined) {
-      return Math.max(0, wp.targetAmount - (wp.currentAmount || 0));
-    }
-    return 0;
-  };
-
-  const formatAmount = (amount: number, unit: string) => {
-    void unit;
-    return amount.toLocaleString('ja-JP');
-  };
-
-  const extractUnit = (weight: string | undefined) => {
-    if (!weight) return '';
-    const match = weight.match(/[^\d.,\s]+/);
-    return match ? match[0] : '';
-  };
-
-  const formatDateTime = (dateString?: string) => {
-    if (!dateString) return '';
-    const d = new Date(dateString);
-    return d.toLocaleString('ja-JP', {
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-  };
-
-  if (authLoading || isLoading) {
-    return <Loading />;
-  }
-
-  if (!user) {
-    return <LoginPage />;
-  }
+  if (authLoading || isLoading) return <Loading />;
+  if (!user) return <LoginPage />;
 
   return (
     <div className="min-h-screen bg-gray-50 p-4 sm:p-6 lg:p-8">
-      <header>
-        <div className="grid grid-cols-2 sm:grid-cols-3 items-center mb-4">
-          {/* 左側: 戻る */}
-          <div className="flex justify-start">
-            <Link
-              href="/"
-              className="px-3 py-2 text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded transition-colors flex items-center justify-center min-h-[44px] min-w-[44px]"
-              title="戻る"
-              aria-label="戻る"
-            >
-              <HiArrowLeft className="h-6 w-6 flex-shrink-0" />
-            </Link>
-          </div>
+      <ProgressHeader
+        viewMode={viewMode}
+        showEmptyState={showEmptyState}
+        hasArchivedItems={archivedWorkProgressesByDate.length > 0}
+        onShowFilter={() => setShowFilterDialog(true)}
+        onShowArchived={() => setViewMode('archived')}
+        onShowModeSelect={() => setShowModeSelectDialog(true)}
+        onBackToNormal={() => setViewMode('normal')}
+      />
 
-          {/* 中央: タイトル */}
-          <div className="hidden sm:flex justify-center items-center gap-2 sm:gap-4 min-w-0">
-            {viewMode === 'archived' ? (
-              <>
-                <HiArchive className="h-8 w-8 sm:h-10 sm:w-10 text-amber-600 flex-shrink-0" />
-                <h1 className="text-lg sm:text-xl lg:text-3xl font-bold text-gray-800 whitespace-nowrap">アーカイブ済み作業</h1>
-              </>
-            ) : (
-              <>
-                <MdTimeline className="h-8 w-8 sm:h-10 sm:w-10 text-amber-600 flex-shrink-0" />
-                <h1 className="text-lg sm:text-xl lg:text-3xl font-bold text-gray-800 whitespace-nowrap">作業進捗</h1>
-              </>
-            )}
-          </div>
-
-          {/* 右側: アクションボタン */}
-          <div className="flex justify-end items-center gap-2 sm:gap-3 flex-shrink-0">
-            {viewMode === 'normal' && !showEmptyState && (
-              <>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setShowFilterDialog(true)}
-                  className="shadow-md !bg-white !text-gray-700 hover:!bg-gray-50"
-                  aria-label="フィルタと並び替え"
-                  title="フィルタと並び替え"
-                >
-                  <HiFilter className="h-4 w-4" />
-                  <span className="hidden md:inline ml-2 text-sm font-medium whitespace-nowrap">フィルター</span>
-                </Button>
-                {archivedWorkProgressesByDate.length > 0 && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setViewMode('archived')}
-                    className="shadow-md !bg-white !text-gray-700 hover:!bg-gray-50"
-                    aria-label="アーカイブ一覧"
-                    title="アーカイブ一覧"
-                  >
-                    <HiArchive className="h-4 w-4" />
-                  </Button>
-                )}
-                <Button
-                  variant="primary"
-                  size="sm"
-                  onClick={() => setShowModeSelectDialog(true)}
-                  className="shadow-md"
-                >
-                  <HiPlus className="h-4 w-4" />
-                  <span className="hidden sm:inline ml-2">追加</span>
-                </Button>
-              </>
-            )}
-            {viewMode === 'archived' && (
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={() => setViewMode('normal')}
-                className="shadow-sm !bg-white !text-gray-700 !border !border-gray-300 hover:!bg-gray-50"
-              >
-                <MdTimeline className="h-4 w-4" />
-                <span className="hidden sm:inline ml-2">一覧に戻る</span>
-              </Button>
-            )}
-          </div>
-        </div>
-
-        {/* モバイル用タイトル */}
-        <div className="sm:hidden flex justify-center items-center gap-2 mb-4">
-          {viewMode === 'archived' ? (
-            <>
-              <HiArchive className="h-6 w-6 text-amber-600 flex-shrink-0" />
-              <h1 className="text-lg font-bold text-gray-800">アーカイブ済み作業</h1>
-            </>
-          ) : (
-            <>
-              <MdTimeline className="h-6 w-6 text-amber-600 flex-shrink-0" />
-              <h1 className="text-lg font-bold text-gray-800">作業進捗</h1>
-            </>
-          )}
-        </div>
-      </header>
-
-      {/* メインコンテンツ */}
       <main>
-        {
-          viewMode === 'normal' ? (
-            <>
-              {/* エンプティステート */}
-              {showEmptyState && (
-                <div className="flex flex-col items-center justify-center py-12 sm:py-20 text-center">
-                  <div className="bg-white p-6 rounded-full shadow-lg mb-6">
-                    <MdTimeline className="h-16 w-16 text-amber-500" />
-                  </div>
-                  <h2 className="text-xl sm:text-2xl font-bold text-gray-800 mb-2">作業進捗を管理しましょう</h2>
-                  <p className="text-gray-600 mb-8 max-w-md mx-auto">
-                    日々の作業の進捗状況を記録・可視化できます。<br />
-                    まずは新しい作業を追加してみましょう。
-                  </p>
-                  <div className="flex flex-col sm:flex-row gap-4">
-                    <Button
-                      variant="primary"
-                      size="lg"
-                      onClick={() => setShowAddForm(true)}
-                      className="shadow-lg hover:shadow-xl !rounded-xl"
-                    >
-                      <HiPlus className="h-5 w-5 mr-2" />
-                      作業を追加
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="lg"
-                      onClick={() => setShowAddGroupForm(true)}
-                      className="shadow-md hover:shadow-lg !rounded-xl"
-                    >
-                      <HiOutlineCollection className="h-5 w-5 mr-2" />
-                      グループを作成
-                    </Button>
-                  </div>
-                  {archivedWorkProgressesByDate.length > 0 && (
-                    <button
-                      onClick={() => setViewMode('archived')}
-                      className="mt-8 text-gray-500 hover:text-gray-700 text-sm flex items-center gap-1"
-                    >
-                      <HiArchive className="h-4 w-4" />
-                      アーカイブ済みの作業を見る
-                    </button>
-                  )}
-                </div>
-              )}
-
-              {/* フィルタ適用時のエンプティステート */}
-              {isEmpty && hasFilters && (
-                <div className="flex flex-col items-center justify-center py-12 text-center">
-                  <div className="text-gray-400 mb-4">
-                    <HiSearch className="h-12 w-12 mx-auto" />
-                  </div>
-                  <p className="text-gray-600 font-medium">条件に一致する作業が見つかりませんでした</p>
-                  <button
-                    onClick={() => {
-                      setFilterTaskName('');
-                      setFilterStatus('all');
-                    }}
-                    className="mt-4 text-amber-600 hover:text-amber-700 font-medium"
-                  >
-                    フィルタを解除
-                  </button>
-                </div>
-              )}
-
-              {/* グループ化された作業 */}
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
-                {groupedWorkProgresses.groups.map((group) => (
-                  <div key={group.groupName} className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
-                  <div className="bg-gray-50 px-4 py-3 border-b border-gray-200 flex justify-between items-center">
-                    <div className="flex items-center gap-2">
-                      <HiOutlineCollection className="text-gray-400 h-5 w-5" />
-                      <h2 className="font-bold text-gray-800 text-lg">{group.groupName}</h2>
-                      <span className="text-xs font-medium bg-gray-200 text-gray-600 px-2 py-0.5 rounded-full">
-                        {group.workProgresses.length}件
-                      </span>
-                    </div>
-                    <div className="flex items-center gap-1">
-                      <button
-                        onClick={() => setEditingGroupName(group.groupName)}
-                        className="p-2 text-gray-400 hover:text-amber-600 hover:bg-amber-50 rounded-full transition-colors"
-                        title="グループ名を編集"
-                      >
-                        <HiPencil className="h-4 w-4" />
-                      </button>
-                      <button
-                        onClick={() => handleDeleteGroup(group.groupName)}
-                        className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-full transition-colors"
-                        title="グループを削除"
-                      >
-                        <HiTrash className="h-4 w-4" />
-                      </button>
-                    </div>
-                  </div>
-
-                  <div className="p-4 flex flex-col gap-4">
-                    {group.workProgresses.map((wp) => (
-                      <WorkProgressCard
-                        key={wp.id}
-                        workProgress={wp}
-                        isInGroup={true}
-                        onEdit={setEditingWorkProgressId}
-                        onStatusChange={handleStatusChange}
-                        onArchive={handleArchiveWorkProgress}
-                        onAddProgress={setAddingProgressWorkProgressId}
-                        onToggleHistory={toggleHistory}
-                        onEditHistory={handleEditHistory}
-                        isHistoryExpanded={expandedHistoryIds.has(wp.id)}
-                        getProgressBarColor={getProgressBarColor}
-                        calculateProgressPercentage={calculateProgressPercentage}
-                        calculateRemaining={calculateRemaining}
-                        formatAmount={formatAmount}
-                        extractUnit={extractUnit}
-                        formatDateTime={formatDateTime}
-                      />
-                    ))}
-
-                  </div>
-
-                  {/* グループ内追加ボタン */}
-                  <div className="px-4 pb-4">
-                    <button
-                      onClick={() => {
-                        setAddingToGroupName(group.groupName);
-                        setShowAddForm(true);
-                      }}
-                      className="w-full py-2 border-2 border-dashed border-gray-200 rounded-lg text-gray-400 hover:text-amber-600 hover:border-amber-300 hover:bg-amber-50 transition-all flex items-center justify-center gap-2 text-sm font-medium"
-                    >
-                      <HiPlus className="h-4 w-4" />
-                      作業を追加
-                    </button>
-                  </div>
-                  </div>
-                ))}
-              </div>
-
-              {/* グループ化されていない作業 */}
-              {groupedWorkProgresses.ungrouped.length > 0 && (
-                <div className="mb-8">
-                  {groupedWorkProgresses.groups.length > 0 && (
-                    <h2 className="text-lg font-bold text-gray-700 mb-4 px-2 border-l-4 border-gray-400">その他の作業</h2>
-                  )}
-                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                    {groupedWorkProgresses.ungrouped.map((wp) => (
-                      <WorkProgressCard
-                        key={wp.id}
-                        workProgress={wp}
-                        isInGroup={false}
-                        onEdit={setEditingWorkProgressId}
-                        onStatusChange={handleStatusChange}
-                        onArchive={handleArchiveWorkProgress}
-                        onAddProgress={setAddingProgressWorkProgressId}
-                        onToggleHistory={toggleHistory}
-                        onEditHistory={handleEditHistory}
-                        isHistoryExpanded={expandedHistoryIds.has(wp.id)}
-                        getProgressBarColor={getProgressBarColor}
-                        calculateProgressPercentage={calculateProgressPercentage}
-                        calculateRemaining={calculateRemaining}
-                        formatAmount={formatAmount}
-                        extractUnit={extractUnit}
-                        formatDateTime={formatDateTime}
-                      />
-                    ))}
-                  </div>
-                </div>
-              )}
-            </>
-          ) : (
-            /* アーカイブ一覧表示 */
-            <div className="space-y-8 animate-fade-in">
-              {archivedWorkProgressesByDate.length === 0 ? (
-                <div className="text-center py-12 bg-white rounded-xl shadow-sm border border-gray-200">
-                  <div className="text-gray-300 mb-4">
-                    <HiArchive className="h-16 w-16 mx-auto" />
-                  </div>
-                  <p className="text-gray-500 font-medium">アーカイブされた作業はありません</p>
-                </div>
-              ) : (
-                archivedWorkProgressesByDate.map((group) => (
-                  <div key={group.date} className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
-                    <div className="bg-gray-50 px-4 py-3 border-b border-gray-200">
-                      <h2 className="font-bold text-gray-800 flex items-center gap-2">
-                        <span className="text-amber-600">{new Date(group.date).toLocaleDateString('ja-JP', { year: 'numeric', month: 'long', day: 'numeric' })}</span>
-                        <span className="text-xs font-normal text-gray-500 bg-white px-2 py-0.5 rounded-full border border-gray-200">
-                          {group.workProgresses.length}件
-                        </span>
-                      </h2>
-                    </div>
-                    <div className="divide-y divide-gray-100">
-                      {group.workProgresses.map((wp) => {
-                        const unit = extractUnit(wp.weight);
-                        return (
-                          <div key={wp.id} className="p-4 hover:bg-gray-50 transition-colors">
-                            <div className="flex justify-between items-start gap-4">
-                              <div className="flex-1">
-                                <div className="flex items-center gap-2 mb-1">
-                                  <h3 className="font-bold text-gray-800">{wp.taskName || '名称未設定'}</h3>
-                                  {wp.groupName && (
-                                    <span className="text-[10px] px-1.5 py-0.5 bg-gray-100 text-gray-600 rounded">
-                                      {wp.groupName}
-                                    </span>
-                                  )}
-                                </div>
-                                <div className="text-sm text-gray-600 mb-2">
-                                  {wp.targetAmount !== undefined ? (
-                                    <span>
-                                      {formatAmount(wp.currentAmount || 0, unit)} / {formatAmount(wp.targetAmount, unit)}{unit}
-                                      <span className="text-gray-400 mx-2">|</span>
-                                      達成率: {calculateProgressPercentage(wp).toFixed(0)}%
-                                    </span>
-                                  ) : (
-                                    <span>完成数: {wp.completedCount || 0}個</span>
-                                  )}
-                                </div>
-                                {wp.memo && (
-                                  <p className="text-xs text-gray-500 bg-gray-50 p-2 rounded border border-gray-100 inline-block max-w-full">
-                                    {wp.memo}
-                                  </p>
-                                )}
-                              </div>
-                              <button
-                                onClick={() => handleUnarchiveWorkProgress(wp.id)}
-                                className="px-3 py-1.5 text-xs font-medium text-amber-600 bg-amber-50 border border-amber-200 rounded hover:bg-amber-100 transition-colors whitespace-nowrap"
-                              >
-                                戻す
-                              </button>
-                            </div>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </div>
-                ))
-              )}
-            </div>
-          )
-        }
+        {viewMode === 'normal' ? (
+          <NormalView
+            showEmptyState={showEmptyState}
+            isEmpty={isEmpty}
+            hasFilters={hasFilters}
+            groupedWorkProgresses={groupedWorkProgresses}
+            archivedCount={archivedWorkProgressesByDate.length}
+            expandedHistoryIds={actions.expandedHistoryIds}
+            onSetShowAddForm={() => setShowAddForm(true)}
+            onSetShowAddGroupForm={() => setShowAddGroupForm(true)}
+            onClearFilters={() => { setFilterTaskName(''); setFilterStatus('all'); }}
+            onEditWorkProgress={setEditingWorkProgressId}
+            onStatusChange={actions.handleStatusChange}
+            onArchive={actions.handleArchiveWorkProgress}
+            onAddProgress={setAddingProgressWorkProgressId}
+            onToggleHistory={actions.toggleHistory}
+            onEditHistory={actions.handleEditHistory}
+            onEditGroupName={setEditingGroupName}
+            onDeleteGroup={actions.handleDeleteGroup}
+            onAddToGroup={(groupName) => { setAddingToGroupName(groupName); setShowAddForm(true); }}
+            onShowArchived={() => setViewMode('archived')}
+          />
+        ) : (
+          <ArchivedView
+            archivedWorkProgressesByDate={archivedWorkProgressesByDate}
+            onUnarchive={actions.handleUnarchiveWorkProgress}
+          />
+        )}
       </main>
 
       {/* Quick Add Modal */}
@@ -698,517 +170,99 @@ export default function ProgressPage() {
         workProgress={activeWorkProgress}
         onAdd={async (amount: number, memo?: string) => {
           if (activeWorkProgress) {
-            await handleAddProgress(activeWorkProgress.id, amount, memo);
+            await actions.handleAddProgress(activeWorkProgress.id, amount, memo);
           }
         }}
         unit={extractUnit(activeWorkProgress?.weight)}
       />
 
       {/* モード選択ダイアログ */}
-      {
-        showModeSelectDialog && (
-          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 animate-fade-in">
-            <div className="bg-white rounded-2xl shadow-xl w-full max-w-sm overflow-hidden animate-scale-in">
-              <div className="p-6 text-center">
-                <h3 className="text-xl font-bold text-gray-800 mb-2">追加する項目を選択</h3>
-                <p className="text-gray-500 text-sm mb-6">
-                  新しい作業を追加するか、作業をまとめるグループを作成するか選択してください。
-                </p>
-                <div className="space-y-3">
-                  <Button
-                    variant="primary"
-                    size="md"
-                    fullWidth
-                    onClick={() => {
-                      setShowModeSelectDialog(false);
-                      setShowAddForm(true);
-                    }}
-                    className="shadow-md !rounded-xl !py-3"
-                  >
-                    <div className="bg-white/20 p-2 rounded-full shadow-sm mr-3">
-                      <HiPlus className="h-5 w-5" />
-                    </div>
-                    <span>作業を追加</span>
-                  </Button>
-                  <Button
-                    variant="secondary"
-                    size="md"
-                    fullWidth
-                    onClick={() => {
-                      setShowModeSelectDialog(false);
-                      setShowAddGroupForm(true);
-                    }}
-                    className="!bg-gray-50 hover:!bg-gray-100 !text-gray-700 !border !border-gray-200 !rounded-xl !py-3"
-                  >
-                    <div className="bg-white p-2 rounded-full shadow-sm mr-3">
-                      <HiOutlineCollection className="h-5 w-5" />
-                    </div>
-                    <span>グループを作成</span>
-                  </Button>
-                </div>
-              </div>
-              <div className="bg-gray-50 px-6 py-4 border-t border-gray-100">
-                <button
-                  onClick={() => setShowModeSelectDialog(false)}
-                  className="w-full py-2 text-gray-600 font-medium hover:text-gray-800 transition-colors"
-                >
-                  キャンセル
-                </button>
-              </div>
-            </div>
-          </div>
-        )
-      }
+      {showModeSelectDialog && (
+        <ModeSelectDialog
+          onClose={() => setShowModeSelectDialog(false)}
+          onAddWork={() => { setShowModeSelectDialog(false); setShowAddForm(true); }}
+          onAddGroup={() => { setShowModeSelectDialog(false); setShowAddGroupForm(true); }}
+        />
+      )}
 
       {/* 作業追加・編集フォーム */}
-      {
-        (showAddForm || editingWorkProgressId) && (
-          <WorkProgressFormDialog
-            isOpen={true}
-            onClose={() => {
-              setShowAddForm(false);
-              setEditingWorkProgressId(null);
-              setAddingToGroupName(null);
-            }}
-            onSubmit={editingWorkProgressId
-              ? (data) => handleUpdateWorkProgress(editingWorkProgressId, data)
-              : handleAddWorkProgress
-            }
-            onDelete={editingWorkProgressId ? () => handleDeleteWorkProgress(editingWorkProgressId) : undefined}
-            initialData={editingWorkProgressId
-              ? data?.workProgresses?.find(wp => wp.id === editingWorkProgressId)
-              : { groupName: addingToGroupName || undefined }
-            }
-            isEditing={!!editingWorkProgressId}
-            defaultGroupName={addingToGroupName}
-          />
-        )
-      }
+      {(showAddForm || editingWorkProgressId) && (
+        <WorkProgressFormDialog
+          isOpen={true}
+          onClose={() => { setShowAddForm(false); setEditingWorkProgressId(null); setAddingToGroupName(null); }}
+          onSubmit={editingWorkProgressId
+            ? (formData) => actions.handleUpdateWorkProgress(editingWorkProgressId, formData)
+            : actions.handleAddWorkProgress
+          }
+          onDelete={editingWorkProgressId ? () => actions.handleDeleteWorkProgress(editingWorkProgressId) : undefined}
+          initialData={editingWorkProgressId
+            ? data?.workProgresses?.find(wp => wp.id === editingWorkProgressId)
+            : { groupName: addingToGroupName || undefined }
+          }
+          isEditing={!!editingWorkProgressId}
+          defaultGroupName={addingToGroupName}
+        />
+      )}
 
       {/* グループ追加フォーム */}
-      {
-        showAddGroupForm && (
-          <GroupFormDialog
-            isOpen={true}
-            onClose={() => setShowAddGroupForm(false)}
-            onSubmit={(groupName) => {
-              // ダミー作業を作成してグループを作る
-              handleAddWorkProgress({
-                groupName,
-                taskName: '',
-                status: 'pending',
-              });
-              setShowAddGroupForm(false);
-            }}
-          />
-        )
-      }
+      {showAddGroupForm && (
+        <GroupFormDialog
+          isOpen={true}
+          onClose={() => setShowAddGroupForm(false)}
+          onSubmit={(groupName) => {
+            actions.handleAddWorkProgress({ groupName, taskName: '', status: 'pending' });
+            setShowAddGroupForm(false);
+          }}
+        />
+      )}
 
       {/* グループ名編集フォーム */}
-      {
-        editingGroupName && (
-          <GroupFormDialog
-            isOpen={true}
-            onClose={() => setEditingGroupName(null)}
-            onSubmit={(newGroupName) => handleUpdateGroup(editingGroupName, { groupName: newGroupName })}
-            initialGroupName={editingGroupName}
-            isEditing={true}
-          />
-        )
-      }
+      {editingGroupName && (
+        <GroupFormDialog
+          isOpen={true}
+          onClose={() => setEditingGroupName(null)}
+          onSubmit={(newGroupName) => actions.handleUpdateGroup(editingGroupName, { groupName: newGroupName })}
+          initialGroupName={editingGroupName}
+          isEditing={true}
+        />
+      )}
 
       {/* フィルタダイアログ */}
-      {
-        showFilterDialog && (
-          <FilterDialog
-            isOpen={true}
-            onClose={() => setShowFilterDialog(false)}
-            filterTaskName={filterTaskName}
-            setFilterTaskName={setFilterTaskName}
-            filterStatus={filterStatus}
-            setFilterStatus={setFilterStatus}
-            sortOption={sortOption}
-            setSortOption={setSortOption}
-          />
-        )
-      }
+      {showFilterDialog && (
+        <FilterDialog
+          isOpen={true}
+          onClose={() => setShowFilterDialog(false)}
+          filterTaskName={filterTaskName}
+          setFilterTaskName={setFilterTaskName}
+          filterStatus={filterStatus}
+          setFilterStatus={setFilterStatus}
+          sortOption={sortOption}
+          setSortOption={setSortOption}
+        />
+      )}
 
       {/* 履歴編集ダイアログ */}
-      {editingHistoryWorkProgressId && editingHistoryEntryId && (() => {
-        const workProgress = data?.workProgresses?.find((wp) => wp.id === editingHistoryWorkProgressId);
-        const entry = workProgress?.progressHistory?.find((e) => e.id === editingHistoryEntryId);
+      {actions.editingHistoryWorkProgressId && actions.editingHistoryEntryId && (() => {
+        const workProgress = data?.workProgresses?.find((wp) => wp.id === actions.editingHistoryWorkProgressId);
+        const entry = workProgress?.progressHistory?.find((e) => e.id === actions.editingHistoryEntryId);
         if (!workProgress || !entry) return null;
-        
+
         return (
           <ProgressHistoryEditDialog
             isOpen={true}
-            onClose={() => {
-              setEditingHistoryWorkProgressId(null);
-              setEditingHistoryEntryId(null);
-            }}
+            onClose={actions.clearEditingHistory}
             entry={entry}
             unit={extractUnit(workProgress.weight)}
             isCountMode={workProgress.targetAmount === undefined}
             onUpdate={async (amount: number, memo?: string) => {
-              await handleUpdateProgressHistory(editingHistoryWorkProgressId, editingHistoryEntryId!, amount, memo);
+              await actions.handleUpdateProgressHistory(actions.editingHistoryWorkProgressId!, actions.editingHistoryEntryId!, amount, memo);
             }}
             onDelete={async () => {
-              await handleDeleteProgressHistory(editingHistoryWorkProgressId, editingHistoryEntryId!);
+              await actions.handleDeleteProgressHistory(actions.editingHistoryWorkProgressId!, actions.editingHistoryEntryId!);
             }}
           />
         );
       })()}
-    </div >
-  );
-}
-
-// --- Sub Components (Dialogs) ---
-
-// 作業追加・編集フォームコンポーネント
-function WorkProgressFormDialog({
-  isOpen, onClose, onSubmit, onDelete, initialData, isEditing, defaultGroupName
-}: {
-  isOpen: boolean;
-  onClose: () => void;
-  onSubmit: (data: WorkProgressInput) => Promise<void>;
-  onDelete?: () => void;
-  initialData?: WorkProgressInput;
-  isEditing: boolean;
-  defaultGroupName?: string | null;
-}) {
-  // 既存データから数字と単位を分離
-  const initialWeight = initialData?.weight || '';
-  const initialAmount = initialWeight ? extractTargetAmount(initialWeight) : undefined;
-  const initialUnit = initialWeight ? extractUnitFromWeight(initialWeight) : '';
-  // 単位が6つ（kg, g, 個, 枚, 袋, 箱）に該当しない場合は空欄にする
-  const validUnits = ['kg', 'g', '個', '枚', '袋', '箱'];
-  const initialUnitValid = validUnits.includes(initialUnit) ? initialUnit : '';
-
-  const [formData, setFormData] = useState({
-    groupName: defaultGroupName || initialData?.groupName || '',
-    taskName: initialData?.taskName || '',
-    targetAmount: initialAmount !== undefined ? initialAmount.toString() : '',
-    targetUnit: initialUnitValid,
-    memo: initialData?.memo || '',
-    status: initialData?.status || 'pending',
-  });
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
-  if (!isOpen) return null;
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setIsSubmitting(true);
-    try {
-      // targetAmountとtargetUnitを結合してweightフィールドを作成
-      let weight = '';
-      if (formData.targetAmount.trim()) {
-        const amount = formData.targetAmount.trim();
-        const unit = formData.targetUnit.trim();
-        weight = unit ? `${amount}${unit}` : amount;
-      }
-      
-      const payload: WorkProgressInput = {
-        groupName: formData.groupName || undefined,
-        taskName: formData.taskName,
-        memo: formData.memo || undefined,
-        status: formData.status,
-        weight: weight || undefined,
-      };
-      await onSubmit(payload);
-      onClose();
-    } catch (error) {
-      console.error(error);
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 animate-fade-in">
-      <div className="bg-white rounded-2xl shadow-xl w-full max-w-md overflow-hidden flex flex-col max-h-[90vh] animate-scale-in">
-        <div className="px-6 py-4 border-b border-gray-100 flex justify-between items-center bg-gray-50">
-          <h3 className="font-bold text-gray-800 text-lg">
-            {isEditing ? '作業を編集' : '新しい作業を追加'}
-          </h3>
-          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 p-1 rounded-full hover:bg-gray-200 transition-colors">
-            <HiX className="h-6 w-6" />
-          </button>
-        </div>
-
-        <form onSubmit={handleSubmit} className="p-6 overflow-y-auto flex-1">
-          <div className="space-y-5">
-            <div>
-              <label className="block text-sm font-bold text-gray-700 mb-1.5">グループ名 (任意)</label>
-              <input
-                type="text"
-                value={formData.groupName}
-                onChange={(e) => setFormData({ ...formData, groupName: e.target.value })}
-                className="w-full px-4 py-2.5 rounded-lg border border-gray-300 focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all text-gray-900 bg-white"
-                placeholder="例: ブラジル No.2"
-              />
-            </div>
-
-            <div>
-              <label className="block text-sm font-bold text-gray-700 mb-1.5">作業名</label>
-              <input
-                type="text"
-                value={formData.taskName}
-                onChange={(e) => setFormData({ ...formData, taskName: e.target.value })}
-                className="w-full px-4 py-2.5 rounded-lg border border-gray-300 focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all text-gray-900 bg-white"
-                placeholder="例: ハンドピック"
-                required
-              />
-            </div>
-
-            <div>
-              <label className="block text-sm font-bold text-gray-700 mb-1.5">目標量 (任意)</label>
-              <div className="flex gap-2">
-                <input
-                  type="number"
-                  value={formData.targetAmount}
-                  onChange={(e) => setFormData({ ...formData, targetAmount: e.target.value })}
-                  className="flex-1 px-4 py-2.5 rounded-lg border border-gray-300 focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all text-gray-900 bg-white"
-                  placeholder="数値"
-                  step="0.1"
-                  min="0"
-                />
-                <select
-                  value={formData.targetUnit}
-                  onChange={(e) => setFormData({ ...formData, targetUnit: e.target.value })}
-                  className="px-4 py-2.5 rounded-lg border border-gray-300 focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all text-gray-900 bg-white"
-                >
-                  <option value="">単位なし</option>
-                  <option value="kg">kg</option>
-                  <option value="g">g</option>
-                  <option value="個">個</option>
-                  <option value="枚">枚</option>
-                  <option value="袋">袋</option>
-                  <option value="箱">箱</option>
-                </select>
-              </div>
-              <p className="text-xs text-gray-500 mt-1.5">
-                ※ 数値と単位を入力すると進捗バーが表示されます（例: 10kg）。<br />
-                ※ 空欄の場合は完成数のみをカウントするモードになります。
-              </p>
-            </div>
-
-            <div>
-              <label className="block text-sm font-bold text-gray-700 mb-1.5">メモ (任意)</label>
-              <textarea
-                value={formData.memo}
-                onChange={(e) => setFormData({ ...formData, memo: e.target.value })}
-                className="w-full px-4 py-2.5 rounded-lg border border-gray-300 focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all resize-none text-gray-900 bg-white"
-                rows={3}
-                placeholder="備考があれば入力してください"
-              />
-            </div>
-
-            {isEditing && (
-              <div>
-                <label className="block text-sm font-bold text-gray-700 mb-1.5">状態</label>
-                <select
-                  value={formData.status}
-                  onChange={(e) => setFormData({ ...formData, status: e.target.value as WorkProgressStatus })}
-                  className="w-full px-4 py-2.5 rounded-lg border border-gray-300 focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all text-gray-900 bg-white"
-                >
-                  <option value="pending">作業前</option>
-                  <option value="in_progress">作業中</option>
-                  <option value="completed">完了</option>
-                </select>
-              </div>
-            )}
-          </div>
-
-          <div className="mt-8 flex gap-3">
-            {isEditing && onDelete && (
-              <Button
-                type="button"
-                variant="danger"
-                size="md"
-                onClick={onDelete}
-                className="!bg-red-50 !text-red-600 hover:!bg-red-100 !rounded-xl"
-                title="削除"
-              >
-                <HiTrash className="h-5 w-5" />
-              </Button>
-            )}
-            <Button
-              type="submit"
-              variant="primary"
-              size="md"
-              disabled={isSubmitting}
-              loading={isSubmitting}
-              className="flex-1 shadow-md hover:shadow-lg !rounded-xl"
-            >
-              {isSubmitting ? '保存中...' : (isEditing ? '更新する' : '追加する')}
-            </Button>
-          </div>
-        </form>
-      </div>
-    </div>
-  );
-}
-
-// グループ追加・編集フォーム
-function GroupFormDialog({
-  isOpen, onClose, onSubmit, initialGroupName, isEditing
-}: {
-  isOpen: boolean;
-  onClose: () => void;
-  onSubmit: (name: string) => void;
-  initialGroupName?: string;
-  isEditing?: boolean;
-}) {
-  const [groupName, setGroupName] = useState(initialGroupName || '');
-
-  if (!isOpen) return null;
-
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 animate-fade-in">
-      <div className="bg-white rounded-2xl shadow-xl w-full max-w-sm overflow-hidden animate-scale-in">
-        <div className="px-6 py-4 border-b border-gray-100 bg-gray-50">
-          <h3 className="font-bold text-gray-800 text-lg">
-            {isEditing ? 'グループ名を編集' : '新しいグループを作成'}
-          </h3>
-        </div>
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            if (groupName.trim()) onSubmit(groupName);
-          }}
-          className="p-6"
-        >
-          <div className="mb-6">
-            <label className="block text-sm font-bold text-gray-700 mb-1.5">グループ名</label>
-            <input
-              type="text"
-              value={groupName}
-              onChange={(e) => setGroupName(e.target.value)}
-              className="w-full px-4 py-2.5 rounded-lg border border-gray-300 focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all text-gray-900 bg-white"
-              placeholder="例: ブラジル No.2"
-              autoFocus
-              required
-            />
-          </div>
-          <div className="flex gap-3">
-            <Button
-              type="button"
-              variant="secondary"
-              size="md"
-              onClick={onClose}
-              className="flex-1 !rounded-xl"
-            >
-              キャンセル
-            </Button>
-            <Button
-              type="submit"
-              variant="primary"
-              size="md"
-              disabled={!groupName.trim()}
-              className="flex-1 shadow-md !rounded-xl"
-            >
-              {isEditing ? '更新' : '作成'}
-            </Button>
-          </div>
-        </form>
-      </div>
-    </div>
-  );
-}
-
-// フィルタダイアログ
-function FilterDialog({
-  isOpen, onClose, filterTaskName, setFilterTaskName, filterStatus, setFilterStatus, sortOption, setSortOption
-}: {
-  isOpen: boolean;
-  onClose: () => void;
-  filterTaskName: string;
-  setFilterTaskName: (val: string) => void;
-  filterStatus: WorkProgressStatus | 'all';
-  setFilterStatus: (val: WorkProgressStatus | 'all') => void;
-  sortOption: SortOption;
-  setSortOption: (val: SortOption) => void;
-}) {
-  if (!isOpen) return null;
-
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 animate-fade-in">
-      <div className="bg-white rounded-2xl shadow-xl w-full max-w-sm overflow-hidden animate-scale-in">
-        <div className="px-6 py-4 border-b border-gray-100 flex justify-between items-center bg-gray-50">
-          <h3 className="font-bold text-gray-800 text-lg">表示設定</h3>
-          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 p-1 rounded-full hover:bg-gray-200 transition-colors">
-            <HiX className="h-6 w-6" />
-          </button>
-        </div>
-
-        <div className="p-6 space-y-6">
-          {/* 検索 */}
-          <div>
-            <label className="block text-sm font-bold text-gray-700 mb-2">キーワード検索</label>
-            <div className="relative">
-              <HiSearch className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 h-5 w-5" />
-              <input
-                type="text"
-                value={filterTaskName}
-                onChange={(e) => setFilterTaskName(e.target.value)}
-                className="w-full pl-10 pr-4 py-2.5 rounded-lg border border-gray-300 focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all text-gray-900 bg-white"
-                placeholder="作業名で検索..."
-              />
-            </div>
-          </div>
-
-          {/* ステータスフィルタ */}
-          <div>
-            <label className="block text-sm font-bold text-gray-700 mb-2">ステータス</label>
-            <div className="flex flex-wrap gap-2">
-              {[
-                { value: 'all', label: 'すべて' },
-                { value: 'pending', label: '作業前' },
-                { value: 'in_progress', label: '作業中' },
-                { value: 'completed', label: '完了' },
-              ].map((option) => (
-                <button
-                  key={option.value}
-                  onClick={() => setFilterStatus(option.value as WorkProgressStatus | 'all')}
-                  className={`px-3 py-1.5 text-sm font-medium rounded-lg border transition-all ${filterStatus === option.value
-                    ? 'bg-amber-50 text-amber-700 border-amber-300 ring-1 ring-amber-300'
-                    : 'bg-white text-gray-600 border-gray-200 hover:bg-gray-50'
-                    }`}
-                >
-                  {option.label}
-                </button>
-              ))}
-            </div>
-          </div>
-
-          {/* 並び替え */}
-          <div>
-            <label className="block text-sm font-bold text-gray-700 mb-2">並び替え</label>
-            <select
-              value={sortOption}
-              onChange={(e) => setSortOption(e.target.value as SortOption)}
-              className="w-full px-4 py-2.5 rounded-lg border border-gray-300 focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all text-gray-900 bg-white"
-            >
-              <option value="createdAt">作成日順</option>
-              <option value="beanName">名前順</option>
-              <option value="status">ステータス順</option>
-            </select>
-          </div>
-        </div>
-
-        <div className="bg-gray-50 px-6 py-4 border-t border-gray-100">
-          <Button
-            variant="primary"
-            size="md"
-            fullWidth
-            onClick={onClose}
-            className="shadow-md !rounded-xl"
-          >
-            完了
-          </Button>
-        </div>
-      </div>
     </div>
   );
 }

--- a/app/progress/utils.ts
+++ b/app/progress/utils.ts
@@ -1,0 +1,44 @@
+import type { WorkProgress } from '@/types';
+
+export const getProgressBarColor = (percentage: number) => {
+  if (percentage >= 100) return 'bg-green-500';
+  if (percentage >= 50) return 'bg-amber-500';
+  return 'bg-gray-400';
+};
+
+export const calculateProgressPercentage = (wp: WorkProgress) => {
+  if (wp.targetAmount !== undefined && wp.targetAmount > 0) {
+    return ((wp.currentAmount || 0) / wp.targetAmount) * 100;
+  }
+  return 0;
+};
+
+export const calculateRemaining = (wp: WorkProgress) => {
+  if (wp.targetAmount !== undefined) {
+    return Math.max(0, wp.targetAmount - (wp.currentAmount || 0));
+  }
+  return 0;
+};
+
+export const formatAmount = (amount: number, unit: string) => {
+  void unit;
+  return amount.toLocaleString('ja-JP');
+};
+
+export const extractUnit = (weight: string | undefined) => {
+  if (!weight) return '';
+  const match = weight.match(/[^\d.,\s]+/);
+  return match ? match[0] : '';
+};
+
+export const formatDateTime = (dateString?: string) => {
+  if (!dateString) return '';
+  const d = new Date(dateString);
+  return d.toLocaleString('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};

--- a/components/TodaySchedule.tsx
+++ b/components/TodaySchedule.tsx
@@ -1,19 +1,22 @@
 'use client';
 
-import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { createPortal } from 'react-dom';
-import type { AppData, TodaySchedule, TimeLabel } from '@/types';
-import { HiPlus, HiX, HiClock, HiUser, HiArrowDown } from 'react-icons/hi';
+import type { AppData, TodaySchedule as TodayScheduleType, TimeLabel } from '@/types';
+import { HiClock, HiUser, HiArrowDown } from 'react-icons/hi';
+import { useTodayScheduleSync } from '@/hooks/useTodayScheduleSync';
+import { TimeInputRow } from '@/components/today-schedule/TimeInputRow';
+import { TimeEditDialog } from '@/components/today-schedule/TimeEditDialog';
 
 interface TodayScheduleProps {
   data: AppData | null;
   onUpdate: (data: AppData) => void;
-  selectedDate: string; // YYYY-MM-DD形式
-  isToday: boolean; // 選択日が今日かどうか
+  selectedDate: string;
+  isToday: boolean;
 }
 
 interface TodayScheduleInnerProps extends TodayScheduleProps {
-  currentSchedule: TodaySchedule;
+  currentSchedule: TodayScheduleType;
 }
 
 export function TodaySchedule(props: TodayScheduleProps) {
@@ -33,366 +36,50 @@ export function TodaySchedule(props: TodayScheduleProps) {
 }
 
 function TodayScheduleInner({ data, onUpdate, selectedDate, currentSchedule }: TodayScheduleInnerProps) {
-  const [isComposing, setIsComposing] = useState(false);
   const [editingLabelId, setEditingLabelId] = useState<string | null>(null);
-  const [addError, setAddError] = useState<string>('');
-  const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
-  const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const errorTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const isUpdatingRef = useRef(false);
-  const dataRef = useRef<AppData | null>(data);
-  const todayScheduleIdRef = useRef<string>('');
-  const originalTimeLabelsRef = useRef<TimeLabel[]>([]);
-  const onUpdateRef = useRef(onUpdate);
-  // 最新の参照を保持
-  useEffect(() => {
-    dataRef.current = data;
-    onUpdateRef.current = onUpdate;
-  }, [data, onUpdate]);
 
-  const lastDataRef = useRef<string>('');
-  const lastSelectedDateRef = useRef<string>(selectedDate);
-  const localTimeLabelsRef = useRef<TimeLabel[]>(currentSchedule.timeLabels || []);
-
-  // 初期値をdataから取得
-  const [localTimeLabels, setLocalTimeLabels] = useState<TimeLabel[]>(currentSchedule.timeLabels || []);
-  const [newHour, setNewHour] = useState<string>('');
-  const [newMinute, setNewMinute] = useState<string>('');
-
-  const clearAddError = useCallback(() => {
-    if (addError) {
-      if (errorTimeoutRef.current) {
-        clearTimeout(errorTimeoutRef.current);
-        errorTimeoutRef.current = null;
-      }
-      setAddError('');
-    }
-  }, [addError]);
-
-  const handleHourInputChange = useCallback(
-    (value: string) => {
-      const hour = parseInt(value, 10);
-      if (value === '' || (!Number.isNaN(hour) && hour >= 0 && hour <= 23)) {
-        setNewHour(value);
-        clearAddError();
-      }
-    },
-    [clearAddError]
-  );
-
-  const handleMinuteInputChange = useCallback((value: string) => {
-    const minute = parseInt(value, 10);
-    if (value === '' || (!Number.isNaN(minute) && minute >= 0 && minute <= 59)) {
-      setNewMinute(value);
-    }
-  }, []);
-
-  useEffect(() => {
-    lastSelectedDateRef.current = selectedDate;
-  }, [selectedDate]);
-
-  useEffect(() => {
-    const initialLabels = currentSchedule.timeLabels || [];
-    originalTimeLabelsRef.current = JSON.parse(JSON.stringify(initialLabels));
-    localTimeLabelsRef.current = JSON.parse(JSON.stringify(initialLabels));
-    todayScheduleIdRef.current = currentSchedule.id;
-    lastDataRef.current = JSON.stringify(initialLabels);
-  }, [currentSchedule]);
-
-  // デバウンス保存関数
-  const debouncedSave = useCallback(
-    (newTimeLabels: TimeLabel[], targetDate: string) => {
-      if (isComposing) {
-        return; // IME変換中は保存しない
-      }
-
-      // 選択日が変わった場合は保存しない（古い日付のデータを保存しないようにする）
-      if (targetDate !== selectedDate) {
-        return;
-      }
-
-      // 既存のタイマーをクリア
-      if (debounceTimerRef.current) {
-        clearTimeout(debounceTimerRef.current);
-        debounceTimerRef.current = null;
-      }
-
-      // 新しいタイマーを設定（500ms後に保存）
-      debounceTimerRef.current = setTimeout(() => {
-        // 再度選択日をチェック（タイマー実行時にも選択日が変わっていないか確認）
-        if (targetDate !== selectedDate) {
-          return;
-        }
-
-        const currentData = dataRef.current;
-        if (!currentData) return;
-
-        // 保存する値がoriginalTimeLabelsRefと同じ場合は保存しない（無限ループ防止）
-        const newTimeLabelsStr = JSON.stringify(newTimeLabels);
-        const originalStr = JSON.stringify(originalTimeLabelsRef.current);
-        if (originalStr === newTimeLabelsStr) {
-          return;
-        }
-
-        isUpdatingRef.current = true;
-        const updatedSchedules = [...(currentData.todaySchedules || [])];
-        const existingIndex = updatedSchedules.findIndex((s) => s.date === targetDate);
-
-        const updatedSchedule: TodaySchedule = {
-          id: todayScheduleIdRef.current || `schedule-${targetDate}`,
-          date: targetDate,
-          timeLabels: newTimeLabels,
-        };
-
-        if (existingIndex >= 0) {
-          updatedSchedules[existingIndex] = updatedSchedule;
-        } else {
-          updatedSchedules.push(updatedSchedule);
-        }
-
-        const updatedData: AppData = {
-          ...currentData,
-          todaySchedules: updatedSchedules,
-        };
-
-        // originalTimeLabelsRefを更新
-        originalTimeLabelsRef.current = JSON.parse(JSON.stringify(newTimeLabels));
-        localTimeLabelsRef.current = JSON.parse(JSON.stringify(newTimeLabels));
-        todayScheduleIdRef.current = updatedSchedule.id;
-        lastDataRef.current = newTimeLabelsStr;
-
-        onUpdateRef.current(updatedData);
-
-        // 更新フラグをリセット（FirestoreのonSnapshotが発火する前に）
-        // useAppData.tsとタイミングを整合させるため100msに設定
-        setTimeout(() => {
-          isUpdatingRef.current = false;
-        }, 100);
-      }, 500);
-    },
-    [selectedDate, isComposing]
-  );
-
-  // ローカル状態が変更されたらデバウンス保存
-  useEffect(() => {
-    if (isUpdatingRef.current) {
-      return; // 更新中は保存しない
-    }
-
-    // 選択日が変わった場合は保存しない
-    if (lastSelectedDateRef.current !== selectedDate) {
-      return;
-    }
-
-    // localTimeLabelsRefを更新
-    localTimeLabelsRef.current = JSON.parse(JSON.stringify(localTimeLabels));
-
-    const originalTimeLabels = originalTimeLabelsRef.current;
-
-    // 長さが異なる場合
-    if (localTimeLabels.length !== originalTimeLabels.length) {
-      debouncedSave(localTimeLabels, selectedDate);
-      return;
-    }
-
-    // 内容が変更されているかチェック
-    const hasChanges = localTimeLabels.some((label, index) => {
-      const original = originalTimeLabels[index];
-      return (
-        !original ||
-        label.id !== original.id ||
-        label.time !== original.time ||
-        label.content !== original.content ||
-        label.memo !== original.memo
-      );
-    });
-
-    if (hasChanges) {
-      debouncedSave(localTimeLabels, selectedDate);
-    }
-  }, [localTimeLabels, debouncedSave, selectedDate]);
-
-  // クリーンアップ（アンマウント時に未保存の変更を保存）
-  useEffect(() => {
-    return () => {
-      // 未保存の変更がある場合は保存
-      if (debounceTimerRef.current) {
-        clearTimeout(debounceTimerRef.current);
-        debounceTimerRef.current = null;
-      }
-
-      // 未保存の変更を即座に保存（変更がある場合のみ）
-      if (!isUpdatingRef.current) {
-        const currentTimeLabels = localTimeLabelsRef.current;
-        const originalTimeLabels = originalTimeLabelsRef.current;
-        const currentSelectedDate = lastSelectedDateRef.current;
-
-        // 選択日が変わっている場合は保存しない
-        if (currentSelectedDate !== selectedDate) {
-          return;
-        }
-
-        const hasChanges = currentTimeLabels.length !== originalTimeLabels.length ||
-          currentTimeLabels.some((label, index) => {
-            const original = originalTimeLabels[index];
-            return (
-              !original ||
-              label.id !== original.id ||
-              label.time !== original.time ||
-              label.content !== original.content ||
-              label.memo !== original.memo
-            );
-          });
-
-        if (hasChanges) {
-          const currentData = dataRef.current;
-          if (currentData) {
-            const updatedSchedules = [...(currentData.todaySchedules || [])];
-            const existingIndex = updatedSchedules.findIndex((s) => s.date === currentSelectedDate);
-
-            const updatedSchedule: TodaySchedule = {
-              id: todayScheduleIdRef.current || `schedule-${currentSelectedDate}`,
-              date: currentSelectedDate,
-              timeLabels: currentTimeLabels,
-            };
-
-            if (existingIndex >= 0) {
-              updatedSchedules[existingIndex] = updatedSchedule;
-            } else {
-              updatedSchedules.push(updatedSchedule);
-            }
-
-            const updatedData: AppData = {
-              ...currentData,
-              todaySchedules: updatedSchedules,
-            };
-
-            onUpdateRef.current(updatedData);
-          }
-        }
-      }
-
-      if (saveTimeoutRef.current) {
-        clearTimeout(saveTimeoutRef.current);
-      }
-
-      if (errorTimeoutRef.current) {
-        clearTimeout(errorTimeoutRef.current);
-      }
-    };
-  }, [selectedDate]);
-
-  const addTimeLabel = () => {
-    if (!newHour) {
-      setAddError('数字を入力してください');
-
-      // 既存のタイマーをクリア
-      if (errorTimeoutRef.current) {
-        clearTimeout(errorTimeoutRef.current);
-      }
-
-      // 3秒後にエラーを自動的にクリア
-      errorTimeoutRef.current = setTimeout(() => {
-        setAddError('');
-        errorTimeoutRef.current = null;
-      }, 3000);
-
-      return;
-    }
-
-    // エラーをクリア（タイマーもクリア）
-    if (errorTimeoutRef.current) {
-      clearTimeout(errorTimeoutRef.current);
-      errorTimeoutRef.current = null;
-    }
-    setAddError('');
-
-    const hour = newHour.padStart(2, '0');
-    const minute = newMinute ? newMinute.padStart(2, '0') : '00'; // 分が未入力の場合は00
-    const time = `${hour}:${minute}`;
-
-    const newLabel: TimeLabel = {
-      id: `time-${Date.now()}`,
-      time: time,
-      content: '',
-      memo: '',
-      order: localTimeLabels.length,
-    };
-    setLocalTimeLabels([...localTimeLabels, newLabel]);
-    setNewHour(''); // 入力欄をクリア
-    setNewMinute(''); // 入力欄をクリア
-  };
-
-  const handleEditCancel = () => {
-    setEditingLabelId(null);
-  };
-
-  const updateTimeLabel = (id: string, updates: Partial<TimeLabel>) => {
-    setLocalTimeLabels(
-      localTimeLabels.map((label) => (label.id === id ? { ...label, ...updates } : label))
-    );
-  };
-
-
-  const handleCompositionStart = () => {
-    setIsComposing(true);
-  };
-
-  const handleCompositionEnd = () => {
-    setIsComposing(false);
-    // IME変換終了後、少し遅延してから保存
-    if (saveTimeoutRef.current) {
-      clearTimeout(saveTimeoutRef.current);
-    }
-    saveTimeoutRef.current = setTimeout(() => {
-      debouncedSave(localTimeLabels, selectedDate);
-    }, 300);
-  };
+  const {
+    localTimeLabels,
+    setLocalTimeLabels,
+    newHour,
+    newMinute,
+    addError,
+    handleHourInputChange,
+    handleMinuteInputChange,
+    handleCompositionStart,
+    handleCompositionEnd,
+    addTimeLabel,
+    updateTimeLabel,
+  } = useTodayScheduleSync({ data, onUpdate, selectedDate, currentSchedule });
 
   // 時間順にソートしてグループ化
   const groupedTimeLabels = useMemo(() => {
     const groups: { time: string; labels: TimeLabel[] }[] = [];
+    const sorted = [...localTimeLabels].sort((a, b) => (a.time || '00:00').localeCompare(b.time || '00:00'));
 
-    // まず時間順にソート
-    const sorted = [...localTimeLabels].sort((a, b) => {
-      const timeA = a.time || '00:00';
-      const timeB = b.time || '00:00';
-      return timeA.localeCompare(timeB);
-    });
-
-    // グループ化
     sorted.forEach((label) => {
       const lastGroup = groups[groups.length - 1];
       if (lastGroup && lastGroup.time === label.time) {
         lastGroup.labels.push(label);
       } else {
-        groups.push({
-          time: label.time,
-          labels: [label],
-        });
+        groups.push({ time: label.time, labels: [label] });
       }
     });
 
     return groups;
   }, [localTimeLabels]);
 
-  // グループ単位での編集・削除用
   const handleEditGroup = (time: string) => {
-    // その時間の最初のラベルのIDを使って編集ダイアログを開く（保存時にtimeを使って一括更新する）
     const label = localTimeLabels.find(l => l.time === time);
-    if (label) {
-      setEditingLabelId(label.id); // IDはダイアログ表示のトリガーとしてのみ使用
-    }
+    if (label) setEditingLabelId(label.id);
   };
 
-  const handleEditGroupSave = (oldTime: string, newHour: string, newMinute: string) => {
-    if (!newHour) return;
-
-    const formattedHour = newHour.padStart(2, '0');
-    const formattedMinute = newMinute ? newMinute.padStart(2, '0') : '00';
+  const handleEditGroupSave = (oldTime: string, newHourVal: string, newMinuteVal: string) => {
+    if (!newHourVal) return;
+    const formattedHour = newHourVal.padStart(2, '0');
+    const formattedMinute = newMinuteVal ? newMinuteVal.padStart(2, '0') : '00';
     const newTime = `${formattedHour}:${formattedMinute}`;
 
-    // 同じ時間のラベルを全て更新
     setLocalTimeLabels(
       localTimeLabels.map((label) =>
         label.time === oldTime ? { ...label, time: newTime } : label
@@ -458,7 +145,7 @@ function TodayScheduleInner({ data, onUpdate, selectedDate, currentSchedule }: T
                 key={group.time}
                 className="group flex items-baseline gap-3 md:gap-4 py-2.5 md:py-2 px-3 md:px-2.5 rounded-lg bg-gray-50 hover:bg-amber-50 border border-gray-200 hover:border-amber-300 transition-all duration-200"
               >
-                {/* 時間表示（グループ共通） */}
+                {/* 時間表示 */}
                 <div
                   onClick={() => handleEditGroup(group.time)}
                   className="flex-shrink-0 w-16 md:w-18 text-center px-2 py-1 bg-white rounded-md text-sm md:text-base font-semibold text-gray-800 group-hover:text-amber-700 group-hover:bg-amber-100 cursor-pointer transition-colors tabular-nums shadow-sm"
@@ -470,7 +157,6 @@ function TodayScheduleInner({ data, onUpdate, selectedDate, currentSchedule }: T
                 <div className="flex-1 min-w-0 flex flex-col gap-2">
                   {group.labels.map((label) => (
                     <div key={label.id} className={`w-full ${label.continuesUntil ? 'border-l-2 border-dashed border-amber-400 pl-3' : ''}`}>
-                      {/* メインコンテンツ行 */}
                       <div className="flex items-center gap-2 min-w-0">
                         <input
                           type="text"
@@ -481,15 +167,13 @@ function TodayScheduleInner({ data, onUpdate, selectedDate, currentSchedule }: T
                           className="flex-1 min-w-0 bg-transparent border-0 border-b border-transparent focus:border-amber-400 text-base md:text-base text-gray-900 focus:outline-none placeholder:text-gray-400 transition-colors py-1"
                           placeholder="内容を入力"
                         />
-                        {/* 時間経過終了時間の表示 */}
                         {label.continuesUntil && (
                           <span className="text-xs text-amber-600 bg-amber-50 px-2 py-0.5 rounded-full whitespace-nowrap">
                             〜{label.continuesUntil}まで
                           </span>
                         )}
                       </div>
-                      
-                      {/* 担当者表示 */}
+
                       {label.assignee && (
                         <div className="flex items-center gap-1.5 mt-1 ml-1">
                           <HiUser className="h-3.5 w-3.5 text-gray-400 flex-shrink-0" />
@@ -498,8 +182,7 @@ function TodayScheduleInner({ data, onUpdate, selectedDate, currentSchedule }: T
                           </span>
                         </div>
                       )}
-                      
-                      {/* サブタスク表示 */}
+
                       {label.subTasks && label.subTasks.length > 0 && (
                         <div className="mt-2 ml-4 space-y-1.5">
                           {label.subTasks
@@ -540,7 +223,7 @@ function TodayScheduleInner({ data, onUpdate, selectedDate, currentSchedule }: T
         </div>
       )}
 
-      {/* モバイル版：時間入力欄をスケジュールの下に表示 */}
+      {/* モバイル版：空状態用の時間入力 */}
       {localTimeLabels.length === 0 && (
         <TimeInputRow
           newHour={newHour}
@@ -555,7 +238,6 @@ function TodayScheduleInner({ data, onUpdate, selectedDate, currentSchedule }: T
         />
       )}
 
-
       {/* 時間編集ダイアログ */}
       {editingLabelId && typeof window !== 'undefined' && (() => {
         const editingLabel = localTimeLabels.find((label) => label.id === editingLabelId);
@@ -568,8 +250,8 @@ function TodayScheduleInner({ data, onUpdate, selectedDate, currentSchedule }: T
         };
 
         const initialTime = parseTime(editingLabel.time);
-
         const labelsForTime = localTimeLabels.filter((label) => label.time === editingLabel.time);
+
         return createPortal(
           <TimeEditDialog
             key={editingLabel.id}
@@ -578,7 +260,7 @@ function TodayScheduleInner({ data, onUpdate, selectedDate, currentSchedule }: T
             onSave={(hour, minute) => handleEditGroupSave(editingLabel.time, hour, minute)}
             labels={labelsForTime}
             onDeleteLabel={handleDeleteLabel}
-            onCancel={handleEditCancel}
+            onCancel={() => setEditingLabelId(null)}
           />,
           document.body
         );
@@ -586,201 +268,3 @@ function TodayScheduleInner({ data, onUpdate, selectedDate, currentSchedule }: T
     </div>
   );
 }
-
-type TimeInputRowProps = {
-  newHour: string;
-  newMinute: string;
-  addError: string;
-  onHourChange: (value: string) => void;
-  onMinuteChange: (value: string) => void;
-  onAdd: () => void;
-  wrapperClassName: string;
-  buttonClassName: string;
-  labelClassName?: string;
-};
-
-function TimeInputRow({
-  newHour,
-  newMinute,
-  addError,
-  onHourChange,
-  onMinuteChange,
-  onAdd,
-  wrapperClassName,
-  buttonClassName,
-  labelClassName,
-}: TimeInputRowProps) {
-  const hourInputClass = `w-12 md:w-14 rounded-md border px-1.5 md:px-2 py-1 md:py-1.5 text-base md:text-base text-gray-900 text-center focus:outline-none focus:ring-2 transition-all duration-300 ease-in-out [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${
-    addError ? 'border-red-500 focus:border-red-500 focus:ring-red-500' : 'border-gray-300 focus:border-amber-500 focus:ring-amber-500'
-  }`;
-  const minuteInputClass =
-    'w-12 md:w-14 rounded-md border border-gray-300 px-1.5 md:px-2 py-1 md:py-1.5 text-base md:text-base text-gray-900 text-center focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none';
-
-  return (
-    <div className={wrapperClassName}>
-      <div className="flex items-center gap-1 md:gap-1.5">
-        <input
-          type="number"
-          value={newHour}
-          onChange={(e) => onHourChange(e.target.value)}
-          min="0"
-          max="23"
-          className={hourInputClass}
-          placeholder="時"
-        />
-        <span className="text-gray-600 text-base md:text-base">:</span>
-        <input
-          type="number"
-          value={newMinute}
-          onChange={(e) => onMinuteChange(e.target.value)}
-          min="0"
-          max="59"
-          className={minuteInputClass}
-          placeholder="分"
-        />
-      </div>
-      <button
-        onClick={onAdd}
-        className={buttonClassName}
-        aria-label="時間ラベルを追加"
-      >
-        <HiPlus className="h-3.5 w-3.5 md:h-4 md:w-4" />
-        <span className={labelClassName}>追加</span>
-      </button>
-    </div>
-  );
-}
-
-interface TimeEditDialogProps {
-  initialHour: string;
-  initialMinute: string;
-  onSave: (hour: string, minute: string) => void;
-  onCancel: () => void;
-  labels: TimeLabel[];
-  onDeleteLabel: (id: string) => void;
-}
-
-function TimeEditDialog({
-  initialHour,
-  initialMinute,
-  onSave,
-  onCancel,
-  labels,
-  onDeleteLabel,
-}: TimeEditDialogProps) {
-  const [hour, setHour] = useState(initialHour);
-  const [minute, setMinute] = useState(initialMinute);
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!hour) return;
-    onSave(hour, minute);
-  };
-
-  return (
-    <div className="fixed inset-0 bg-black/20 flex items-center justify-center z-[100] p-4" onClick={onCancel}>
-      <div className="bg-white rounded-lg shadow-xl max-w-md w-full border-2 border-gray-300" onClick={(e) => e.stopPropagation()}>
-        {/* ヘッダー */}
-        <div className="sticky top-0 bg-white border-b border-gray-200 px-4 md:px-6 py-3 md:py-5 flex items-center justify-between">
-          <h3 className="text-2xl md:text-2xl font-semibold text-gray-800">時間を編集</h3>
-          <button
-            onClick={onCancel}
-            className="rounded-md bg-gray-200 p-1.5 md:p-2.5 text-gray-700 transition-colors hover:bg-gray-300 min-w-[44px] min-h-[44px] flex items-center justify-center"
-            aria-label="閉じる"
-          >
-            <HiX className="h-6 w-6 md:h-7 md:w-7" />
-          </button>
-        </div>
-
-        {/* フォーム */}
-        <form onSubmit={handleSubmit} className="p-4 md:p-6">
-          <div className="space-y-3 md:space-y-5 max-w-md mx-auto">
-            {/* 時間選択 */}
-            <div>
-              <label className="mb-1 md:mb-2 block text-base md:text-lg font-medium text-gray-700 text-center">
-                時間 <span className="text-red-500">*</span>
-              </label>
-              <div className="flex items-center justify-center gap-2 md:gap-3">
-                <input
-                  type="number"
-                  value={hour}
-                  onChange={(e) => {
-                    const value = e.target.value;
-                    if (value === '' || (parseInt(value) >= 0 && parseInt(value) <= 23)) {
-                      setHour(value);
-                    }
-                  }}
-                  min="0"
-                  max="23"
-                  required
-                  className="w-16 md:w-24 rounded-md border border-gray-300 px-2 md:px-4 py-1.5 md:py-2.5 text-base md:text-lg text-gray-900 text-center focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-                  placeholder="時"
-                />
-                <span className="text-gray-600 text-base md:text-xl">:</span>
-                <input
-                  type="number"
-                  value={minute}
-                  onChange={(e) => {
-                    const value = e.target.value;
-                    if (value === '' || (parseInt(value) >= 0 && parseInt(value) <= 59)) {
-                      setMinute(value);
-                    }
-                  }}
-                  min="0"
-                  max="59"
-                  className="w-16 md:w-24 rounded-md border border-gray-300 px-2 md:px-4 py-1.5 md:py-2.5 text-base md:text-lg text-gray-900 text-center focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-                  placeholder="分"
-                />
-              </div>
-            </div>
-
-            {/* この時間のラベル一覧（個別削除） */}
-            {labels.length > 0 && (
-              <div className="space-y-2 md:space-y-3">
-                <h4 className="text-base md:text-lg font-medium text-gray-800">この時間のラベル</h4>
-                <div className="space-y-2">
-                  {labels.map((label) => (
-                    <div
-                      key={label.id}
-                      className="flex items-center gap-2 md:gap-3 rounded-md border border-gray-200 px-3 py-2 bg-gray-50"
-                    >
-                      <div className="flex-1 text-sm md:text-base text-gray-800 truncate">
-                        {label.content || '内容なし'}
-                      </div>
-                      <button
-                        type="button"
-                        onClick={() => onDeleteLabel(label.id)}
-                        className="px-2 md:px-3 py-1 md:py-1.5 text-sm md:text-sm bg-white text-red-600 border border-red-200 rounded-md hover:bg-red-50 transition-colors min-h-[36px]"
-                      >
-                        削除
-                      </button>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* フッター */}
-            <div className="flex gap-2 md:gap-4 pt-3 md:pt-5 border-t border-gray-200 justify-center">
-              <button
-                type="button"
-                onClick={onCancel}
-                className="px-3 md:px-5 py-1.5 md:py-2.5 text-base md:text-lg text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors min-h-[44px]"
-              >
-                キャンセル
-              </button>
-              <button
-                type="submit"
-                disabled={!hour}
-                className="px-4 md:px-6 py-1.5 md:py-2.5 text-base md:text-lg bg-amber-600 text-white rounded-md hover:bg-amber-700 transition-colors font-medium min-h-[44px] disabled:bg-gray-300 disabled:cursor-not-allowed"
-              >
-                保存
-              </button>
-            </div>
-          </div>
-        </form>
-      </div>
-    </div>
-  );
-}
-

--- a/components/today-schedule/TimeEditDialog.tsx
+++ b/components/today-schedule/TimeEditDialog.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useState } from 'react';
+import { HiX } from 'react-icons/hi';
+import type { TimeLabel } from '@/types';
+
+interface TimeEditDialogProps {
+  initialHour: string;
+  initialMinute: string;
+  onSave: (hour: string, minute: string) => void;
+  onCancel: () => void;
+  labels: TimeLabel[];
+  onDeleteLabel: (id: string) => void;
+}
+
+export function TimeEditDialog({
+  initialHour,
+  initialMinute,
+  onSave,
+  onCancel,
+  labels,
+  onDeleteLabel,
+}: TimeEditDialogProps) {
+  const [hour, setHour] = useState(initialHour);
+  const [minute, setMinute] = useState(initialMinute);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!hour) return;
+    onSave(hour, minute);
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/20 flex items-center justify-center z-[100] p-4" onClick={onCancel}>
+      <div className="bg-white rounded-lg shadow-xl max-w-md w-full border-2 border-gray-300" onClick={(e) => e.stopPropagation()}>
+        {/* ヘッダー */}
+        <div className="sticky top-0 bg-white border-b border-gray-200 px-4 md:px-6 py-3 md:py-5 flex items-center justify-between">
+          <h3 className="text-2xl md:text-2xl font-semibold text-gray-800">時間を編集</h3>
+          <button
+            onClick={onCancel}
+            className="rounded-md bg-gray-200 p-1.5 md:p-2.5 text-gray-700 transition-colors hover:bg-gray-300 min-w-[44px] min-h-[44px] flex items-center justify-center"
+            aria-label="閉じる"
+          >
+            <HiX className="h-6 w-6 md:h-7 md:w-7" />
+          </button>
+        </div>
+
+        {/* フォーム */}
+        <form onSubmit={handleSubmit} className="p-4 md:p-6">
+          <div className="space-y-3 md:space-y-5 max-w-md mx-auto">
+            {/* 時間選択 */}
+            <div>
+              <label className="mb-1 md:mb-2 block text-base md:text-lg font-medium text-gray-700 text-center">
+                時間 <span className="text-red-500">*</span>
+              </label>
+              <div className="flex items-center justify-center gap-2 md:gap-3">
+                <input
+                  type="number"
+                  value={hour}
+                  onChange={(e) => {
+                    const value = e.target.value;
+                    if (value === '' || (parseInt(value) >= 0 && parseInt(value) <= 23)) {
+                      setHour(value);
+                    }
+                  }}
+                  min="0"
+                  max="23"
+                  required
+                  className="w-16 md:w-24 rounded-md border border-gray-300 px-2 md:px-4 py-1.5 md:py-2.5 text-base md:text-lg text-gray-900 text-center focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                  placeholder="時"
+                />
+                <span className="text-gray-600 text-base md:text-xl">:</span>
+                <input
+                  type="number"
+                  value={minute}
+                  onChange={(e) => {
+                    const value = e.target.value;
+                    if (value === '' || (parseInt(value) >= 0 && parseInt(value) <= 59)) {
+                      setMinute(value);
+                    }
+                  }}
+                  min="0"
+                  max="59"
+                  className="w-16 md:w-24 rounded-md border border-gray-300 px-2 md:px-4 py-1.5 md:py-2.5 text-base md:text-lg text-gray-900 text-center focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                  placeholder="分"
+                />
+              </div>
+            </div>
+
+            {/* この時間のラベル一覧（個別削除） */}
+            {labels.length > 0 && (
+              <div className="space-y-2 md:space-y-3">
+                <h4 className="text-base md:text-lg font-medium text-gray-800">この時間のラベル</h4>
+                <div className="space-y-2">
+                  {labels.map((label) => (
+                    <div
+                      key={label.id}
+                      className="flex items-center gap-2 md:gap-3 rounded-md border border-gray-200 px-3 py-2 bg-gray-50"
+                    >
+                      <div className="flex-1 text-sm md:text-base text-gray-800 truncate">
+                        {label.content || '内容なし'}
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => onDeleteLabel(label.id)}
+                        className="px-2 md:px-3 py-1 md:py-1.5 text-sm md:text-sm bg-white text-red-600 border border-red-200 rounded-md hover:bg-red-50 transition-colors min-h-[36px]"
+                      >
+                        削除
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* フッター */}
+            <div className="flex gap-2 md:gap-4 pt-3 md:pt-5 border-t border-gray-200 justify-center">
+              <button
+                type="button"
+                onClick={onCancel}
+                className="px-3 md:px-5 py-1.5 md:py-2.5 text-base md:text-lg text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors min-h-[44px]"
+              >
+                キャンセル
+              </button>
+              <button
+                type="submit"
+                disabled={!hour}
+                className="px-4 md:px-6 py-1.5 md:py-2.5 text-base md:text-lg bg-amber-600 text-white rounded-md hover:bg-amber-700 transition-colors font-medium min-h-[44px] disabled:bg-gray-300 disabled:cursor-not-allowed"
+              >
+                保存
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/components/today-schedule/TimeInputRow.tsx
+++ b/components/today-schedule/TimeInputRow.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { HiPlus } from 'react-icons/hi';
+
+export interface TimeInputRowProps {
+  newHour: string;
+  newMinute: string;
+  addError: string;
+  onHourChange: (value: string) => void;
+  onMinuteChange: (value: string) => void;
+  onAdd: () => void;
+  wrapperClassName: string;
+  buttonClassName: string;
+  labelClassName?: string;
+}
+
+export function TimeInputRow({
+  newHour,
+  newMinute,
+  addError,
+  onHourChange,
+  onMinuteChange,
+  onAdd,
+  wrapperClassName,
+  buttonClassName,
+  labelClassName,
+}: TimeInputRowProps) {
+  const hourInputClass = `w-12 md:w-14 rounded-md border px-1.5 md:px-2 py-1 md:py-1.5 text-base md:text-base text-gray-900 text-center focus:outline-none focus:ring-2 transition-all duration-300 ease-in-out [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${
+    addError ? 'border-red-500 focus:border-red-500 focus:ring-red-500' : 'border-gray-300 focus:border-amber-500 focus:ring-amber-500'
+  }`;
+  const minuteInputClass =
+    'w-12 md:w-14 rounded-md border border-gray-300 px-1.5 md:px-2 py-1 md:py-1.5 text-base md:text-base text-gray-900 text-center focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none';
+
+  return (
+    <div className={wrapperClassName}>
+      <div className="flex items-center gap-1 md:gap-1.5">
+        <input
+          type="number"
+          value={newHour}
+          onChange={(e) => onHourChange(e.target.value)}
+          min="0"
+          max="23"
+          className={hourInputClass}
+          placeholder="時"
+        />
+        <span className="text-gray-600 text-base md:text-base">:</span>
+        <input
+          type="number"
+          value={newMinute}
+          onChange={(e) => onMinuteChange(e.target.value)}
+          min="0"
+          max="59"
+          className={minuteInputClass}
+          placeholder="分"
+        />
+      </div>
+      <button
+        onClick={onAdd}
+        className={buttonClassName}
+        aria-label="時間ラベルを追加"
+      >
+        <HiPlus className="h-3.5 w-3.5 md:h-4 md:w-4" />
+        <span className={labelClassName}>追加</span>
+      </button>
+    </div>
+  );
+}

--- a/hooks/useTodayScheduleSync.ts
+++ b/hooks/useTodayScheduleSync.ts
@@ -1,0 +1,304 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import type { AppData, TodaySchedule, TimeLabel } from '@/types';
+
+interface UseTodayScheduleSyncOptions {
+  data: AppData | null;
+  onUpdate: (data: AppData) => void;
+  selectedDate: string;
+  currentSchedule: TodaySchedule;
+}
+
+export function useTodayScheduleSync({
+  data,
+  onUpdate,
+  selectedDate,
+  currentSchedule,
+}: UseTodayScheduleSyncOptions) {
+  const [isComposing, setIsComposing] = useState(false);
+  const [localTimeLabels, setLocalTimeLabels] = useState<TimeLabel[]>(currentSchedule.timeLabels || []);
+  const [newHour, setNewHour] = useState<string>('');
+  const [newMinute, setNewMinute] = useState<string>('');
+  const [addError, setAddError] = useState<string>('');
+
+  const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const errorTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const isUpdatingRef = useRef(false);
+  const dataRef = useRef<AppData | null>(data);
+  const todayScheduleIdRef = useRef<string>('');
+  const originalTimeLabelsRef = useRef<TimeLabel[]>([]);
+  const onUpdateRef = useRef(onUpdate);
+  const lastDataRef = useRef<string>('');
+  const lastSelectedDateRef = useRef<string>(selectedDate);
+  const localTimeLabelsRef = useRef<TimeLabel[]>(currentSchedule.timeLabels || []);
+
+  // 最新の参照を保持
+  useEffect(() => {
+    dataRef.current = data;
+    onUpdateRef.current = onUpdate;
+  }, [data, onUpdate]);
+
+  useEffect(() => {
+    lastSelectedDateRef.current = selectedDate;
+  }, [selectedDate]);
+
+  useEffect(() => {
+    const initialLabels = currentSchedule.timeLabels || [];
+    originalTimeLabelsRef.current = JSON.parse(JSON.stringify(initialLabels));
+    localTimeLabelsRef.current = JSON.parse(JSON.stringify(initialLabels));
+    todayScheduleIdRef.current = currentSchedule.id;
+    lastDataRef.current = JSON.stringify(initialLabels);
+  }, [currentSchedule]);
+
+  const clearAddError = useCallback(() => {
+    if (addError) {
+      if (errorTimeoutRef.current) {
+        clearTimeout(errorTimeoutRef.current);
+        errorTimeoutRef.current = null;
+      }
+      setAddError('');
+    }
+  }, [addError]);
+
+  const handleHourInputChange = useCallback(
+    (value: string) => {
+      const hour = parseInt(value, 10);
+      if (value === '' || (!Number.isNaN(hour) && hour >= 0 && hour <= 23)) {
+        setNewHour(value);
+        clearAddError();
+      }
+    },
+    [clearAddError]
+  );
+
+  const handleMinuteInputChange = useCallback((value: string) => {
+    const minute = parseInt(value, 10);
+    if (value === '' || (!Number.isNaN(minute) && minute >= 0 && minute <= 59)) {
+      setNewMinute(value);
+    }
+  }, []);
+
+  // デバウンス保存関数
+  const debouncedSave = useCallback(
+    (newTimeLabels: TimeLabel[], targetDate: string) => {
+      if (isComposing) return;
+      if (targetDate !== selectedDate) return;
+
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
+
+      debounceTimerRef.current = setTimeout(() => {
+        if (targetDate !== selectedDate) return;
+
+        const currentData = dataRef.current;
+        if (!currentData) return;
+
+        const newTimeLabelsStr = JSON.stringify(newTimeLabels);
+        const originalStr = JSON.stringify(originalTimeLabelsRef.current);
+        if (originalStr === newTimeLabelsStr) return;
+
+        isUpdatingRef.current = true;
+        const updatedSchedules = [...(currentData.todaySchedules || [])];
+        const existingIndex = updatedSchedules.findIndex((s) => s.date === targetDate);
+
+        const updatedSchedule: TodaySchedule = {
+          id: todayScheduleIdRef.current || `schedule-${targetDate}`,
+          date: targetDate,
+          timeLabels: newTimeLabels,
+        };
+
+        if (existingIndex >= 0) {
+          updatedSchedules[existingIndex] = updatedSchedule;
+        } else {
+          updatedSchedules.push(updatedSchedule);
+        }
+
+        const updatedData: AppData = {
+          ...currentData,
+          todaySchedules: updatedSchedules,
+        };
+
+        originalTimeLabelsRef.current = JSON.parse(JSON.stringify(newTimeLabels));
+        localTimeLabelsRef.current = JSON.parse(JSON.stringify(newTimeLabels));
+        todayScheduleIdRef.current = updatedSchedule.id;
+        lastDataRef.current = newTimeLabelsStr;
+
+        onUpdateRef.current(updatedData);
+
+        setTimeout(() => {
+          isUpdatingRef.current = false;
+        }, 100);
+      }, 500);
+    },
+    [selectedDate, isComposing]
+  );
+
+  // ローカル状態が変更されたらデバウンス保存
+  useEffect(() => {
+    if (isUpdatingRef.current) return;
+    if (lastSelectedDateRef.current !== selectedDate) return;
+
+    localTimeLabelsRef.current = JSON.parse(JSON.stringify(localTimeLabels));
+
+    const originalTimeLabels = originalTimeLabelsRef.current;
+
+    if (localTimeLabels.length !== originalTimeLabels.length) {
+      debouncedSave(localTimeLabels, selectedDate);
+      return;
+    }
+
+    const hasChanges = localTimeLabels.some((label, index) => {
+      const original = originalTimeLabels[index];
+      return (
+        !original ||
+        label.id !== original.id ||
+        label.time !== original.time ||
+        label.content !== original.content ||
+        label.memo !== original.memo
+      );
+    });
+
+    if (hasChanges) {
+      debouncedSave(localTimeLabels, selectedDate);
+    }
+  }, [localTimeLabels, debouncedSave, selectedDate]);
+
+  // クリーンアップ（アンマウント時に未保存の変更を保存）
+  useEffect(() => {
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
+
+      if (!isUpdatingRef.current) {
+        const currentTimeLabels = localTimeLabelsRef.current;
+        const originalTimeLabels = originalTimeLabelsRef.current;
+        const currentSelectedDate = lastSelectedDateRef.current;
+
+        if (currentSelectedDate !== selectedDate) return;
+
+        const hasChanges = currentTimeLabels.length !== originalTimeLabels.length ||
+          currentTimeLabels.some((label, index) => {
+            const original = originalTimeLabels[index];
+            return (
+              !original ||
+              label.id !== original.id ||
+              label.time !== original.time ||
+              label.content !== original.content ||
+              label.memo !== original.memo
+            );
+          });
+
+        if (hasChanges) {
+          const currentData = dataRef.current;
+          if (currentData) {
+            const updatedSchedules = [...(currentData.todaySchedules || [])];
+            const existingIndex = updatedSchedules.findIndex((s) => s.date === currentSelectedDate);
+
+            const updatedSchedule: TodaySchedule = {
+              id: todayScheduleIdRef.current || `schedule-${currentSelectedDate}`,
+              date: currentSelectedDate,
+              timeLabels: currentTimeLabels,
+            };
+
+            if (existingIndex >= 0) {
+              updatedSchedules[existingIndex] = updatedSchedule;
+            } else {
+              updatedSchedules.push(updatedSchedule);
+            }
+
+            const updatedData: AppData = {
+              ...currentData,
+              todaySchedules: updatedSchedules,
+            };
+
+            onUpdateRef.current(updatedData);
+          }
+        }
+      }
+
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+      }
+
+      if (errorTimeoutRef.current) {
+        clearTimeout(errorTimeoutRef.current);
+      }
+    };
+  }, [selectedDate]);
+
+  const handleCompositionStart = () => {
+    setIsComposing(true);
+  };
+
+  const handleCompositionEnd = () => {
+    setIsComposing(false);
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current);
+    }
+    saveTimeoutRef.current = setTimeout(() => {
+      debouncedSave(localTimeLabels, selectedDate);
+    }, 300);
+  };
+
+  const addTimeLabel = () => {
+    if (!newHour) {
+      setAddError('数字を入力してください');
+
+      if (errorTimeoutRef.current) {
+        clearTimeout(errorTimeoutRef.current);
+      }
+
+      errorTimeoutRef.current = setTimeout(() => {
+        setAddError('');
+        errorTimeoutRef.current = null;
+      }, 3000);
+
+      return;
+    }
+
+    if (errorTimeoutRef.current) {
+      clearTimeout(errorTimeoutRef.current);
+      errorTimeoutRef.current = null;
+    }
+    setAddError('');
+
+    const hour = newHour.padStart(2, '0');
+    const minute = newMinute ? newMinute.padStart(2, '0') : '00';
+    const time = `${hour}:${minute}`;
+
+    const newLabel: TimeLabel = {
+      id: `time-${Date.now()}`,
+      time: time,
+      content: '',
+      memo: '',
+      order: localTimeLabels.length,
+    };
+    setLocalTimeLabels([...localTimeLabels, newLabel]);
+    setNewHour('');
+    setNewMinute('');
+  };
+
+  const updateTimeLabel = (id: string, updates: Partial<TimeLabel>) => {
+    setLocalTimeLabels(
+      localTimeLabels.map((label) => (label.id === id ? { ...label, ...updates } : label))
+    );
+  };
+
+  return {
+    localTimeLabels,
+    setLocalTimeLabels,
+    newHour,
+    newMinute,
+    addError,
+    handleHourInputChange,
+    handleMinuteInputChange,
+    handleCompositionStart,
+    handleCompositionEnd,
+    addTimeLabel,
+    updateTimeLabel,
+  };
+}

--- a/hooks/useWorkProgressActions.ts
+++ b/hooks/useWorkProgressActions.ts
@@ -1,0 +1,144 @@
+import { useState } from 'react';
+import type { AppData, WorkProgress, WorkProgressStatus } from '@/types';
+import {
+  addWorkProgress,
+  updateWorkProgress,
+  updateWorkProgresses,
+  deleteWorkProgress,
+  addProgressToWorkProgress,
+  addCompletedCountToWorkProgress,
+  archiveWorkProgress,
+  unarchiveWorkProgress,
+  updateProgressHistoryEntry,
+  deleteProgressHistoryEntry,
+} from '@/lib/firestore';
+
+type WorkProgressInput = Partial<Omit<WorkProgress, 'id' | 'createdAt' | 'updatedAt'>>;
+
+export function useWorkProgressActions(userId: string | undefined, data: AppData | undefined) {
+  const [expandedHistoryIds, setExpandedHistoryIds] = useState<Set<string>>(new Set());
+  const [editingHistoryEntryId, setEditingHistoryEntryId] = useState<string | null>(null);
+  const [editingHistoryWorkProgressId, setEditingHistoryWorkProgressId] = useState<string | null>(null);
+
+  const handleAddWorkProgress = async (workProgressData: WorkProgressInput) => {
+    if (!userId || !data) return;
+    const payload: Omit<WorkProgress, 'id' | 'createdAt' | 'updatedAt'> = {
+      ...workProgressData,
+      status: workProgressData.status ?? 'pending',
+    };
+    await addWorkProgress(userId, payload, data);
+  };
+
+  const handleUpdateWorkProgress = async (id: string, updates: Partial<WorkProgress>) => {
+    if (!userId || !data) return;
+    await updateWorkProgress(userId, id, updates, data);
+  };
+
+  const handleDeleteWorkProgress = async (id: string) => {
+    if (!userId || !data) return;
+    await deleteWorkProgress(userId, id, data);
+  };
+
+  const handleStatusChange = async (id: string, status: WorkProgressStatus) => {
+    if (!userId || !data) return;
+    await updateWorkProgress(userId, id, { status }, data);
+  };
+
+  const handleArchiveWorkProgress = async (id: string) => {
+    if (!userId || !data) return;
+    await archiveWorkProgress(userId, id, data);
+  };
+
+  const handleUnarchiveWorkProgress = async (id: string) => {
+    if (!userId || !data) return;
+    await unarchiveWorkProgress(userId, id, data);
+  };
+
+  const handleAddProgress = async (id: string, amount: number, memo?: string) => {
+    if (!userId || !data) return;
+    const workProgress = data.workProgresses?.find((wp) => wp.id === id);
+    if (!workProgress) return;
+
+    if (workProgress.targetAmount !== undefined) {
+      await addProgressToWorkProgress(userId, id, amount, data, memo);
+    } else {
+      await addCompletedCountToWorkProgress(userId, id, Math.floor(amount), data, memo);
+    }
+  };
+
+  const handleUpdateGroup = async (oldGroupName: string, newData: { groupName: string }) => {
+    if (!userId || !data?.workProgresses) return;
+    const workProgresses = data.workProgresses.filter((wp) => wp.groupName === oldGroupName);
+    const updates = new Map<string, Partial<Omit<WorkProgress, 'id' | 'createdAt'>>>();
+    workProgresses.forEach((wp) => {
+      updates.set(wp.id, { groupName: newData.groupName });
+    });
+    await updateWorkProgresses(userId, updates, data);
+  };
+
+  const handleDeleteGroup = async (groupName: string) => {
+    if (!userId || !data?.workProgresses) return;
+    const workProgresses = data.workProgresses.filter((wp) => wp.groupName === groupName);
+    for (const wp of workProgresses) {
+      await deleteWorkProgress(userId, wp.id, data);
+    }
+  };
+
+  const handleEditHistory = (workProgressId: string, entryId: string) => {
+    setEditingHistoryWorkProgressId(workProgressId);
+    setEditingHistoryEntryId(entryId);
+  };
+
+  const handleUpdateProgressHistory = async (workProgressId: string, entryId: string, amount: number, memo?: string) => {
+    if (!userId || !data) return;
+    await updateProgressHistoryEntry(userId, workProgressId, entryId, { amount, memo }, data);
+    setEditingHistoryWorkProgressId(null);
+    setEditingHistoryEntryId(null);
+  };
+
+  const handleDeleteProgressHistory = async (workProgressId: string, entryId: string) => {
+    if (!userId || !data) return;
+    await deleteProgressHistoryEntry(userId, workProgressId, entryId, data);
+    setEditingHistoryWorkProgressId(null);
+    setEditingHistoryEntryId(null);
+  };
+
+  const clearEditingHistory = () => {
+    setEditingHistoryWorkProgressId(null);
+    setEditingHistoryEntryId(null);
+  };
+
+  const toggleHistory = (id: string) => {
+    setExpandedHistoryIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  return {
+    expandedHistoryIds,
+    editingHistoryEntryId,
+    editingHistoryWorkProgressId,
+    handleAddWorkProgress,
+    handleUpdateWorkProgress,
+    handleDeleteWorkProgress,
+    handleStatusChange,
+    handleArchiveWorkProgress,
+    handleUnarchiveWorkProgress,
+    handleAddProgress,
+    handleUpdateGroup,
+    handleDeleteGroup,
+    handleEditHistory,
+    handleUpdateProgressHistory,
+    handleDeleteProgressHistory,
+    clearEditingHistory,
+    toggleHistory,
+  };
+}
+
+export type { WorkProgressInput };


### PR DESCRIPTION
## 概要

Issue #62 の対応（部分）として、最優先2ファイルのモジュール分割を実施しました。

## 変更内容

### progress/page.tsx: 1,214行 → 268行（-78%）
| 抽出先ファイル | 内容 | 行数 |
|-------------|------|-----|
| `app/progress/components/WorkProgressFormDialog.tsx` | 作業追加・編集フォーム | 192 |
| `app/progress/components/NormalView.tsx` | 通常表示ビュー | 228 |
| `app/progress/components/ProgressHeader.tsx` | ヘッダー部分 | 125 |
| `app/progress/components/FilterDialog.tsx` | フィルタダイアログ | 101 |
| `app/progress/components/ArchivedView.tsx` | アーカイブ一覧 | 86 |
| `app/progress/components/GroupFormDialog.tsx` | グループ作成・編集 | 72 |
| `app/progress/components/ModeSelectDialog.tsx` | モード選択 | 60 |
| `app/progress/utils.ts` | ユーティリティ関数 | 43 |
| `hooks/useWorkProgressActions.ts` | CRUD操作フック | 144 |

### TodaySchedule.tsx: 786行 → 270行（-66%）
| 抽出先ファイル | 内容 | 行数 |
|-------------|------|-----|
| `hooks/useTodayScheduleSync.ts` | デバウンス保存・同期ロジック | 304 |
| `components/today-schedule/TimeEditDialog.tsx` | 時間編集ダイアログ | 138 |
| `components/today-schedule/TimeInputRow.tsx` | 時間入力行 | 67 |

## テスト

- [x] `npm run lint` 新規ファイルのエラーなし（既存エラーのみ）
- [x] `npm run build` 成功
- [ ] 実機で動作確認

Closes #62
