### PR TITLE
[Issue #109] dx: Stop Hookによるテスト強制ゲートの導入

### DIFF
--- a/.claude/hooks/test-gate.sh
+++ b/.claude/hooks/test-gate.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Stop Hook: セッション終了前にテストスイートを実行するゲート
+# テスト失敗時はnon-zero exit codeを返し、Claudeに修正を促す
+
+# プロジェクトルートに移動
+cd "$CLAUDE_PROJECT_DIR" || exit 0
+
+# テストファイルが存在するか確認（テストがなければスキップ）
+TEST_FILES=$(find . -path ./node_modules -prune -o -path ./.next -prune -o -name '*.test.ts' -print -o -name '*.test.tsx' -print 2>/dev/null)
+
+if [ -z "$TEST_FILES" ]; then
+  # テストファイルがない場合はスキップ
+  exit 0
+fi
+
+# テスト実行
+npx vitest run --reporter=verbose 2>&1
+TEST_EXIT=$?
+
+if [ $TEST_EXIT -ne 0 ]; then
+  echo ""
+  echo "=========================================="
+  echo "  テストが失敗しました"
+  echo "  失敗したテストを修正してください"
+  echo "=========================================="
+  exit 1
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,6 +17,17 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/test-gate.sh\"",
+            "timeout": 300
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## 概要

Issue #109 を解決。Claude Codeの `Stop` Hookにテスト強制ゲートを導入。

## 変更内容

- **`.claude/hooks/test-gate.sh`（新規）** — セッション終了前のテスト実行スクリプト
  - `vitest run --reporter=verbose` を実行
  - テストファイルが存在しない場合はスキップ
  - テスト失敗時はnon-zero exit codeを返し、修正を促す
- **`.claude/settings.json`** — `Stop` Hookを追加（タイムアウト300秒）

## 動作フロー

```
Claudeのセッション終了
  → test-gate.sh 実行
  → テストファイルあり？
    → なし: exit 0（スキップ）
    → あり: vitest run
      → 全パス: exit 0（正常終了）
      → 失敗あり: exit 1（Claudeに修正を促す）
```

## テスト

- [x] `npm run build` 通過
- [x] `test-gate.sh` 手動実行で14テスト全パス確認

Closes #109
