### PR TITLE
[Issue #88] refactor(roast-timer): 焙煎タイマー関連分割

### DIFF
--- a/components/RoastTimer.tsx
+++ b/components/RoastTimer.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { useAuth } from '@/lib/auth';
 import { useAppData } from '@/hooks/useAppData';
 import { useRoastTimer } from '@/hooks/useRoastTimer';
+import { useRoastTimerDialogs } from '@/hooks/useRoastTimerDialogs';
 import { CompletionDialog, ContinuousRoastDialog, AfterPurgeDialog } from './RoastTimerDialogs';
 import { RoastTimerSettings } from './RoastTimerSettings';
 import { TimerDisplay, TimerControls, TimerHeader, SetupPanel } from './roast-timer';
@@ -12,7 +12,6 @@ import type { BeanName } from '@/lib/beanConfig';
 import type { RoastLevel, Weight } from '@/lib/constants';
 
 export function RoastTimer() {
-  const { user } = useAuth();
   const { data, updateData, isLoading } = useAppData();
   const router = useRouter();
   const {
@@ -25,28 +24,20 @@ export function RoastTimer() {
     stopSound,
   } = useRoastTimer({ data, updateData, isLoading });
 
-  // ダイアログの状態
-  const [showCompletionDialog, setShowCompletionDialog] = useState(false);
-  const [showContinuousRoastDialog, setShowContinuousRoastDialog] = useState(false);
-  const [showAfterPurgeDialog, setShowAfterPurgeDialog] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
-  const prevStatusRef = useRef<string | undefined>(undefined);
-  const hasInitializedRef = useRef(false);
-  const dialogSyncLockRef = useRef(false);
 
-  // ページを開いた時の初期化（完了状態の場合は自動リセット）
-  useEffect(() => {
-    if (!hasInitializedRef.current) {
-      hasInitializedRef.current = true;
-
-      if (state?.status === 'completed') {
-        resetTimer();
-        setShowCompletionDialog(false);
-        setShowContinuousRoastDialog(false);
-        setShowAfterPurgeDialog(false);
-      }
-    }
-  }, [state?.status, resetTimer]);
+  const {
+    showCompletionDialog,
+    showContinuousRoastDialog,
+    showAfterPurgeDialog,
+    handleCompletionClose,
+    handleCompletionOk,
+    handleContinuousRoastClose,
+    handleContinuousRoastYes,
+    handleContinuousRoastNo,
+    handleAfterPurgeRecord,
+    handleAfterPurgeClose,
+  } = useRoastTimerDialogs({ state, resetTimer, stopSound, updateData });
 
   // コンポーネントがアンマウントされる時やページを離れる時に音を停止
   useEffect(() => {
@@ -61,65 +52,6 @@ export function RoastTimer() {
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
   }, [stopSound]);
-
-  // 完了状態を検出してダイアログを表示（runningからcompletedに変化した時のみ）
-  useEffect(() => {
-    const currentStatus = state?.status;
-    const prevStatus = prevStatusRef.current;
-
-    const shouldOpenCompletionDialog =
-      !dialogSyncLockRef.current &&
-      prevStatus === 'running' &&
-      currentStatus === 'completed' &&
-      !showCompletionDialog &&
-      !showContinuousRoastDialog &&
-      !showAfterPurgeDialog;
-
-    if (shouldOpenCompletionDialog) {
-      setShowCompletionDialog(true);
-    }
-
-    prevStatusRef.current = currentStatus;
-  }, [state?.status, showCompletionDialog, showContinuousRoastDialog, showAfterPurgeDialog]);
-
-  // FirestoreのdialogStateを監視してダイアログを同期表示
-  useEffect(() => {
-    if (!state) {
-      if (showCompletionDialog || showContinuousRoastDialog || showAfterPurgeDialog) {
-        setShowCompletionDialog(false);
-        setShowContinuousRoastDialog(false);
-        setShowAfterPurgeDialog(false);
-      }
-      return;
-    }
-
-    if (dialogSyncLockRef.current) {
-      return;
-    }
-
-    const dialogState = state.dialogState;
-
-    if (dialogState === 'completion' && state.status === 'completed') {
-      if (!showCompletionDialog && !showContinuousRoastDialog && !showAfterPurgeDialog) {
-        setShowCompletionDialog(true);
-      }
-    } else if (dialogState === 'continuousRoast' && state.status === 'completed') {
-      if (!showContinuousRoastDialog && !showAfterPurgeDialog) {
-        setShowCompletionDialog(false);
-        setShowContinuousRoastDialog(true);
-      }
-    } else if (dialogState === 'afterPurge' && state.status === 'completed') {
-      if (!showAfterPurgeDialog) {
-        setShowCompletionDialog(false);
-        setShowContinuousRoastDialog(false);
-        setShowAfterPurgeDialog(true);
-      }
-    } else if (dialogState === null) {
-      setShowCompletionDialog(false);
-      setShowContinuousRoastDialog(false);
-      setShowAfterPurgeDialog(false);
-    }
-  }, [state, showCompletionDialog, showContinuousRoastDialog, showAfterPurgeDialog]);
 
   // ハンドラー関数
   const handleStart = async (
@@ -142,143 +74,10 @@ export function RoastTimer() {
   const handleReset = () => {
     stopSound();
     resetTimer();
-    setShowCompletionDialog(false);
-    setShowContinuousRoastDialog(false);
-    setShowAfterPurgeDialog(false);
   };
 
   const handleSkip = () => {
     skipTimer();
-  };
-
-  // 完了ダイアログのOKボタン
-  const handleCompletionOk = async () => {
-    stopSound();
-    setShowCompletionDialog(false);
-    setShowContinuousRoastDialog(true);
-
-    if (state) {
-      try {
-        await updateData((currentData) => ({
-          ...currentData,
-          roastTimerState: {
-            ...state,
-            dialogState: 'continuousRoast',
-            lastUpdatedAt: new Date().toISOString(),
-          },
-        }));
-      } catch (error) {
-        console.error('Failed to update dialog state:', error);
-      }
-    }
-  };
-
-  // 連続焙煎ダイアログの「はい」
-  const handleContinuousRoastYes = async () => {
-    stopSound();
-    setShowCompletionDialog(false);
-    setShowContinuousRoastDialog(false);
-    setShowAfterPurgeDialog(false);
-    await resetTimer();
-    router.push('/roast-timer');
-  };
-
-  // 連続焙煎ダイアログの「いいえ」
-  const handleContinuousRoastNo = async () => {
-    setShowContinuousRoastDialog(false);
-    setShowAfterPurgeDialog(true);
-
-    if (state) {
-      try {
-        await updateData((currentData) => ({
-          ...currentData,
-          roastTimerState: {
-            ...state,
-            dialogState: 'afterPurge',
-            lastUpdatedAt: new Date().toISOString(),
-          },
-        }));
-      } catch (error) {
-        console.error('Failed to update dialog state:', error);
-      }
-    }
-  };
-
-  // アフターパージダイアログの「記録に進む」
-  const handleAfterPurgeRecord = async () => {
-    dialogSyncLockRef.current = true;
-    stopSound();
-    setShowCompletionDialog(false);
-    setShowContinuousRoastDialog(false);
-    setShowAfterPurgeDialog(false);
-    prevStatusRef.current = undefined;
-
-    const stateSnapshot = state;
-    let clearDialogStatePromise: Promise<void> | null = null;
-
-    if (stateSnapshot) {
-      try {
-        clearDialogStatePromise = updateData((currentData) => ({
-          ...currentData,
-          roastTimerState: {
-            ...stateSnapshot,
-            dialogState: null,
-            lastUpdatedAt: new Date().toISOString(),
-          },
-        }));
-      } catch (error) {
-        console.error('Failed to update dialog state:', error);
-      }
-    }
-
-    let targetUrl = '/roast-record';
-    if (
-      stateSnapshot &&
-      stateSnapshot.beanName &&
-      stateSnapshot.weight &&
-      stateSnapshot.roastLevel &&
-      stateSnapshot.elapsed > 0
-    ) {
-      const params = new URLSearchParams({
-        beanName: stateSnapshot.beanName,
-        weight: stateSnapshot.weight.toString(),
-        roastLevel: stateSnapshot.roastLevel,
-        duration: Math.round(stateSnapshot.elapsed).toString(),
-      });
-      targetUrl = `/roast-record?${params.toString()}`;
-    }
-
-    setShowCompletionDialog(false);
-    setShowContinuousRoastDialog(false);
-    setShowAfterPurgeDialog(false);
-
-    router.push(targetUrl);
-
-    if (clearDialogStatePromise) {
-      try {
-        await clearDialogStatePromise;
-      } catch (error) {
-        console.error('Failed to update dialog state:', error);
-      }
-    }
-
-    try {
-      await resetTimer();
-    } finally {
-      setShowCompletionDialog(false);
-      setShowContinuousRoastDialog(false);
-      setShowAfterPurgeDialog(false);
-      dialogSyncLockRef.current = false;
-    }
-  };
-
-  // アフターパージダイアログの「閉じる」
-  const handleAfterPurgeClose = async () => {
-    stopSound();
-    setShowCompletionDialog(false);
-    setShowContinuousRoastDialog(false);
-    setShowAfterPurgeDialog(false);
-    await resetTimer();
   };
 
   // 状態の計算
@@ -300,47 +99,12 @@ export function RoastTimer() {
       {/* ダイアログ */}
       <CompletionDialog
         isOpen={showCompletionDialog}
-        onClose={async () => {
-          stopSound();
-          setShowCompletionDialog(false);
-
-          if (state) {
-            try {
-              await updateData((currentData) => ({
-                ...currentData,
-                roastTimerState: {
-                  ...state,
-                  dialogState: null,
-                  lastUpdatedAt: new Date().toISOString(),
-                },
-              }));
-            } catch (error) {
-              console.error('Failed to update dialog state:', error);
-            }
-          }
-        }}
+        onClose={handleCompletionClose}
         onContinue={handleCompletionOk}
       />
       <ContinuousRoastDialog
         isOpen={showContinuousRoastDialog}
-        onClose={async () => {
-          setShowContinuousRoastDialog(false);
-
-          if (state) {
-            try {
-              await updateData((currentData) => ({
-                ...currentData,
-                roastTimerState: {
-                  ...state,
-                  dialogState: null,
-                  lastUpdatedAt: new Date().toISOString(),
-                },
-              }));
-            } catch (error) {
-              console.error('Failed to update dialog state:', error);
-            }
-          }
-        }}
+        onClose={handleContinuousRoastClose}
         onYes={handleContinuousRoastYes}
         onNo={handleContinuousRoastNo}
       />

--- a/components/roast-timer/ModeSelectView.tsx
+++ b/components/roast-timer/ModeSelectView.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { HiPlay } from 'react-icons/hi';
+import { MdTimer, MdLightbulb } from 'react-icons/md';
+
+interface ModeSelectViewProps {
+  durationMinutes: string;
+  durationSeconds: string;
+  onDurationMinutesChange: (value: string) => void;
+  onDurationSecondsChange: (value: string) => void;
+  onManualStart: () => Promise<void>;
+  onRecommendedMode: () => void;
+  isStartDisabled: boolean;
+}
+
+/**
+ * モード選択画面（inputMode === null の場合に表示）
+ * - 手動入力フィールドとスタートボタン
+ * - おすすめタイマーボタン
+ */
+export function ModeSelectView({
+  durationMinutes,
+  durationSeconds,
+  onDurationMinutesChange,
+  onDurationSecondsChange,
+  onManualStart,
+  onRecommendedMode,
+  isStartDisabled,
+}: ModeSelectViewProps) {
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center px-4 sm:px-6 py-8">
+      {/* タイトルセクション */}
+      <div className="text-center space-y-4 mb-10 sm:mb-12">
+        <div className="inline-flex items-center justify-center w-20 h-20 sm:w-24 sm:h-24 rounded-full bg-gradient-to-br from-amber-400 to-amber-600 shadow-lg mb-3">
+          <MdTimer className="text-white text-4xl sm:text-5xl" />
+        </div>
+        <h3 className="text-3xl sm:text-4xl font-bold text-gray-900 tracking-tight">
+          ローストタイマー
+        </h3>
+        <p className="text-base sm:text-lg text-gray-500">焙煎時間を設定してスタート</p>
+      </div>
+
+      {/* 手動入力フィールド */}
+      <div className="space-y-4 max-w-md mx-auto w-full mb-8 sm:mb-10">
+        <label className="block text-sm sm:text-base font-semibold text-gray-700 uppercase tracking-wide">
+          時間設定
+        </label>
+        <div className="flex gap-3 sm:gap-4">
+          <div className="flex-1">
+            <input
+              type="text"
+              inputMode="numeric"
+              value={durationMinutes}
+              onChange={(e) => onDurationMinutesChange(e.target.value)}
+              placeholder="分"
+              className="w-full rounded-lg border-2 border-gray-200 px-4 py-3.5 sm:py-4 text-lg sm:text-xl text-gray-900 bg-white focus:border-amber-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-amber-100 transition-all duration-200 font-semibold text-center min-h-[56px] shadow-sm hover:border-gray-300"
+            />
+          </div>
+          <div className="flex items-end pb-2">
+            <span className="text-3xl font-bold text-gray-400">:</span>
+          </div>
+          <div className="flex-1">
+            <input
+              type="text"
+              inputMode="numeric"
+              value={durationSeconds}
+              onChange={(e) => onDurationSecondsChange(e.target.value)}
+              placeholder="秒"
+              maxLength={2}
+              className="w-full rounded-lg border-2 border-gray-200 px-4 py-3.5 sm:py-4 text-lg sm:text-xl text-gray-900 bg-white focus:border-amber-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-amber-100 transition-all duration-200 font-semibold text-center min-h-[56px] shadow-sm hover:border-gray-300"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* ボタンセクション */}
+      <div className="space-y-3 sm:space-y-4 max-w-md mx-auto w-full">
+        {/* 手動スタートボタン */}
+        <button
+          onClick={onManualStart}
+          disabled={isStartDisabled}
+          className="w-full flex items-center justify-center gap-2 px-6 py-4 sm:py-5 bg-gradient-to-r from-amber-500 to-amber-600 text-white rounded-xl font-bold text-base sm:text-lg shadow-lg hover:shadow-xl hover:from-amber-600 hover:to-amber-700 active:scale-[0.98] transition-all duration-200 min-h-[60px] sm:min-h-[64px] disabled:from-gray-300 disabled:to-gray-400 disabled:cursor-not-allowed disabled:hover:shadow-lg disabled:active:scale-100 disabled:hover:from-gray-300 disabled:hover:to-gray-400"
+        >
+          <HiPlay className="text-xl sm:text-2xl" />
+          <span>手動でタイマースタート</span>
+        </button>
+
+        {/* おすすめ焙煎ボタン */}
+        <button
+          onClick={onRecommendedMode}
+          className="w-full flex items-center justify-center gap-2 px-6 py-4 sm:py-5 bg-gradient-to-r from-amber-50 to-amber-100 text-amber-700 border-2 border-amber-200 rounded-xl font-bold text-base sm:text-lg shadow-sm hover:shadow-md hover:from-amber-100 hover:to-amber-200 hover:border-amber-300 active:scale-[0.98] transition-all duration-200 min-h-[60px] sm:min-h-[64px]"
+        >
+          <MdLightbulb className="text-xl sm:text-2xl text-amber-600" />
+          <span>おすすめタイマー</span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/roast-timer/RecommendedModeView.tsx
+++ b/components/roast-timer/RecommendedModeView.tsx
@@ -1,0 +1,307 @@
+'use client';
+
+import { HiPlay } from 'react-icons/hi';
+import { MdLightbulb } from 'react-icons/md';
+import { formatTimeAsMinutesAndSeconds } from '@/lib/roastTimerUtils';
+import { WEIGHTS, type RoastLevel, type Weight } from '@/lib/constants';
+import type { BeanName } from '@/lib/beanConfig';
+
+interface RecommendedModeViewProps {
+  recommendedMode: 'weight' | 'history';
+  beanName: BeanName | '';
+  weight: Weight | '';
+  roastLevel: RoastLevel | '';
+  availableBeans: BeanName[];
+  availableWeights: Weight[];
+  availableRoastLevels: RoastLevel[];
+  recommendedTimeInfo: {
+    averageDuration: number;
+    recommendedDuration: number;
+  } | null;
+  onRecommendedModeChange: (mode: 'weight' | 'history') => void;
+  onBeanNameChange: (value: BeanName | '') => void;
+  onWeightChange: (value: Weight | '') => void;
+  onRoastLevelChange: (value: RoastLevel | '') => void;
+  onStart: () => Promise<void>;
+  isStartDisabled: boolean;
+}
+
+/**
+ * おすすめモード画面
+ * - 重さで設定モード
+ * - 過去の記録から設定モード
+ */
+export function RecommendedModeView({
+  recommendedMode,
+  beanName,
+  weight,
+  roastLevel,
+  availableBeans,
+  availableWeights,
+  availableRoastLevels,
+  recommendedTimeInfo,
+  onRecommendedModeChange,
+  onBeanNameChange,
+  onWeightChange,
+  onRoastLevelChange,
+  onStart,
+  isStartDisabled,
+}: RecommendedModeViewProps) {
+  return (
+    <div className="flex-1 flex flex-col px-4 sm:px-6">
+      <div className="max-w-md mx-auto w-full flex-1 flex flex-col justify-center py-8">
+        <div className="flex items-center justify-center mb-6 flex-shrink-0">
+          <h3 className="text-xl sm:text-2xl font-bold text-gray-900 flex items-center gap-2">
+            <div className="w-8 h-8 rounded-full bg-gradient-to-br from-amber-400 to-amber-600 flex items-center justify-center">
+              <MdLightbulb className="text-white text-lg" />
+            </div>
+            おすすめタイマー
+          </h3>
+        </div>
+
+        {/* モード切り替えタブ */}
+        <div className="mb-6 flex-shrink-0">
+          <div className="flex gap-2 bg-gray-100 rounded-lg p-1">
+            <button
+              onClick={() => onRecommendedModeChange('weight')}
+              className={`flex-1 px-4 py-2.5 rounded-md text-sm sm:text-base font-semibold transition-all duration-200 ${
+                recommendedMode === 'weight'
+                  ? 'bg-white text-amber-700 shadow-sm'
+                  : 'text-gray-600 hover:text-gray-900'
+              }`}
+            >
+              重さで設定
+            </button>
+            <button
+              onClick={() => onRecommendedModeChange('history')}
+              className={`flex-1 px-4 py-2.5 rounded-md text-sm sm:text-base font-semibold transition-all duration-200 ${
+                recommendedMode === 'history'
+                  ? 'bg-white text-amber-700 shadow-sm'
+                  : 'text-gray-600 hover:text-gray-900'
+              }`}
+            >
+              過去の記録から設定
+            </button>
+          </div>
+        </div>
+
+        <div className="space-y-5 flex-1">
+          {recommendedMode === 'weight' && (
+            <WeightModeSection weight={weight} onWeightChange={onWeightChange} />
+          )}
+
+          {recommendedMode === 'history' && (
+            <HistoryModeSection
+              beanName={beanName}
+              weight={weight}
+              roastLevel={roastLevel}
+              availableBeans={availableBeans}
+              availableWeights={availableWeights}
+              availableRoastLevels={availableRoastLevels}
+              recommendedTimeInfo={recommendedTimeInfo}
+              onBeanNameChange={onBeanNameChange}
+              onWeightChange={onWeightChange}
+              onRoastLevelChange={onRoastLevelChange}
+            />
+          )}
+
+          <div className="pt-2 flex-shrink-0">
+            <button
+              onClick={onStart}
+              disabled={isStartDisabled}
+              className="w-full flex items-center justify-center gap-3 px-6 py-4 bg-gradient-to-r from-amber-500 to-amber-600 text-white rounded-xl font-bold shadow-lg hover:shadow-xl hover:from-amber-600 hover:to-amber-700 active:scale-[0.98] transition-all duration-200 text-base sm:text-lg min-h-[56px] disabled:from-gray-300 disabled:to-gray-400 disabled:cursor-not-allowed disabled:hover:shadow-lg disabled:active:scale-100 disabled:hover:from-gray-300 disabled:hover:to-gray-400"
+            >
+              <HiPlay className="text-2xl" />
+              <span>スタート</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// --- サブセクション ---
+
+function WeightModeSection({
+  weight,
+  onWeightChange,
+}: {
+  weight: Weight | '';
+  onWeightChange: (value: Weight | '') => void;
+}) {
+  return (
+    <>
+      <div>
+        <label className="block text-sm font-semibold text-gray-700 uppercase tracking-wide mb-2">
+          重さ <span className="text-red-500">*</span>
+        </label>
+        <select
+          value={weight}
+          onChange={(e) =>
+            onWeightChange(e.target.value ? (parseInt(e.target.value, 10) as Weight) : '')
+          }
+          className="w-full rounded-xl border-2 border-gray-200 px-4 py-3.5 text-base sm:text-lg text-gray-900 bg-gray-50 focus:border-amber-500 focus:bg-white focus:outline-none focus:ring-4 focus:ring-amber-100 transition-all duration-200 shadow-sm hover:border-gray-300 min-h-[52px]"
+        >
+          <option value="">選択してください</option>
+          {WEIGHTS.map((w) => (
+            <option key={w} value={w}>
+              {w}g
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {weight !== '' && (
+        <div className="bg-gradient-to-br from-amber-50 to-amber-100 border-2 border-amber-200 rounded-xl p-4 shadow-sm">
+          <p className="text-sm sm:text-base text-gray-700">
+            重さに応じたおすすめ時間は{' '}
+            <span className="font-bold text-amber-800">
+              {weight === 200 ? '8分' : weight === 300 ? '9分' : '10分'}
+            </span>{' '}
+            です
+          </p>
+        </div>
+      )}
+    </>
+  );
+}
+
+function HistoryModeSection({
+  beanName,
+  weight,
+  roastLevel,
+  availableBeans,
+  availableWeights,
+  availableRoastLevels,
+  recommendedTimeInfo,
+  onBeanNameChange,
+  onWeightChange,
+  onRoastLevelChange,
+}: {
+  beanName: BeanName | '';
+  weight: Weight | '';
+  roastLevel: RoastLevel | '';
+  availableBeans: BeanName[];
+  availableWeights: Weight[];
+  availableRoastLevels: RoastLevel[];
+  recommendedTimeInfo: { averageDuration: number; recommendedDuration: number } | null;
+  onBeanNameChange: (value: BeanName | '') => void;
+  onWeightChange: (value: Weight | '') => void;
+  onRoastLevelChange: (value: RoastLevel | '') => void;
+}) {
+  return (
+    <>
+      <div>
+        <label className="block text-sm font-semibold text-gray-700 uppercase tracking-wide mb-2">
+          豆の名前 <span className="text-red-500">*</span>
+        </label>
+        <select
+          value={beanName}
+          onChange={(e) => {
+            onBeanNameChange(e.target.value as BeanName);
+          }}
+          className="w-full rounded-xl border-2 border-gray-200 px-4 py-3.5 text-base sm:text-lg text-gray-900 bg-gray-50 focus:border-amber-500 focus:bg-white focus:outline-none focus:ring-4 focus:ring-amber-100 transition-all duration-200 shadow-sm hover:border-gray-300 min-h-[52px]"
+        >
+          <option value="">選択してください</option>
+          {availableBeans.length > 0 ? (
+            availableBeans.map((bean) => (
+              <option key={bean} value={bean}>
+                {bean}
+              </option>
+            ))
+          ) : (
+            <option value="" disabled>
+              記録がありません（2件以上の記録が必要です）
+            </option>
+          )}
+        </select>
+      </div>
+
+      <div>
+        <label className="block text-sm font-semibold text-gray-700 uppercase tracking-wide mb-2">
+          焙煎度合い <span className="text-red-500">*</span>
+        </label>
+        <select
+          value={roastLevel}
+          onChange={(e) => onRoastLevelChange(e.target.value as RoastLevel | '')}
+          disabled={!beanName}
+          className="w-full rounded-xl border-2 border-gray-200 px-4 py-3.5 text-base sm:text-lg text-gray-900 bg-gray-50 focus:border-amber-500 focus:bg-white focus:outline-none focus:ring-4 focus:ring-amber-100 transition-all duration-200 shadow-sm hover:border-gray-300 min-h-[52px] disabled:bg-gray-100 disabled:cursor-not-allowed disabled:text-gray-400"
+        >
+          <option value="">選択してください</option>
+          {availableRoastLevels.length > 0 ? (
+            availableRoastLevels.map((level) => (
+              <option key={level} value={level}>
+                {level}
+              </option>
+            ))
+          ) : beanName ? (
+            <option value="" disabled>
+              記録がありません（2件以上の記録が必要です）
+            </option>
+          ) : (
+            <option value="" disabled>
+              豆を選択してください
+            </option>
+          )}
+        </select>
+      </div>
+
+      <div>
+        <label className="block text-sm font-semibold text-gray-700 uppercase tracking-wide mb-2">
+          重さ <span className="text-red-500">*</span>
+        </label>
+        <select
+          value={weight}
+          onChange={(e) =>
+            onWeightChange(e.target.value ? (parseInt(e.target.value, 10) as Weight) : '')
+          }
+          disabled={!beanName}
+          className="w-full rounded-xl border-2 border-gray-200 px-4 py-3.5 text-base sm:text-lg text-gray-900 bg-gray-50 focus:border-amber-500 focus:bg-white focus:outline-none focus:ring-4 focus:ring-amber-100 transition-all duration-200 shadow-sm hover:border-gray-300 min-h-[52px] disabled:bg-gray-100 disabled:cursor-not-allowed disabled:text-gray-400"
+        >
+          <option value="">選択してください</option>
+          {availableWeights.length > 0 ? (
+            availableWeights.map((w) => (
+              <option key={w} value={w}>
+                {w}g
+              </option>
+            ))
+          ) : beanName ? (
+            <option value="" disabled>
+              記録がありません（2件以上の記録が必要です）
+            </option>
+          ) : (
+            <option value="" disabled>
+              豆を選択してください
+            </option>
+          )}
+        </select>
+      </div>
+
+      {!recommendedTimeInfo && beanName && weight !== '' && roastLevel && (
+        <div className="bg-yellow-50 border-2 border-yellow-200 rounded-xl p-4 shadow-sm">
+          <p className="text-sm sm:text-base text-yellow-800">
+            この組み合わせの記録が2件未満のため、平均焙煎時間を計算できません。重さに応じたデフォルト時間（
+            {weight === 200 ? '8分' : weight === 300 ? '9分' : '10分'}）でタイマーを開始します。
+          </p>
+        </div>
+      )}
+
+      {recommendedTimeInfo && (
+        <div className="bg-gradient-to-br from-amber-50 to-amber-100 border-2 border-amber-200 rounded-xl p-4 shadow-sm">
+          <p className="text-sm sm:text-base text-gray-700">
+            過去の記録から、平均焙煎時間は{' '}
+            <span className="font-bold text-amber-800">
+              {formatTimeAsMinutesAndSeconds(recommendedTimeInfo.averageDuration)}
+            </span>
+            、おすすめタイマー時間は{' '}
+            <span className="font-bold text-amber-800">
+              {formatTimeAsMinutesAndSeconds(recommendedTimeInfo.recommendedDuration)}
+            </span>{' '}
+            です
+          </p>
+        </div>
+      )}
+    </>
+  );
+}

--- a/components/roast-timer/SetupPanel.tsx
+++ b/components/roast-timer/SetupPanel.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef } from 'react';
 import { useAuth } from '@/lib/auth';
 import { useAppData } from '@/hooks/useAppData';
 import { HiPlay } from 'react-icons/hi';
-import { MdTimer, MdLightbulb } from 'react-icons/md';
+import { MdTimer } from 'react-icons/md';
 import { useToastContext } from '@/components/Toast';
 import { ALL_BEANS, type BeanName } from '@/lib/beanConfig';
 import { loadRoastTimerSettings } from '@/lib/roastTimerSettings';
@@ -12,6 +12,8 @@ import { getAllRoastTimerRecords } from '@/lib/roastTimerRecords';
 import { formatTimeAsMinutesAndSeconds, calculateRecommendedTime } from '@/lib/roastTimerUtils';
 import { ROAST_LEVELS, WEIGHTS, DEFAULT_DURATIONS as DEFAULT_DURATION_BY_WEIGHT, type RoastLevel, type Weight } from '@/lib/constants';
 import { convertToHalfWidth, removeNonNumeric } from '@/lib/utils';
+import { ModeSelectView } from './ModeSelectView';
+import { RecommendedModeView } from './RecommendedModeView';
 
 interface SetupPanelProps {
   onStart: (
@@ -310,11 +312,19 @@ export function SetupPanel({ onStart, isLoading }: SetupPanelProps) {
     }
   };
 
-  // 戻るハンドラー
-  const handleBack = () => {
-    setInputMode(null);
-    setRecommendedMode('weight');
-    setBeanName('');
+  // おすすめモード切り替え
+  const handleRecommendedModeChange = (mode: 'weight' | 'history') => {
+    if (mode === 'weight') {
+      setBeanName('');
+      setRoastLevel('');
+      setRecommendedTimeInfo(null);
+    }
+    setRecommendedMode(mode);
+  };
+
+  // 豆名変更
+  const handleBeanNameChange = (value: BeanName | '') => {
+    setBeanName(value);
     setWeight('');
     setRoastLevel('');
   };
@@ -322,83 +332,25 @@ export function SetupPanel({ onStart, isLoading }: SetupPanelProps) {
   // モード選択画面
   if (inputMode === null) {
     return (
-      <div className="flex-1 flex flex-col items-center justify-center px-4 sm:px-6 py-8">
-        {/* タイトルセクション */}
-        <div className="text-center space-y-4 mb-10 sm:mb-12">
-          <div className="inline-flex items-center justify-center w-20 h-20 sm:w-24 sm:h-24 rounded-full bg-gradient-to-br from-amber-400 to-amber-600 shadow-lg mb-3">
-            <MdTimer className="text-white text-4xl sm:text-5xl" />
-          </div>
-          <h3 className="text-3xl sm:text-4xl font-bold text-gray-900 tracking-tight">
-            ローストタイマー
-          </h3>
-          <p className="text-base sm:text-lg text-gray-500">焙煎時間を設定してスタート</p>
-        </div>
-
-        {/* 手動入力フィールド */}
-        <div className="space-y-4 max-w-md mx-auto w-full mb-8 sm:mb-10">
-          <label className="block text-sm sm:text-base font-semibold text-gray-700 uppercase tracking-wide">
-            時間設定
-          </label>
-          <div className="flex gap-3 sm:gap-4">
-            <div className="flex-1">
-              <input
-                type="text"
-                inputMode="numeric"
-                value={durationMinutes}
-                onChange={(e) => handleDurationMinutesChange(e.target.value)}
-                placeholder="分"
-                className="w-full rounded-lg border-2 border-gray-200 px-4 py-3.5 sm:py-4 text-lg sm:text-xl text-gray-900 bg-white focus:border-amber-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-amber-100 transition-all duration-200 font-semibold text-center min-h-[56px] shadow-sm hover:border-gray-300"
-              />
-            </div>
-            <div className="flex items-end pb-2">
-              <span className="text-3xl font-bold text-gray-400">:</span>
-            </div>
-            <div className="flex-1">
-              <input
-                type="text"
-                inputMode="numeric"
-                value={durationSeconds}
-                onChange={(e) => handleDurationSecondsChange(e.target.value)}
-                placeholder="秒"
-                maxLength={2}
-                className="w-full rounded-lg border-2 border-gray-200 px-4 py-3.5 sm:py-4 text-lg sm:text-xl text-gray-900 bg-white focus:border-amber-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-amber-100 transition-all duration-200 font-semibold text-center min-h-[56px] shadow-sm hover:border-gray-300"
-              />
-            </div>
-          </div>
-        </div>
-
-        {/* ボタンセクション */}
-        <div className="space-y-3 sm:space-y-4 max-w-md mx-auto w-full">
-          {/* 手動スタートボタン */}
-          <button
-            onClick={handleManualStart}
-            disabled={
-              ((!durationMinutes || durationMinutes.trim() === '') &&
-                (!durationSeconds || durationSeconds.trim() === '')) ||
-              !user ||
-              isLoading
-            }
-            className="w-full flex items-center justify-center gap-2 px-6 py-4 sm:py-5 bg-gradient-to-r from-amber-500 to-amber-600 text-white rounded-xl font-bold text-base sm:text-lg shadow-lg hover:shadow-xl hover:from-amber-600 hover:to-amber-700 active:scale-[0.98] transition-all duration-200 min-h-[60px] sm:min-h-[64px] disabled:from-gray-300 disabled:to-gray-400 disabled:cursor-not-allowed disabled:hover:shadow-lg disabled:active:scale-100 disabled:hover:from-gray-300 disabled:hover:to-gray-400"
-          >
-            <HiPlay className="text-xl sm:text-2xl" />
-            <span>手動でタイマースタート</span>
-          </button>
-
-          {/* おすすめ焙煎ボタン */}
-          <button
-            onClick={() => {
-              setDurationMinutes('');
-              setDurationSeconds('');
-              setRecommendedMode('weight');
-              setInputMode('recommended');
-            }}
-            className="w-full flex items-center justify-center gap-2 px-6 py-4 sm:py-5 bg-gradient-to-r from-amber-50 to-amber-100 text-amber-700 border-2 border-amber-200 rounded-xl font-bold text-base sm:text-lg shadow-sm hover:shadow-md hover:from-amber-100 hover:to-amber-200 hover:border-amber-300 active:scale-[0.98] transition-all duration-200 min-h-[60px] sm:min-h-[64px]"
-          >
-            <MdLightbulb className="text-xl sm:text-2xl text-amber-600" />
-            <span>おすすめタイマー</span>
-          </button>
-        </div>
-      </div>
+      <ModeSelectView
+        durationMinutes={durationMinutes}
+        durationSeconds={durationSeconds}
+        onDurationMinutesChange={handleDurationMinutesChange}
+        onDurationSecondsChange={handleDurationSecondsChange}
+        onManualStart={handleManualStart}
+        onRecommendedMode={() => {
+          setDurationMinutes('');
+          setDurationSeconds('');
+          setRecommendedMode('weight');
+          setInputMode('recommended');
+        }}
+        isStartDisabled={
+          ((!durationMinutes || durationMinutes.trim() === '') &&
+            (!durationSeconds || durationSeconds.trim() === '')) ||
+          !user ||
+          isLoading
+        }
+      />
     );
   }
 
@@ -470,217 +422,22 @@ export function SetupPanel({ onStart, isLoading }: SetupPanelProps) {
 
   // おすすめモード
   return (
-    <div className="flex-1 flex flex-col px-4 sm:px-6">
-      <div className="max-w-md mx-auto w-full flex-1 flex flex-col justify-center py-8">
-        <div className="flex items-center justify-center mb-6 flex-shrink-0">
-          <h3 className="text-xl sm:text-2xl font-bold text-gray-900 flex items-center gap-2">
-            <div className="w-8 h-8 rounded-full bg-gradient-to-br from-amber-400 to-amber-600 flex items-center justify-center">
-              <MdLightbulb className="text-white text-lg" />
-            </div>
-            おすすめタイマー
-          </h3>
-        </div>
-
-        {/* モード切り替えタブ */}
-        <div className="mb-6 flex-shrink-0">
-          <div className="flex gap-2 bg-gray-100 rounded-lg p-1">
-            <button
-              onClick={() => {
-                setRecommendedMode('weight');
-                setBeanName('');
-                setRoastLevel('');
-                setRecommendedTimeInfo(null);
-              }}
-              className={`flex-1 px-4 py-2.5 rounded-md text-sm sm:text-base font-semibold transition-all duration-200 ${
-                recommendedMode === 'weight'
-                  ? 'bg-white text-amber-700 shadow-sm'
-                  : 'text-gray-600 hover:text-gray-900'
-              }`}
-            >
-              重さで設定
-            </button>
-            <button
-              onClick={() => {
-                setRecommendedMode('history');
-              }}
-              className={`flex-1 px-4 py-2.5 rounded-md text-sm sm:text-base font-semibold transition-all duration-200 ${
-                recommendedMode === 'history'
-                  ? 'bg-white text-amber-700 shadow-sm'
-                  : 'text-gray-600 hover:text-gray-900'
-              }`}
-            >
-              過去の記録から設定
-            </button>
-          </div>
-        </div>
-
-        <div className="space-y-5 flex-1">
-          {recommendedMode === 'weight' && (
-            <>
-              <div>
-                <label className="block text-sm font-semibold text-gray-700 uppercase tracking-wide mb-2">
-                  重さ <span className="text-red-500">*</span>
-                </label>
-                <select
-                  value={weight}
-                  onChange={(e) =>
-                    setWeight(e.target.value ? (parseInt(e.target.value, 10) as Weight) : '')
-                  }
-                  className="w-full rounded-xl border-2 border-gray-200 px-4 py-3.5 text-base sm:text-lg text-gray-900 bg-gray-50 focus:border-amber-500 focus:bg-white focus:outline-none focus:ring-4 focus:ring-amber-100 transition-all duration-200 shadow-sm hover:border-gray-300 min-h-[52px]"
-                >
-                  <option value="">選択してください</option>
-                  {WEIGHTS.map((w) => (
-                    <option key={w} value={w}>
-                      {w}g
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              {weight !== '' && (
-                <div className="bg-gradient-to-br from-amber-50 to-amber-100 border-2 border-amber-200 rounded-xl p-4 shadow-sm">
-                  <p className="text-sm sm:text-base text-gray-700">
-                    重さに応じたおすすめ時間は{' '}
-                    <span className="font-bold text-amber-800">
-                      {weight === 200 ? '8分' : weight === 300 ? '9分' : '10分'}
-                    </span>{' '}
-                    です
-                  </p>
-                </div>
-              )}
-            </>
-          )}
-
-          {recommendedMode === 'history' && (
-            <>
-              <div>
-                <label className="block text-sm font-semibold text-gray-700 uppercase tracking-wide mb-2">
-                  豆の名前 <span className="text-red-500">*</span>
-                </label>
-                <select
-                  value={beanName}
-                  onChange={(e) => {
-                    setBeanName(e.target.value as BeanName);
-                    setWeight('');
-                    setRoastLevel('');
-                  }}
-                  className="w-full rounded-xl border-2 border-gray-200 px-4 py-3.5 text-base sm:text-lg text-gray-900 bg-gray-50 focus:border-amber-500 focus:bg-white focus:outline-none focus:ring-4 focus:ring-amber-100 transition-all duration-200 shadow-sm hover:border-gray-300 min-h-[52px]"
-                >
-                  <option value="">選択してください</option>
-                  {availableBeans.length > 0 ? (
-                    availableBeans.map((bean) => (
-                      <option key={bean} value={bean}>
-                        {bean}
-                      </option>
-                    ))
-                  ) : (
-                    <option value="" disabled>
-                      記録がありません（2件以上の記録が必要です）
-                    </option>
-                  )}
-                </select>
-              </div>
-
-              <div>
-                <label className="block text-sm font-semibold text-gray-700 uppercase tracking-wide mb-2">
-                  焙煎度合い <span className="text-red-500">*</span>
-                </label>
-                <select
-                  value={roastLevel}
-                  onChange={(e) => setRoastLevel(e.target.value as RoastLevel | '')}
-                  disabled={!beanName}
-                  className="w-full rounded-xl border-2 border-gray-200 px-4 py-3.5 text-base sm:text-lg text-gray-900 bg-gray-50 focus:border-amber-500 focus:bg-white focus:outline-none focus:ring-4 focus:ring-amber-100 transition-all duration-200 shadow-sm hover:border-gray-300 min-h-[52px] disabled:bg-gray-100 disabled:cursor-not-allowed disabled:text-gray-400"
-                >
-                  <option value="">選択してください</option>
-                  {availableRoastLevels.length > 0 ? (
-                    availableRoastLevels.map((level) => (
-                      <option key={level} value={level}>
-                        {level}
-                      </option>
-                    ))
-                  ) : beanName ? (
-                    <option value="" disabled>
-                      記録がありません（2件以上の記録が必要です）
-                    </option>
-                  ) : (
-                    <option value="" disabled>
-                      豆を選択してください
-                    </option>
-                  )}
-                </select>
-              </div>
-
-              <div>
-                <label className="block text-sm font-semibold text-gray-700 uppercase tracking-wide mb-2">
-                  重さ <span className="text-red-500">*</span>
-                </label>
-                <select
-                  value={weight}
-                  onChange={(e) =>
-                    setWeight(e.target.value ? (parseInt(e.target.value, 10) as Weight) : '')
-                  }
-                  disabled={!beanName}
-                  className="w-full rounded-xl border-2 border-gray-200 px-4 py-3.5 text-base sm:text-lg text-gray-900 bg-gray-50 focus:border-amber-500 focus:bg-white focus:outline-none focus:ring-4 focus:ring-amber-100 transition-all duration-200 shadow-sm hover:border-gray-300 min-h-[52px] disabled:bg-gray-100 disabled:cursor-not-allowed disabled:text-gray-400"
-                >
-                  <option value="">選択してください</option>
-                  {availableWeights.length > 0 ? (
-                    availableWeights.map((w) => (
-                      <option key={w} value={w}>
-                        {w}g
-                      </option>
-                    ))
-                  ) : beanName ? (
-                    <option value="" disabled>
-                      記録がありません（2件以上の記録が必要です）
-                    </option>
-                  ) : (
-                    <option value="" disabled>
-                      豆を選択してください
-                    </option>
-                  )}
-                </select>
-              </div>
-
-              {!recommendedTimeInfo && beanName && weight !== '' && roastLevel && (
-                <div className="bg-yellow-50 border-2 border-yellow-200 rounded-xl p-4 shadow-sm">
-                  <p className="text-sm sm:text-base text-yellow-800">
-                    この組み合わせの記録が2件未満のため、平均焙煎時間を計算できません。重さに応じたデフォルト時間（
-                    {weight === 200 ? '8分' : weight === 300 ? '9分' : '10分'}）でタイマーを開始します。
-                  </p>
-                </div>
-              )}
-
-              {recommendedTimeInfo && (
-                <div className="bg-gradient-to-br from-amber-50 to-amber-100 border-2 border-amber-200 rounded-xl p-4 shadow-sm">
-                  <p className="text-sm sm:text-base text-gray-700">
-                    過去の記録から、平均焙煎時間は{' '}
-                    <span className="font-bold text-amber-800">
-                      {formatTimeAsMinutesAndSeconds(recommendedTimeInfo.averageDuration)}
-                    </span>
-                    、おすすめタイマー時間は{' '}
-                    <span className="font-bold text-amber-800">
-                      {formatTimeAsMinutesAndSeconds(recommendedTimeInfo.recommendedDuration)}
-                    </span>{' '}
-                    です
-                  </p>
-                </div>
-              )}
-            </>
-          )}
-
-          <div className="pt-2 flex-shrink-0">
-            <button
-              onClick={handleStart}
-              disabled={!weight || (recommendedMode === 'history' && (!beanName || !roastLevel))}
-              className="w-full flex items-center justify-center gap-3 px-6 py-4 bg-gradient-to-r from-amber-500 to-amber-600 text-white rounded-xl font-bold shadow-lg hover:shadow-xl hover:from-amber-600 hover:to-amber-700 active:scale-[0.98] transition-all duration-200 text-base sm:text-lg min-h-[56px] disabled:from-gray-300 disabled:to-gray-400 disabled:cursor-not-allowed disabled:hover:shadow-lg disabled:active:scale-100 disabled:hover:from-gray-300 disabled:hover:to-gray-400"
-            >
-              <HiPlay className="text-2xl" />
-              <span>スタート</span>
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
+    <RecommendedModeView
+      recommendedMode={recommendedMode}
+      beanName={beanName}
+      weight={weight}
+      roastLevel={roastLevel}
+      availableBeans={availableBeans}
+      availableWeights={availableWeights}
+      availableRoastLevels={availableRoastLevels}
+      recommendedTimeInfo={recommendedTimeInfo}
+      onRecommendedModeChange={handleRecommendedModeChange}
+      onBeanNameChange={handleBeanNameChange}
+      onWeightChange={setWeight}
+      onRoastLevelChange={setRoastLevel}
+      onStart={handleStart}
+      isStartDisabled={!weight || (recommendedMode === 'history' && (!beanName || !roastLevel))}
+    />
   );
 }
 

--- a/hooks/roast-timer/audioUnlocker.ts
+++ b/hooks/roast-timer/audioUnlocker.ts
@@ -1,0 +1,125 @@
+/**
+ * 音声ファイルの準備・アンロックヘルパー
+ * iOS等の自動再生制限を回避するため、無音再生でアンロックする
+ */
+
+/** 音声パスを解決する */
+export function resolveAudioPath(path: string): string {
+  const audioPath = path.startsWith('/') ? path : `/${path}`;
+  const version = process.env.NEXT_PUBLIC_APP_VERSION || '0.5.5';
+  return `${audioPath}?v=${version}`;
+}
+
+interface AudioErrorDetails {
+  code?: number;
+  message?: string;
+  path: string;
+  readyState?: number;
+  networkState?: number;
+  MEDIA_ERR_ABORTED?: number;
+  MEDIA_ERR_NETWORK?: number;
+  MEDIA_ERR_DECODE?: number;
+  MEDIA_ERR_SRC_NOT_SUPPORTED?: number;
+}
+
+/**
+ * 音声ファイルを準備してアンロックする
+ * @param soundFile 音声ファイルパス
+ * @param defaultSoundFile フォールバック用デフォルトファイル
+ * @param volume 音量 (0-1)
+ * @param label ログ用ラベル（例: 'Timer', 'Notification'）
+ * @returns 準備済みの HTMLAudioElement、または失敗時は null
+ */
+export async function prepareAndUnlockAudio(
+  soundFile: string,
+  defaultSoundFile: string,
+  volume: number,
+  label: string
+): Promise<HTMLAudioElement | null> {
+  let audioPath = resolveAudioPath(soundFile);
+  let audio = new Audio(audioPath);
+  let hasError = false;
+  let usedFallback = false;
+  let errorDetails: AudioErrorDetails | null = null;
+
+  const createErrorHandler = (target: HTMLAudioElement, path: string) => () => {
+    hasError = true;
+    const error = target.error;
+    if (error) {
+      errorDetails = {
+        code: error.code,
+        message: error.message,
+        path,
+        MEDIA_ERR_ABORTED: error.MEDIA_ERR_ABORTED,
+        MEDIA_ERR_NETWORK: error.MEDIA_ERR_NETWORK,
+        MEDIA_ERR_DECODE: error.MEDIA_ERR_DECODE,
+        MEDIA_ERR_SRC_NOT_SUPPORTED: error.MEDIA_ERR_SRC_NOT_SUPPORTED,
+      };
+    } else {
+      errorDetails = {
+        path,
+        readyState: target.readyState,
+        networkState: target.networkState,
+      };
+    }
+    console.error(`[RoastTimer] ${label} audio loading error:`, errorDetails);
+  };
+
+  let errorHandler: (() => void) | null = createErrorHandler(audio, audioPath);
+  audio.addEventListener('error', errorHandler);
+
+  // エラーイベントを待つための短い待機
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  if (hasError) {
+    audio.removeEventListener('error', errorHandler);
+    errorHandler = null;
+
+    // デフォルトファイルで再試行(元ファイルと異なる場合のみ)
+    if (soundFile !== defaultSoundFile) {
+      audioPath = resolveAudioPath(defaultSoundFile);
+      audio = new Audio(audioPath);
+      usedFallback = true;
+      hasError = false;
+      errorDetails = null;
+      errorHandler = createErrorHandler(audio, audioPath);
+      audio.addEventListener('error', errorHandler);
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      if (hasError) {
+        audio.removeEventListener('error', errorHandler);
+        console.error(`[RoastTimer] Fallback ${label.toLowerCase()} audio loading failed:`, errorDetails);
+        return null;
+      }
+    } else {
+      console.error(`[RoastTimer] Default ${label.toLowerCase()} audio failed, skipping unlock`);
+      return null;
+    }
+  }
+
+  // 無音で再生しアンロック
+  audio.volume = 0;
+  audio.muted = true;
+
+  try {
+    await audio.play();
+    audio.pause();
+    audio.currentTime = 0;
+
+    audio.muted = false;
+    audio.volume = Math.max(0, Math.min(1, volume));
+
+    if (errorHandler) {
+      audio.removeEventListener('error', errorHandler);
+    }
+    console.log(`[RoastTimer] ${label} sound prepared and unlocked`, usedFallback ? '(fallback)' : '');
+    return audio;
+  } catch (playError) {
+    if (errorHandler) {
+      audio.removeEventListener('error', errorHandler);
+    }
+    console.error(`[RoastTimer] Failed to play ${label.toLowerCase()} audio for unlock:`, playError);
+    return null;
+  }
+}

--- a/hooks/roast-timer/useTimerControls.ts
+++ b/hooks/roast-timer/useTimerControls.ts
@@ -1,18 +1,16 @@
 'use client';
 
-import { useEffect, useCallback } from 'react';
+import { useCallback } from 'react';
 import type { AppData, RoastTimerState } from '@/types';
 import { setRoastTimerState as saveLocalState } from '@/lib/localStorage';
-import { playTimerSound, stopAllSounds, stopAudio } from '@/lib/sounds';
-import { loadRoastTimerSettings } from '@/lib/roastTimerSettings';
-import { getSyncedTimestamp, getSyncedTimestampSync, getSyncedIsoString } from '@/lib/timeSync';
+import { stopAllSounds, stopAudio } from '@/lib/sounds';
+import { getSyncedTimestamp, getSyncedTimestampSync } from '@/lib/timeSync';
 import { calculateElapsedTime } from './useTimerState';
 import type { UseTimerStateReturn } from './useTimerState';
 import type { UseTimerNotificationsReturn } from './useTimerNotifications';
+import { useTimerUpdater } from './useTimerUpdater';
 
 type UpdateAppDataFn = (newDataOrUpdater: AppData | ((currentData: AppData) => AppData)) => Promise<void>;
-
-const UPDATE_INTERVAL = 250; // 250msごとに更新（CSS transitionと同期）
 
 export interface UseTimerControlsArgs {
   user: { uid: string } | null;
@@ -39,8 +37,7 @@ export interface UseTimerControlsReturn {
 /**
  * タイマー操作フック
  * - タイマーの開始/一時停止/再開/スキップ/リセット
- * - タイマー完了処理
- * - 定期更新とバックグラウンド復帰時の処理
+ * - 定期更新とバックグラウンド復帰は useTimerUpdater に委譲
  */
 export function useTimerControls({
   user,
@@ -53,8 +50,6 @@ export function useTimerControls({
   const {
     localState,
     setLocalState,
-    localStateRef,
-    intervalRef,
     lastUpdateRef,
     pausedElapsedRef,
     hasResetRef,
@@ -62,196 +57,19 @@ export function useTimerControls({
 
   const {
     soundAudioRef,
-    preparedTimerAudioRef,
     prepareTimerSound,
     prepareNotificationSound,
-    playNotificationSoundFromRef,
   } = notifications;
 
-  // タイマー完了処理
-  const completeTimer = useCallback(async (currentState: RoastTimerState) => {
-    // インターバルを即座に停止(重複実行を防ぐ)
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
-    }
-
-    const updatedState: RoastTimerState = {
-      ...currentState,
-      status: 'completed',
-      remaining: 0,
-      elapsed: currentState.duration,
-      completedByDeviceId: currentDeviceId,
-      dialogState: 'completion', // 完了ダイアログを表示
-      lastUpdatedAt: getSyncedIsoString(),
-    };
-
-    // アラーム音を再生(タイマー音)
-    try {
-      const settings = await loadRoastTimerSettings();
-
-      if (settings.timerSoundEnabled) {
-        if (preparedTimerAudioRef.current) {
-          try {
-            // 既存の音声を停止してから再生
-            if (soundAudioRef.current && soundAudioRef.current !== preparedTimerAudioRef.current) {
-              stopAudio(soundAudioRef.current);
-            }
-            preparedTimerAudioRef.current.currentTime = 0;
-            await preparedTimerAudioRef.current.play();
-            soundAudioRef.current = preparedTimerAudioRef.current;
-            console.log('[RoastTimer] Timer sound played from prepared ref');
-          } catch (err) {
-            console.error('[RoastTimer] Failed to play prepared timer audio, fallback', err);
-            const audio = await playTimerSound(settings.timerSoundFile, settings.timerSoundVolume);
-            soundAudioRef.current = audio;
-          }
-        } else {
-          const audio = await playTimerSound(settings.timerSoundFile, settings.timerSoundVolume);
-          soundAudioRef.current = audio;
-        }
-      }
-
-      // 通知音は通知設定に基づき独立判定で再生
-      // ただし、タイマー音と通知音が同じファイルの場合は重複再生を避けるためスキップ
-      if (settings.notificationSoundEnabled && settings.timerSoundFile !== settings.notificationSoundFile) {
-        void playNotificationSoundFromRef();
-      }
-    } catch (error) {
-      console.error('Failed to play timer/notification sound:', error);
-    }
-
-    // ローカル状態を即座に更新(同期処理として扱う)
-    saveLocalState(updatedState);
-    // 状態を同期的に更新(次のupdateTimerが実行される前に完了状態にする)
-    setLocalState(updatedState);
-
-    // Firestoreに完了状態を保存
-    try {
-      await updateData((currentData) => ({
-        ...currentData,
-        roastTimerState: updatedState,
-      }));
-    } catch (error) {
-      console.error('Failed to save roast timer state to Firestore:', error);
-    }
-  }, [currentDeviceId, updateData, playNotificationSoundFromRef, intervalRef, setLocalState, soundAudioRef, preparedTimerAudioRef]);
-
-  // タイマーの更新処理(開始時刻ベースで計算)
-  const updateTimer = useCallback(async () => {
-    // 最新のlocalStateを取得
-    const currentState = localStateRef.current;
-    if (!currentState || !user || isLoading) {
-      return;
-    }
-
-    // 既に完了している場合は何もしない
-    if (currentState.status === 'completed') {
-      return;
-    }
-
-    if (currentState.status === 'running' && currentState.startedAt) {
-      const pausedElapsed = currentState.pausedElapsed ?? pausedElapsedRef.current ?? 0;
-      pausedElapsedRef.current = pausedElapsed;
-      // 開始時刻から経過時間を計算
-      const elapsed = calculateElapsedTime(
-        currentState.startedAt,
-        currentState.pausedAt,
-        pausedElapsed,
-        currentState.status
-      );
-      const remaining = Math.max(0, currentState.duration - elapsed);
-
-      // タイマーが完了した場合
-      if (remaining <= 0) {
-        // completeTimer内でインターバルを停止するため、ここでは停止しない
-        await completeTimer(currentState);
-        return;
-      }
-
-      // React状態更新は1秒ごとに制限（テキスト同期・完了判定用）
-      // プログレスバーのアニメーションはTimerDisplayのrAFで60fps処理
-      const now = Date.now();
-      if (!lastUpdateRef.current || now - lastUpdateRef.current >= 1000) {
-        const updatedState: RoastTimerState = {
-          ...currentState,
-          pausedElapsed,
-          elapsed,
-          remaining,
-          lastUpdatedAt: getSyncedIsoString(),
-        };
-        setLocalState(updatedState);
-        lastUpdateRef.current = now;
-      }
-    }
-  }, [user, isLoading, completeTimer]);
-
-  // タイマーの定期更新(UI表示用)
-  useEffect(() => {
-    if (localState?.status === 'running') {
-      // 既存のインターバルをクリア
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
-      intervalRef.current = setInterval(updateTimer, UPDATE_INTERVAL);
-      lastUpdateRef.current = Date.now();
-    } else {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
-    }
-
-    return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
-    };
-  }, [localState?.status, updateTimer]);
-
-  // ページの可視性変更を監視(バックグラウンドから復帰時に状態を更新)
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === 'visible' && localState?.status === 'running' && localState.startedAt) {
-        // ページが表示された時、開始時刻から経過時間を再計算
-        const pausedElapsed = localState.pausedElapsed ?? pausedElapsedRef.current ?? 0;
-        pausedElapsedRef.current = pausedElapsed;
-        const elapsed = calculateElapsedTime(
-          localState.startedAt,
-          localState.pausedAt,
-          pausedElapsed,
-          localState.status
-        );
-        const remaining = Math.max(0, localState.duration - elapsed);
-
-        // タイマーが完了している場合
-        if (remaining <= 0) {
-          completeTimer(localState);
-          return;
-        }
-
-        const updatedState: RoastTimerState = {
-          ...localState,
-          pausedElapsed,
-          elapsed,
-          remaining,
-          lastUpdatedAt: getSyncedIsoString(),
-        };
-
-        // LocalStorageへの保存は不要（重要イベント時のみ保存）
-        setLocalState(updatedState);
-      }
-    };
-
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-    return () => {
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
-    };
-  }, [localState, user, completeTimer]);
+  // タイマー更新処理（定期更新・バックグラウンド復帰・完了処理）
+  const { completeTimer } = useTimerUpdater({
+    user,
+    updateData,
+    isLoading,
+    stateManager,
+    notifications,
+    currentDeviceId,
+  });
 
   // タイマーを開始
   const startTimer = useCallback(

--- a/hooks/roast-timer/useTimerNotifications.ts
+++ b/hooks/roast-timer/useTimerNotifications.ts
@@ -3,6 +3,7 @@
 import { useRef, useCallback } from 'react';
 import { playNotificationSound, stopAllSounds } from '@/lib/sounds';
 import { loadRoastTimerSettings } from '@/lib/roastTimerSettings';
+import { prepareAndUnlockAudio } from './audioUnlocker';
 
 export interface UseTimerNotificationsReturn {
   soundAudioRef: React.MutableRefObject<HTMLAudioElement | null>;
@@ -24,13 +25,6 @@ export function useTimerNotifications(): UseTimerNotificationsReturn {
   const notificationAudioRef = useRef<HTMLAudioElement | null>(null);
   const preparedTimerAudioRef = useRef<HTMLAudioElement | null>(null);
 
-  // 音声ファイルのパスを解決するヘルパー
-  const resolveAudioPath = useCallback((path: string) => {
-    const audioPath = path.startsWith('/') ? path : `/${path}`;
-    const version = process.env.NEXT_PUBLIC_APP_VERSION || '0.5.5';
-    return `${audioPath}?v=${version}`;
-  }, []);
-
   // タイマー音の準備(アンロック)を行う
   const prepareTimerSound = useCallback(async () => {
     try {
@@ -45,109 +39,21 @@ export function useTimerNotifications(): UseTimerNotificationsReturn {
         return;
       }
 
-      const DEFAULT_SOUND_FILE = settings.timerSoundFile || '/sounds/roasttimer/alarm.mp3';
+      const defaultFile = settings.timerSoundFile || '/sounds/roasttimer/alarm.mp3';
+      const audio = await prepareAndUnlockAudio(
+        settings.timerSoundFile,
+        defaultFile,
+        settings.timerSoundVolume,
+        'Timer'
+      );
 
-      let audioPath = resolveAudioPath(settings.timerSoundFile);
-      let audio = new Audio(audioPath);
-      let hasError = false;
-      let usedFallback = false;
-      let errorDetails:
-        | {
-            code?: number;
-            message?: string;
-            path: string;
-            readyState?: number;
-            networkState?: number;
-            MEDIA_ERR_ABORTED?: number;
-            MEDIA_ERR_NETWORK?: number;
-            MEDIA_ERR_DECODE?: number;
-            MEDIA_ERR_SRC_NOT_SUPPORTED?: number;
-          }
-        | null = null;
-
-      const attachErrorLogger = (target: HTMLAudioElement, path: string) => () => {
-        hasError = true;
-        const error = target.error;
-        if (error) {
-          errorDetails = {
-            code: error.code,
-            message: error.message,
-            path,
-            MEDIA_ERR_ABORTED: error.MEDIA_ERR_ABORTED,
-            MEDIA_ERR_NETWORK: error.MEDIA_ERR_NETWORK,
-            MEDIA_ERR_DECODE: error.MEDIA_ERR_DECODE,
-            MEDIA_ERR_SRC_NOT_SUPPORTED: error.MEDIA_ERR_SRC_NOT_SUPPORTED,
-          };
-        } else {
-          errorDetails = {
-            path,
-            readyState: target.readyState,
-            networkState: target.networkState,
-          };
-        }
-        console.error('[RoastTimer] Timer audio loading error:', errorDetails);
-      };
-
-      let errorHandler: ((e: Event) => void) | null = attachErrorLogger(audio, audioPath);
-      audio.addEventListener('error', errorHandler);
-
-      // エラーイベントを待つための短い待機
-      await new Promise((resolve) => setTimeout(resolve, 100));
-
-      if (hasError) {
-        audio.removeEventListener('error', errorHandler);
-        errorHandler = null;
-
-        // デフォルトファイルで再試行(元ファイルと異なる場合のみ)
-        if (settings.timerSoundFile !== DEFAULT_SOUND_FILE) {
-          audioPath = resolveAudioPath(DEFAULT_SOUND_FILE);
-          audio = new Audio(audioPath);
-          usedFallback = true;
-          hasError = false;
-          errorDetails = null;
-          errorHandler = attachErrorLogger(audio, audioPath);
-          audio.addEventListener('error', errorHandler);
-
-          await new Promise((resolve) => setTimeout(resolve, 100));
-
-          if (hasError) {
-            audio.removeEventListener('error', errorHandler);
-            console.error('[RoastTimer] Fallback timer audio loading failed:', errorDetails);
-            return;
-          }
-        } else {
-          console.error('[RoastTimer] Default timer audio failed, skipping unlock');
-          return;
-        }
-      }
-
-      // 無音で再生しアンロック
-      audio.volume = 0;
-      audio.muted = true;
-
-      try {
-        await audio.play();
-        audio.pause();
-        audio.currentTime = 0;
-
-        audio.muted = false;
-        audio.volume = Math.max(0, Math.min(1, settings.timerSoundVolume));
-
-        if (errorHandler) {
-          audio.removeEventListener('error', errorHandler);
-        }
+      if (audio) {
         preparedTimerAudioRef.current = audio;
-        console.log('[RoastTimer] Timer sound prepared and unlocked', usedFallback ? '(fallback)' : '');
-      } catch (playError) {
-        if (errorHandler) {
-          audio.removeEventListener('error', errorHandler);
-        }
-        console.error('[RoastTimer] Failed to play timer audio for unlock:', playError);
       }
     } catch (error) {
       console.error('[RoastTimer] Failed to prepare timer sound:', error);
     }
-  }, [resolveAudioPath]);
+  }, []);
 
   // 通知音の準備(アンロック)を行う
   const prepareNotificationSound = useCallback(async () => {
@@ -158,154 +64,27 @@ export function useTimerNotifications(): UseTimerNotificationsReturn {
         return;
       }
 
-      // フォールバック用のデフォルトファイルパス
-      const DEFAULT_SOUND_FILE = settings.notificationSoundFile || '/sounds/roasttimer/alarm.mp3';
+      // 既存のAudioがあれば破棄
+      if (notificationAudioRef.current) {
+        notificationAudioRef.current.pause();
+        notificationAudioRef.current = null;
+      }
 
-      try {
-        // 既存のAudioがあれば破棄
-        if (notificationAudioRef.current) {
-          notificationAudioRef.current.pause();
-          notificationAudioRef.current = null;
-        }
+      const defaultFile = settings.notificationSoundFile || '/sounds/roasttimer/alarm.mp3';
+      const audio = await prepareAndUnlockAudio(
+        settings.notificationSoundFile,
+        defaultFile,
+        settings.notificationSoundVolume,
+        'Notification'
+      );
 
-        let audioPath = resolveAudioPath(settings.notificationSoundFile);
-        let audio = new Audio(audioPath);
-
-        // エラーフラグを設定
-        let hasError = false;
-        let usedFallback = false;
-        let errorDetails: {
-          code?: number;
-          message?: string;
-          path: string;
-          MEDIA_ERR_ABORTED?: number;
-          MEDIA_ERR_NETWORK?: number;
-          MEDIA_ERR_DECODE?: number;
-          MEDIA_ERR_SRC_NOT_SUPPORTED?: number;
-          readyState?: number;
-          networkState?: number;
-        } | null = null;
-
-        // エラーハンドリング
-        let errorHandler: (() => void) | null = null;
-        let fallbackErrorHandler: (() => void) | null = null;
-
-        errorHandler = () => {
-          hasError = true;
-          const error = audio.error;
-          if (error) {
-            errorDetails = {
-              code: error.code,
-              message: error.message,
-              path: audioPath,
-              MEDIA_ERR_ABORTED: error.MEDIA_ERR_ABORTED,
-              MEDIA_ERR_NETWORK: error.MEDIA_ERR_NETWORK,
-              MEDIA_ERR_DECODE: error.MEDIA_ERR_DECODE,
-              MEDIA_ERR_SRC_NOT_SUPPORTED: error.MEDIA_ERR_SRC_NOT_SUPPORTED,
-            };
-            console.error('[RoastTimer] Audio loading error:', errorDetails);
-            console.error('[RoastTimer] Failed to load audio file:', audioPath);
-          } else {
-            errorDetails = {
-              path: audioPath,
-              readyState: audio.readyState,
-              networkState: audio.networkState,
-            };
-            console.error('[RoastTimer] Audio error event fired but no error details available', errorDetails);
-          }
-        };
-        audio.addEventListener('error', errorHandler);
-
-        // エラーが発生した場合は、play()を試みない
-        // ただし、エラーイベントは非同期で発火する可能性があるため、
-        // 短い待機時間を設けてからエラーチェックを行う
-        await new Promise((resolve) => setTimeout(resolve, 100));
-
-        // エラーが発生した場合、デフォルトファイルにフォールバック
-        if (hasError) {
-          console.warn('[RoastTimer] Audio loading failed, trying fallback file. Error:', errorDetails);
-          audio.removeEventListener('error', errorHandler);
-
-          // デフォルトファイルが元のファイルと同じ場合は、フォールバックしない
-          if (settings.notificationSoundFile === DEFAULT_SOUND_FILE) {
-            console.error('[RoastTimer] Default sound file also failed, skipping unlock');
-            return;
-          }
-
-          // デフォルトファイルで再試行
-          audioPath = resolveAudioPath(DEFAULT_SOUND_FILE);
-          audio = new Audio(audioPath);
-          hasError = false;
-          errorDetails = null;
-          usedFallback = true;
-
-          fallbackErrorHandler = () => {
-            hasError = true;
-            const error = audio.error;
-            if (error) {
-              errorDetails = {
-                code: error.code,
-                message: error.message,
-                path: audioPath,
-                MEDIA_ERR_ABORTED: error.MEDIA_ERR_ABORTED,
-                MEDIA_ERR_NETWORK: error.MEDIA_ERR_NETWORK,
-                MEDIA_ERR_DECODE: error.MEDIA_ERR_DECODE,
-                MEDIA_ERR_SRC_NOT_SUPPORTED: error.MEDIA_ERR_SRC_NOT_SUPPORTED,
-              };
-              console.error('[RoastTimer] Fallback audio loading error:', errorDetails);
-            } else {
-              errorDetails = {
-                path: audioPath,
-                readyState: audio.readyState,
-                networkState: audio.networkState,
-              };
-              console.error('[RoastTimer] Fallback audio error event fired but no error details available', errorDetails);
-            }
-          };
-          audio.addEventListener('error', fallbackErrorHandler);
-
-          await new Promise((resolve) => setTimeout(resolve, 100));
-
-          if (hasError) {
-            console.error('[RoastTimer] Fallback audio also failed, skipping unlock. Error:', errorDetails);
-            audio.removeEventListener('error', fallbackErrorHandler);
-            return;
-          }
-        }
-
-        // 音量を0にし、さらにミュートも設定して確実に無音にする
-        // 一瞬再生することで、iOS等の自動再生制限を解除(アンロック)する
-        audio.volume = 0;
-        audio.muted = true; // 確実に無音にする
-
-        try {
-          await audio.play();
-          audio.pause();
-          audio.currentTime = 0;
-
-          // 本番再生用に音量を設定し、ミュートを解除
-          audio.muted = false;
-          audio.volume = Math.max(0, Math.min(1, settings.notificationSoundVolume));
-
-          // Refに保存
-          notificationAudioRef.current = audio;
-          console.log('[RoastTimer] Notification sound prepared and unlocked', usedFallback ? '(using fallback)' : '');
-        } catch (playError) {
-          console.error('[RoastTimer] Failed to play audio for unlock:', playError);
-          // エラーイベントリスナーを削除
-          if (usedFallback && fallbackErrorHandler) {
-            audio.removeEventListener('error', fallbackErrorHandler);
-          } else if (errorHandler) {
-            audio.removeEventListener('error', errorHandler);
-          }
-        }
-      } catch (error) {
-        console.error('[RoastTimer] Failed to prepare notification sound:', error);
+      if (audio) {
+        notificationAudioRef.current = audio;
       }
     } catch (error) {
-      console.error('[RoastTimer] Failed to load settings for notification sound unlock:', error);
+      console.error('[RoastTimer] Failed to prepare notification sound:', error);
     }
-  }, [resolveAudioPath]);
+  }, []);
 
   // 通知音を再生(Refから)
   const playNotificationSoundFromRef = useCallback(async () => {

--- a/hooks/roast-timer/useTimerUpdater.ts
+++ b/hooks/roast-timer/useTimerUpdater.ts
@@ -1,0 +1,241 @@
+'use client';
+
+import { useEffect, useCallback } from 'react';
+import type { RoastTimerState } from '@/types';
+import { setRoastTimerState as saveLocalState } from '@/lib/localStorage';
+import { playTimerSound, stopAudio } from '@/lib/sounds';
+import { loadRoastTimerSettings } from '@/lib/roastTimerSettings';
+import { getSyncedIsoString } from '@/lib/timeSync';
+import { calculateElapsedTime } from './useTimerState';
+import type { UseTimerStateReturn } from './useTimerState';
+import type { UseTimerNotificationsReturn } from './useTimerNotifications';
+
+type UpdateAppDataFn = (newDataOrUpdater: import('@/types').AppData | ((currentData: import('@/types').AppData) => import('@/types').AppData)) => Promise<void>;
+
+const UPDATE_INTERVAL = 250; // 250msごとに更新（CSS transitionと同期）
+
+export interface UseTimerUpdaterArgs {
+  user: { uid: string } | null;
+  updateData: UpdateAppDataFn;
+  isLoading: boolean;
+  stateManager: UseTimerStateReturn;
+  notifications: UseTimerNotificationsReturn;
+  currentDeviceId: string;
+}
+
+/**
+ * タイマー更新フック
+ * - タイマー完了処理
+ * - 定期更新（250msごと）
+ * - バックグラウンド復帰時の状態更新
+ */
+export function useTimerUpdater({
+  user,
+  updateData,
+  isLoading,
+  stateManager,
+  notifications,
+  currentDeviceId,
+}: UseTimerUpdaterArgs) {
+  const {
+    localState,
+    setLocalState,
+    localStateRef,
+    intervalRef,
+    lastUpdateRef,
+    pausedElapsedRef,
+  } = stateManager;
+
+  const {
+    soundAudioRef,
+    preparedTimerAudioRef,
+    playNotificationSoundFromRef,
+  } = notifications;
+
+  // タイマー完了処理
+  const completeTimer = useCallback(async (currentState: RoastTimerState) => {
+    // インターバルを即座に停止(重複実行を防ぐ)
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+
+    const updatedState: RoastTimerState = {
+      ...currentState,
+      status: 'completed',
+      remaining: 0,
+      elapsed: currentState.duration,
+      completedByDeviceId: currentDeviceId,
+      dialogState: 'completion', // 完了ダイアログを表示
+      lastUpdatedAt: getSyncedIsoString(),
+    };
+
+    // アラーム音を再生(タイマー音)
+    try {
+      const settings = await loadRoastTimerSettings();
+
+      if (settings.timerSoundEnabled) {
+        if (preparedTimerAudioRef.current) {
+          try {
+            // 既存の音声を停止してから再生
+            if (soundAudioRef.current && soundAudioRef.current !== preparedTimerAudioRef.current) {
+              stopAudio(soundAudioRef.current);
+            }
+            preparedTimerAudioRef.current.currentTime = 0;
+            await preparedTimerAudioRef.current.play();
+            soundAudioRef.current = preparedTimerAudioRef.current;
+            console.log('[RoastTimer] Timer sound played from prepared ref');
+          } catch (err) {
+            console.error('[RoastTimer] Failed to play prepared timer audio, fallback', err);
+            const audio = await playTimerSound(settings.timerSoundFile, settings.timerSoundVolume);
+            soundAudioRef.current = audio;
+          }
+        } else {
+          const audio = await playTimerSound(settings.timerSoundFile, settings.timerSoundVolume);
+          soundAudioRef.current = audio;
+        }
+      }
+
+      // 通知音は通知設定に基づき独立判定で再生
+      // ただし、タイマー音と通知音が同じファイルの場合は重複再生を避けるためスキップ
+      if (settings.notificationSoundEnabled && settings.timerSoundFile !== settings.notificationSoundFile) {
+        void playNotificationSoundFromRef();
+      }
+    } catch (error) {
+      console.error('Failed to play timer/notification sound:', error);
+    }
+
+    // ローカル状態を即座に更新(同期処理として扱う)
+    saveLocalState(updatedState);
+    // 状態を同期的に更新(次のupdateTimerが実行される前に完了状態にする)
+    setLocalState(updatedState);
+
+    // Firestoreに完了状態を保存
+    try {
+      await updateData((currentData) => ({
+        ...currentData,
+        roastTimerState: updatedState,
+      }));
+    } catch (error) {
+      console.error('Failed to save roast timer state to Firestore:', error);
+    }
+  }, [currentDeviceId, updateData, playNotificationSoundFromRef, intervalRef, setLocalState, soundAudioRef, preparedTimerAudioRef]);
+
+  // タイマーの更新処理(開始時刻ベースで計算)
+  const updateTimer = useCallback(async () => {
+    // 最新のlocalStateを取得
+    const currentState = localStateRef.current;
+    if (!currentState || !user || isLoading) {
+      return;
+    }
+
+    // 既に完了している場合は何もしない
+    if (currentState.status === 'completed') {
+      return;
+    }
+
+    if (currentState.status === 'running' && currentState.startedAt) {
+      const pausedElapsed = currentState.pausedElapsed ?? pausedElapsedRef.current ?? 0;
+      pausedElapsedRef.current = pausedElapsed;
+      // 開始時刻から経過時間を計算
+      const elapsed = calculateElapsedTime(
+        currentState.startedAt,
+        currentState.pausedAt,
+        pausedElapsed,
+        currentState.status
+      );
+      const remaining = Math.max(0, currentState.duration - elapsed);
+
+      // タイマーが完了した場合
+      if (remaining <= 0) {
+        // completeTimer内でインターバルを停止するため、ここでは停止しない
+        await completeTimer(currentState);
+        return;
+      }
+
+      // React状態更新は1秒ごとに制限（テキスト同期・完了判定用）
+      // プログレスバーのアニメーションはTimerDisplayのrAFで60fps処理
+      const now = Date.now();
+      if (!lastUpdateRef.current || now - lastUpdateRef.current >= 1000) {
+        const updatedState: RoastTimerState = {
+          ...currentState,
+          pausedElapsed,
+          elapsed,
+          remaining,
+          lastUpdatedAt: getSyncedIsoString(),
+        };
+        setLocalState(updatedState);
+        lastUpdateRef.current = now;
+      }
+    }
+  }, [user, isLoading, completeTimer, localStateRef, pausedElapsedRef, lastUpdateRef, setLocalState]);
+
+  // タイマーの定期更新(UI表示用)
+  useEffect(() => {
+    if (localState?.status === 'running') {
+      // 既存のインターバルをクリア
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      intervalRef.current = setInterval(updateTimer, UPDATE_INTERVAL);
+      lastUpdateRef.current = Date.now();
+    } else {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    }
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [localState?.status, updateTimer, intervalRef, lastUpdateRef]);
+
+  // ページの可視性変更を監視(バックグラウンドから復帰時に状態を更新)
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible' && localState?.status === 'running' && localState.startedAt) {
+        // ページが表示された時、開始時刻から経過時間を再計算
+        const pausedElapsed = localState.pausedElapsed ?? pausedElapsedRef.current ?? 0;
+        pausedElapsedRef.current = pausedElapsed;
+        const elapsed = calculateElapsedTime(
+          localState.startedAt,
+          localState.pausedAt,
+          pausedElapsed,
+          localState.status
+        );
+        const remaining = Math.max(0, localState.duration - elapsed);
+
+        // タイマーが完了している場合
+        if (remaining <= 0) {
+          completeTimer(localState);
+          return;
+        }
+
+        const updatedState: RoastTimerState = {
+          ...localState,
+          pausedElapsed,
+          elapsed,
+          remaining,
+          lastUpdatedAt: getSyncedIsoString(),
+        };
+
+        // LocalStorageへの保存は不要（重要イベント時のみ保存）
+        setLocalState(updatedState);
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [localState, user, completeTimer, pausedElapsedRef, setLocalState]);
+
+  return { completeTimer };
+}

--- a/hooks/useRoastTimerDialogs.ts
+++ b/hooks/useRoastTimerDialogs.ts
@@ -1,0 +1,268 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import type { AppData, RoastTimerState } from '@/types';
+
+type UpdateAppDataFn = (newDataOrUpdater: AppData | ((currentData: AppData) => AppData)) => Promise<void>;
+
+interface UseRoastTimerDialogsArgs {
+  state: RoastTimerState | null;
+  resetTimer: () => Promise<void>;
+  stopSound: () => void;
+  updateData: UpdateAppDataFn;
+}
+
+export interface UseRoastTimerDialogsReturn {
+  showCompletionDialog: boolean;
+  showContinuousRoastDialog: boolean;
+  showAfterPurgeDialog: boolean;
+  handleCompletionClose: () => Promise<void>;
+  handleCompletionOk: () => Promise<void>;
+  handleContinuousRoastClose: () => Promise<void>;
+  handleContinuousRoastYes: () => Promise<void>;
+  handleContinuousRoastNo: () => Promise<void>;
+  handleAfterPurgeRecord: () => Promise<void>;
+  handleAfterPurgeClose: () => Promise<void>;
+}
+
+/**
+ * ローストタイマーのダイアログ管理フック
+ * - 完了ダイアログ、連続焙煎ダイアログ、アフターパージダイアログの状態管理
+ * - Firestoreの dialogState との同期
+ * - 各ダイアログのハンドラー
+ */
+export function useRoastTimerDialogs({
+  state,
+  resetTimer,
+  stopSound,
+  updateData,
+}: UseRoastTimerDialogsArgs): UseRoastTimerDialogsReturn {
+  const router = useRouter();
+
+  const [showCompletionDialog, setShowCompletionDialog] = useState(false);
+  const [showContinuousRoastDialog, setShowContinuousRoastDialog] = useState(false);
+  const [showAfterPurgeDialog, setShowAfterPurgeDialog] = useState(false);
+  const prevStatusRef = useRef<string | undefined>(undefined);
+  const hasInitializedRef = useRef(false);
+  const dialogSyncLockRef = useRef(false);
+
+  // ページを開いた時の初期化（完了状態の場合は自動リセット）
+  useEffect(() => {
+    if (!hasInitializedRef.current) {
+      hasInitializedRef.current = true;
+
+      if (state?.status === 'completed') {
+        resetTimer();
+        setShowCompletionDialog(false);
+        setShowContinuousRoastDialog(false);
+        setShowAfterPurgeDialog(false);
+      }
+    }
+  }, [state?.status, resetTimer]);
+
+  // 完了状態を検出してダイアログを表示（runningからcompletedに変化した時のみ）
+  useEffect(() => {
+    const currentStatus = state?.status;
+    const prevStatus = prevStatusRef.current;
+
+    const shouldOpenCompletionDialog =
+      !dialogSyncLockRef.current &&
+      prevStatus === 'running' &&
+      currentStatus === 'completed' &&
+      !showCompletionDialog &&
+      !showContinuousRoastDialog &&
+      !showAfterPurgeDialog;
+
+    if (shouldOpenCompletionDialog) {
+      setShowCompletionDialog(true);
+    }
+
+    prevStatusRef.current = currentStatus;
+  }, [state?.status, showCompletionDialog, showContinuousRoastDialog, showAfterPurgeDialog]);
+
+  // FirestoreのdialogStateを監視してダイアログを同期表示
+  useEffect(() => {
+    if (!state) {
+      if (showCompletionDialog || showContinuousRoastDialog || showAfterPurgeDialog) {
+        setShowCompletionDialog(false);
+        setShowContinuousRoastDialog(false);
+        setShowAfterPurgeDialog(false);
+      }
+      return;
+    }
+
+    if (dialogSyncLockRef.current) {
+      return;
+    }
+
+    const dialogState = state.dialogState;
+
+    if (dialogState === 'completion' && state.status === 'completed') {
+      if (!showCompletionDialog && !showContinuousRoastDialog && !showAfterPurgeDialog) {
+        setShowCompletionDialog(true);
+      }
+    } else if (dialogState === 'continuousRoast' && state.status === 'completed') {
+      if (!showContinuousRoastDialog && !showAfterPurgeDialog) {
+        setShowCompletionDialog(false);
+        setShowContinuousRoastDialog(true);
+      }
+    } else if (dialogState === 'afterPurge' && state.status === 'completed') {
+      if (!showAfterPurgeDialog) {
+        setShowCompletionDialog(false);
+        setShowContinuousRoastDialog(false);
+        setShowAfterPurgeDialog(true);
+      }
+    } else if (dialogState === null) {
+      setShowCompletionDialog(false);
+      setShowContinuousRoastDialog(false);
+      setShowAfterPurgeDialog(false);
+    }
+  }, [state, showCompletionDialog, showContinuousRoastDialog, showAfterPurgeDialog]);
+
+  // dialogStateをFirestoreに更新するヘルパー
+  const updateDialogState = useCallback(async (dialogState: RoastTimerState['dialogState']) => {
+    if (state) {
+      try {
+        await updateData((currentData) => ({
+          ...currentData,
+          roastTimerState: {
+            ...state,
+            dialogState,
+            lastUpdatedAt: new Date().toISOString(),
+          },
+        }));
+      } catch (error) {
+        console.error('Failed to update dialog state:', error);
+      }
+    }
+  }, [state, updateData]);
+
+  // 完了ダイアログの閉じるボタン
+  const handleCompletionClose = useCallback(async () => {
+    stopSound();
+    setShowCompletionDialog(false);
+    await updateDialogState(null);
+  }, [stopSound, updateDialogState]);
+
+  // 完了ダイアログのOKボタン
+  const handleCompletionOk = useCallback(async () => {
+    stopSound();
+    setShowCompletionDialog(false);
+    setShowContinuousRoastDialog(true);
+    await updateDialogState('continuousRoast');
+  }, [stopSound, updateDialogState]);
+
+  // 連続焙煎ダイアログの閉じるボタン
+  const handleContinuousRoastClose = useCallback(async () => {
+    setShowContinuousRoastDialog(false);
+    await updateDialogState(null);
+  }, [updateDialogState]);
+
+  // 連続焙煎ダイアログの「はい」
+  const handleContinuousRoastYes = useCallback(async () => {
+    stopSound();
+    setShowCompletionDialog(false);
+    setShowContinuousRoastDialog(false);
+    setShowAfterPurgeDialog(false);
+    await resetTimer();
+    router.push('/roast-timer');
+  }, [stopSound, resetTimer, router]);
+
+  // 連続焙煎ダイアログの「いいえ」
+  const handleContinuousRoastNo = useCallback(async () => {
+    setShowContinuousRoastDialog(false);
+    setShowAfterPurgeDialog(true);
+    await updateDialogState('afterPurge');
+  }, [updateDialogState]);
+
+  // アフターパージダイアログの「記録に進む」
+  const handleAfterPurgeRecord = useCallback(async () => {
+    dialogSyncLockRef.current = true;
+    stopSound();
+    setShowCompletionDialog(false);
+    setShowContinuousRoastDialog(false);
+    setShowAfterPurgeDialog(false);
+    prevStatusRef.current = undefined;
+
+    const stateSnapshot = state;
+    let clearDialogStatePromise: Promise<void> | null = null;
+
+    if (stateSnapshot) {
+      try {
+        clearDialogStatePromise = updateData((currentData) => ({
+          ...currentData,
+          roastTimerState: {
+            ...stateSnapshot,
+            dialogState: null,
+            lastUpdatedAt: new Date().toISOString(),
+          },
+        }));
+      } catch (error) {
+        console.error('Failed to update dialog state:', error);
+      }
+    }
+
+    let targetUrl = '/roast-record';
+    if (
+      stateSnapshot &&
+      stateSnapshot.beanName &&
+      stateSnapshot.weight &&
+      stateSnapshot.roastLevel &&
+      stateSnapshot.elapsed > 0
+    ) {
+      const params = new URLSearchParams({
+        beanName: stateSnapshot.beanName,
+        weight: stateSnapshot.weight.toString(),
+        roastLevel: stateSnapshot.roastLevel,
+        duration: Math.round(stateSnapshot.elapsed).toString(),
+      });
+      targetUrl = `/roast-record?${params.toString()}`;
+    }
+
+    setShowCompletionDialog(false);
+    setShowContinuousRoastDialog(false);
+    setShowAfterPurgeDialog(false);
+
+    router.push(targetUrl);
+
+    if (clearDialogStatePromise) {
+      try {
+        await clearDialogStatePromise;
+      } catch (error) {
+        console.error('Failed to update dialog state:', error);
+      }
+    }
+
+    try {
+      await resetTimer();
+    } finally {
+      setShowCompletionDialog(false);
+      setShowContinuousRoastDialog(false);
+      setShowAfterPurgeDialog(false);
+      dialogSyncLockRef.current = false;
+    }
+  }, [state, stopSound, resetTimer, updateData, router]);
+
+  // アフターパージダイアログの「閉じる」
+  const handleAfterPurgeClose = useCallback(async () => {
+    stopSound();
+    setShowCompletionDialog(false);
+    setShowContinuousRoastDialog(false);
+    setShowAfterPurgeDialog(false);
+    await resetTimer();
+  }, [stopSound, resetTimer]);
+
+  return {
+    showCompletionDialog,
+    showContinuousRoastDialog,
+    showAfterPurgeDialog,
+    handleCompletionClose,
+    handleCompletionOk,
+    handleContinuousRoastClose,
+    handleContinuousRoastYes,
+    handleContinuousRoastNo,
+    handleAfterPurgeRecord,
+    handleAfterPurgeClose,
+  };
+}


### PR DESCRIPTION
## 概要
Issue #88 を解決。焙煎タイマー関連の大規模ファイル4つを機能別モジュールに分割。

## 変更内容
- `SetupPanel.tsx` (688行) → `SetupPanel` + `ModeSelectView` + `RecommendedModeView` に分割
- `useTimerControls.ts` (458行) → `useTimerControls` + `useTimerUpdater` に分割
- `RoastTimer.tsx` (402行) → `RoastTimer` + `useRoastTimerDialogs` に分割
- `useTimerNotifications.ts` (372行) → `useTimerNotifications` + `audioUnlocker` に分割

## 分割方針
- 外部公開インターフェース（export）は変更なし
- タイマー音/通知音の重複コードを `audioUnlocker.ts` に共通化
- ダイアログ管理ロジックを `useRoastTimerDialogs` カスタムフックに抽出

## テスト
- [x] lint 通過（既存エラーのみ残存、新規エラーなし）
- [x] build 通過
- [ ] 実機動作確認

Closes #88
