### PR TITLE
feat(dx): PostToolUseフックによるESLint自動整形を導入

### DIFF
--- a/.claude/hooks/eslint-autofix.sh
+++ b/.claude/hooks/eslint-autofix.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# PostToolUse hook: Edit/Write後にESLint --fixを自動実行する
+# stdinからJSON（tool_input）を受け取り、対象ファイルを整形する
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+# ファイルパスが取得できない場合は何もしない
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# 対象拡張子のみ処理（ts, tsx, js, jsx, mjs）
+case "$FILE_PATH" in
+  *.ts|*.tsx|*.js|*.jsx|*.mjs)
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+# ファイルが存在するか確認
+if [ ! -f "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# ESLint --fix を実行（エラーがあっても続行）
+npx eslint --fix "$FILE_PATH" 2>/dev/null
+
+# 常に成功として返す（ブロックしない）
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,5 +4,19 @@
     "supabase@claude-plugins-official": false,
     "obsidian@obsidian-skills": false,
     "document-skills@anthropic-agent-skills": false
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/eslint-autofix.sh\"",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## 概要

Issue #104 を解決。AIがファイルを編集するたびにESLint --fixが自動実行される `PostToolUse` フックを導入。

## 変更内容

- **`.claude/hooks/eslint-autofix.sh`** — hookスクリプト新規作成
  - stdinからJSONを読み取り、編集対象ファイルパスを抽出
  - `.ts` / `.tsx` / `.js` / `.jsx` / `.mjs` ファイルのみ対象
  - `npx eslint --fix` を実行（ブロックなし、自動修正のみ）
- **`.claude/settings.json`** — PostToolUseフック設定追加
  - `Edit` / `Write` ツール使用後に自動トリガー
  - タイムアウト30秒

## テスト

- [x] `npm run build` 通過
- [x] 既存の lint エラーは今回の変更に起因しない（既存Issue）

Closes #104
