### PR TITLE
refactor(drip-guide): ドリップガイド関連コンポーネントを分割

### DIFF
--- a/components/drip-guide/DripGuideRunner.tsx
+++ b/components/drip-guide/DripGuideRunner.tsx
@@ -2,12 +2,15 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import { DripRecipe } from '@/lib/drip-guide/types';
-import { motion, AnimatePresence } from 'framer-motion';
-import { Play, Pause, ArrowCounterClockwise, X, ArrowLeft, Lightbulb, ArrowRight, CheckCircle } from 'phosphor-react';
-import { clsx } from 'clsx';
-import Link from 'next/link';
-import Lottie, { LottieRefCurrentProps } from 'lottie-react';
 import { playNotificationSound } from '@/lib/sounds';
+import { useRunnerTimer } from '@/hooks/drip-guide/useRunnerTimer';
+import { CompletionScreen } from './runner/CompletionScreen';
+import { RunnerHeader } from './runner/RunnerHeader';
+import { StepMiniMap } from './runner/StepMiniMap';
+import { TimerDisplay } from './runner/TimerDisplay';
+import { StepInfo } from './runner/StepInfo';
+import { ProgressBar } from './runner/ProgressBar';
+import { FooterControls } from './runner/FooterControls';
 
 interface DripGuideRunnerProps {
     recipe: DripRecipe;
@@ -17,112 +20,45 @@ export const DripGuideRunner: React.FC<DripGuideRunnerProps> = ({ recipe }) => {
     const [currentTime, setCurrentTime] = useState(0);
     const [isRunning, setIsRunning] = useState(false);
     const [isCompleted, setIsCompleted] = useState(false);
-    const [animationData, setAnimationData] = useState<unknown>(null);
-    const timerRef = useRef<NodeJS.Timeout | null>(null);
-    const scrollContainerRef = useRef<HTMLDivElement>(null);
-    const lottieRef = useRef<LottieRefCurrentProps>(null);
     const countdownSoundPlayedRef = useRef<boolean>(false);
-    
+
     // Manual mode state
     const isManualMode = recipe.isManualMode ?? false;
     const [manualStepIndex, setManualStepIndex] = useState(0);
 
-    // Sort steps just in case
+    // Sort steps
     const steps = [...recipe.steps].sort((a, b) => a.startTimeSec - b.startTimeSec);
 
-    // Determine current step based on mode
+    // Determine current step
     const autoModeStepIndex = steps.findLastIndex((step) => step.startTimeSec <= currentTime);
     const currentStepIndex = isManualMode ? manualStepIndex : autoModeStepIndex;
-    const currentStep = currentStepIndex !== -1 && currentStepIndex < steps.length ? steps[currentStepIndex] : null;
+    const currentStep =
+        currentStepIndex !== -1 && currentStepIndex < steps.length ? steps[currentStepIndex] : null;
     const nextStep = currentStepIndex < steps.length - 1 ? steps[currentStepIndex + 1] : null;
 
-    // Load Lottie animation when completed
-    useEffect(() => {
-        const loadAnimation = async () => {
-            try {
-                const response = await fetch('/animations/Break Time.json');
-                if (response.ok) {
-                    const data = await response.json();
-                    setAnimationData(data);
-                } else {
-                    console.error('Failed to load Lottie animation');
-                }
-            } catch (error) {
-                console.error('Error loading Lottie animation:', error);
-            }
-        };
-
-        if (isCompleted) {
-            loadAnimation();
-        }
-    }, [isCompleted]);
-
     // Timer logic
-    useEffect(() => {
-        if (!isRunning) {
-            if (timerRef.current) {
-                clearInterval(timerRef.current);
-            }
-            return;
-        }
-
-        timerRef.current = setInterval(() => {
-            setCurrentTime((prev) => {
-                const next = prev + 1;
-                if (!isManualMode && next >= recipe.totalDurationSec) {
-                    setIsRunning(false);
-                    setIsCompleted(true);
-                    return recipe.totalDurationSec;
-                }
-                return next;
-            });
-        }, 1000);
-
-        return () => {
-            if (timerRef.current) clearInterval(timerRef.current);
-        };
-    }, [isRunning, isManualMode, recipe.totalDurationSec]);
+    useRunnerTimer({
+        isRunning,
+        isManualMode,
+        totalDurationSec: recipe.totalDurationSec,
+        onTick: setCurrentTime,
+        onComplete: () => {
+            setIsRunning(false);
+            setIsCompleted(true);
+        },
+    });
 
     const scrollKey = isManualMode ? manualStepIndex : currentTime;
 
-    // Auto scroll to current step in mini map
-    useEffect(() => {
-        if (currentStep && scrollContainerRef.current) {
-            const activeStepElement = document.getElementById(`step-card-${currentStep.id}`);
-            if (activeStepElement) {
-                activeStepElement.scrollIntoView({
-                    behavior: 'smooth',
-                    block: 'nearest',
-                    inline: 'center'
-                });
-            }
-        }
-    }, [currentStep, scrollKey]);
-
-    // Set animation speed
-    useEffect(() => {
-        if (lottieRef.current) {
-            lottieRef.current.setSpeed(0.5);
-        }
-    }, [animationData]);
-
     // Play countdown sound 3 seconds before next step starts
     useEffect(() => {
-        // 手動モードでは音声を再生しない
-        if (isManualMode) {
-            return;
-        }
-
-        // 次のステップが存在しない場合は何もしない
-        if (!nextStep) {
+        if (isManualMode || !nextStep) {
             countdownSoundPlayedRef.current = false;
             return;
         }
 
-        // 次のステップ開始時刻の3秒前
         const countdownTime = nextStep.startTimeSec - 3;
 
-        // 現在時刻がカウントダウン時刻に達したら音声を再生（1回のみ）
         if (currentTime >= countdownTime && !countdownSoundPlayedRef.current) {
             playNotificationSound('/sounds/countdown/countdown.mp3', 1).catch((error) => {
                 console.error('Failed to play countdown sound:', error);
@@ -130,8 +66,6 @@ export const DripGuideRunner: React.FC<DripGuideRunnerProps> = ({ recipe }) => {
             countdownSoundPlayedRef.current = true;
         }
 
-        // 次のステップが変わったらフラグをリセット
-        // （前のステップから次のステップに移った時）
         if (currentTime < countdownTime) {
             countdownSoundPlayedRef.current = false;
         }
@@ -143,13 +77,12 @@ export const DripGuideRunner: React.FC<DripGuideRunnerProps> = ({ recipe }) => {
         setIsRunning(false);
         setCurrentTime(0);
         setIsCompleted(false);
-        countdownSoundPlayedRef.current = false; // Reset countdown sound flag
+        countdownSoundPlayedRef.current = false;
         if (isManualMode) {
             setManualStepIndex(0);
         }
     };
 
-    // Manual mode navigation
     const goToNextStep = () => {
         if (isManualMode && manualStepIndex < steps.length - 1) {
             setManualStepIndex(manualStepIndex + 1);
@@ -168,357 +101,48 @@ export const DripGuideRunner: React.FC<DripGuideRunnerProps> = ({ recipe }) => {
         }
     };
 
-    const formatTime = (seconds: number) => {
-        const m = Math.floor(seconds / 60);
-        const s = seconds % 60;
-        return `${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
-    };
-
     const progressPercent = Math.min((currentTime / recipe.totalDurationSec) * 100, 100);
 
     if (isCompleted) {
-        return (
-            <div className="flex flex-col items-center justify-center h-[100dvh] text-center p-6">
-                <div className="mb-6 flex items-center justify-center">
-                    {animationData ? (
-                        <Lottie
-                            lottieRef={lottieRef}
-                            animationData={animationData}
-                            loop={false}
-                            style={{ width: 160, height: 160 }}
-                            onDOMLoaded={() => {
-                                lottieRef.current?.setSpeed(0.5);
-                            }}
-                        />
-                    ) : (
-                        <div className="w-40 h-40 flex items-center justify-center">
-                            <div className="w-8 h-8 border-4 border-amber-500 border-t-transparent rounded-full animate-spin"></div>
-                        </div>
-                    )}
-                </div>
-                <h2 className="text-3xl font-bold text-gray-800 mb-2">抽出完了！</h2>
-                <p className="text-gray-600 mb-8">お疲れ様でした。美味しいコーヒーを楽しみましょう。</p>
-
-                <div className="flex gap-4">
-                    <button
-                        onClick={resetTimer}
-                        className="px-6 py-2 border border-gray-300 rounded-full text-gray-600 hover:bg-gray-50 transition-colors"
-                    >
-                        もう一度淹れる
-                    </button>
-                    <Link
-                        href="/drip-guide"
-                        className="px-6 py-2 bg-amber-600 text-white rounded-full hover:bg-amber-700 transition-colors"
-                    >
-                        一覧に戻る
-                    </Link>
-                </div>
-            </div>
-        );
+        return <CompletionScreen onReset={resetTimer} />;
     }
 
     return (
         <div className="flex flex-col h-[100dvh] bg-white relative overflow-hidden">
-            {/* Header */}
-            <div className="flex-none px-4 py-3 flex items-center justify-between border-b border-gray-100 bg-white z-10">
-                <Link href="/drip-guide" className="p-2 -ml-2 text-gray-500 hover:text-gray-800 transition-colors rounded-full active:bg-gray-100">
-                    <ArrowLeft size={24} />
-                </Link>
-                <h1 className="font-bold text-gray-800 text-lg truncate max-w-[200px] text-center">
-                    {recipe.name}
-                </h1>
-                <div className="w-10" /> {/* Spacer for centering */}
-            </div>
+            <RunnerHeader recipeName={recipe.name} />
 
-            {/* Main Content - No Scroll */}
             <div className="flex-grow flex flex-col items-center py-2 px-4 overflow-hidden">
-                {/* Steps Mini Map - Fixed at top */}
-                <div className="w-full max-w-2xl mb-2 sm:mb-3 px-2 flex-shrink-0">
-                    <div className="overflow-x-auto scrollbar-hide pb-1 -mx-2 px-2" ref={scrollContainerRef}>
-                        <div className="flex gap-2 sm:gap-2 min-w-max">
-                            {steps.map((step, index) => {
-                                const stepEndTime = index < steps.length - 1 
-                                    ? steps[index + 1].startTimeSec 
-                                    : recipe.totalDurationSec;
-                                const isStepCompleted = isManualMode 
-                                    ? index < currentStepIndex
-                                    : currentTime > stepEndTime;
-                                const isCurrent = currentStep?.id === step.id;
-
-                                return (
-                                    <motion.div
-                                        key={step.id}
-                                        id={`step-card-${step.id}`}
-                                        initial={{ opacity: 0, scale: 0.9 }}
-                                        animate={{ opacity: 1, scale: 1 }}
-                                        className={clsx(
-                                            "flex-shrink-0 rounded-lg px-3 py-2 sm:px-3 sm:py-2 min-w-[120px] sm:min-w-[120px] border-2 transition-all",
-                                            isCurrent
-                                                ? "bg-amber-50 border-amber-400 shadow-md"
-                                                : isStepCompleted
-                                                ? "bg-gray-50 border-gray-200"
-                                                : "bg-gray-100 border-gray-200 opacity-60"
-                                        )}
-                                    >
-                                        <div className={clsx(
-                                            "text-sm sm:text-sm font-bold truncate",
-                                            isCurrent
-                                                ? "text-amber-800"
-                                                : isStepCompleted
-                                                ? "text-gray-700"
-                                                : "text-gray-500"
-                                        )}>
-                                            {step.title}
-                                        </div>
-                                        {!isManualMode && (
-                                            <div className={clsx(
-                                                "text-xs sm:text-xs font-semibold mt-0.5 sm:mt-0.5",
-                                                isCurrent
-                                                    ? "text-amber-700"
-                                                    : isStepCompleted
-                                                    ? "text-gray-600"
-                                                    : "text-gray-400"
-                                            )}>
-                                                {formatTime(step.startTimeSec)} - {formatTime(stepEndTime)}
-                                            </div>
-                                        )}
-                                        {step.targetTotalWater && (
-                                            <div className={clsx(
-                                                "text-xs sm:text-xs mt-0.5 sm:mt-0.5",
-                                                isCurrent
-                                                    ? "text-amber-600"
-                                                    : isStepCompleted
-                                                    ? "text-gray-500"
-                                                    : "text-gray-400"
-                                            )}>
-                                                {step.targetTotalWater}gまで注ぐ
-                                            </div>
-                                        )}
-                                        {isCurrent && !isManualMode && (
-                                            <motion.div
-                                                initial={{ width: 0 }}
-                                                animate={{ 
-                                                    width: `${Math.min(
-                                                        ((currentTime - step.startTimeSec) / (stepEndTime - step.startTimeSec)) * 100,
-                                                        100
-                                                    )}%` 
-                                                }}
-                                                className="h-1 sm:h-1 bg-amber-500 rounded-full mt-1.5 sm:mt-1.5"
-                                                transition={{ duration: 1, ease: "linear" }}
-                                            />
-                                        )}
-                                    </motion.div>
-                                );
-                            })}
-                        </div>
-                    </div>
-                </div>
-
-                {/* Timer and Step Info - Centered */}
-                <div className="flex-grow flex flex-col items-center justify-center w-full">
-                    {/* Timer */}
-                    <div className="text-center mb-4 sm:mb-6 flex-shrink-0 -mt-4 sm:mt-0">
-                        <div className="text-8xl sm:text-7xl md:text-8xl lg:text-9xl tabular-nums font-bold text-gray-800 tracking-tighter leading-none" style={{ fontFamily: 'var(--font-nunito), sans-serif' }}>
-                            {formatTime(currentTime)}
-                        </div>
-                    </div>
-
-                    {/* Current Step Info */}
-                    <div className="w-full max-w-md text-center flex-shrink-0 flex flex-col justify-center">
-                    <AnimatePresence mode="wait">
-                        {currentStep ? (
-                            <motion.div
-                                key={currentStep.id}
-                                initial={{ opacity: 0, y: 20 }}
-                                animate={{ opacity: 1, y: 0 }}
-                                exit={{ opacity: 0, y: -20 }}
-                                transition={{ duration: 0.3 }}
-                                className="flex flex-col items-center"
-                            >
-                                <h3 className="text-3xl sm:text-2xl md:text-3xl font-bold text-amber-700 mb-4 sm:mb-3">{currentStep.title}</h3>
-
-                                {currentStep.targetTotalWater && (
-                                    <div className="mb-4 sm:mb-3">
-                                        <span className="inline-block bg-blue-50 text-blue-600 px-6 py-3 sm:px-5 sm:py-2 rounded-full font-bold text-xl sm:text-lg shadow-sm border border-blue-100">
-                                            {currentStep.targetTotalWater}g <span className="text-base sm:text-sm font-normal text-blue-400">まで注ぐ</span>
-                                        </span>
-                                    </div>
-                                )}
-
-                                <p className="text-lg sm:text-base md:text-lg text-gray-600 leading-relaxed mb-4 sm:mb-3 max-w-xs mx-auto">
-                                    {currentStep.description}
-                                </p>
-
-                                {currentStep.note && (
-                                    <div className="bg-amber-50 p-4 sm:p-3 rounded-xl border border-amber-100 text-amber-800 text-base sm:text-sm max-w-xs mx-auto flex items-start gap-2">
-                                        <Lightbulb size={20} className="sm:w-4 sm:h-4 text-amber-600 flex-shrink-0 mt-0.5" weight="fill" />
-                                        <span>{currentStep.note}</span>
-                                    </div>
-                                )}
-                            </motion.div>
-                        ) : (
-                            <motion.div
-                                key="start"
-                                initial={{ opacity: 0 }}
-                                animate={{ opacity: 1 }}
-                                className="text-gray-400 text-base py-4"
-                            >
-                                準備ができたら<br />スタートボタンを押してください
-                            </motion.div>
-                        )}
-                    </AnimatePresence>
-                    </div>
-                </div>
-            </div>
-
-            {/* Progress Bar */}
-            <div className="flex-none h-1 bg-gray-100 w-full">
-                <motion.div
-                    className="h-full bg-amber-500"
-                    initial={{ width: 0 }}
-                    animate={{ width: `${progressPercent}%` }}
-                    transition={{ duration: 1, ease: "linear" }}
+                <StepMiniMap
+                    steps={steps}
+                    currentStep={currentStep}
+                    currentTime={currentTime}
+                    totalDurationSec={recipe.totalDurationSec}
+                    isManualMode={isManualMode}
+                    currentStepIndex={currentStepIndex}
+                    scrollKey={scrollKey}
                 />
+
+                <div className="flex-grow flex flex-col items-center justify-center w-full">
+                    <TimerDisplay currentTime={currentTime} />
+                    <StepInfo currentStep={currentStep} />
+                </div>
             </div>
 
-            {/* Footer Controls - Fixed */}
-            <div className="flex-none bg-white border-t border-gray-100 pb-8 pt-4 px-6 safe-area-bottom">
-                {/* Next Step Preview */}
-                {!isManualMode && (
-                    <div className="h-8 mb-4 flex justify-center items-center">
-                        {nextStep && (
-                            <motion.div
-                                initial={{ opacity: 0 }}
-                                animate={{ opacity: 1 }}
-                                className="text-gray-400 text-xs font-medium bg-gray-50 px-3 py-1 rounded-full"
-                            >
-                                Next: {formatTime(nextStep.startTimeSec)} - {nextStep.title}
-                            </motion.div>
-                        )}
-                    </div>
-                )}
+            <ProgressBar progressPercent={progressPercent} />
 
-                {isManualMode ? (
-                    // Manual mode controls
-                    <div className="flex items-center justify-center gap-4 sm:gap-6">
-                        <button
-                            onClick={resetTimer}
-                            className="flex flex-col items-center gap-1 text-gray-400 hover:text-gray-600 transition-colors p-2 active:scale-95 min-h-[44px] min-w-[44px]"
-                        >
-                            <div className="p-3 rounded-full bg-gray-50">
-                                <ArrowCounterClockwise size={24} />
-                            </div>
-                            <span className="text-xs font-medium">リセット</span>
-                        </button>
-
-                        <button
-                            onClick={goToPrevStep}
-                            disabled={manualStepIndex === 0}
-                            className={clsx(
-                                "flex flex-col items-center gap-1 transition-colors p-2 active:scale-95 min-h-[44px] min-w-[44px]",
-                                manualStepIndex === 0
-                                    ? "text-gray-300 cursor-not-allowed"
-                                    : "text-gray-400 hover:text-gray-600"
-                            )}
-                        >
-                            <div className={clsx(
-                                "p-3 rounded-full",
-                                manualStepIndex === 0 ? "bg-gray-50" : "bg-gray-50"
-                            )}>
-                                <ArrowLeft size={24} />
-                            </div>
-                            <span className="text-xs font-medium">前へ</span>
-                        </button>
-
-                        <button
-                            onClick={toggleTimer}
-                            className={clsx(
-                                "w-16 h-16 sm:w-20 sm:h-20 rounded-full flex items-center justify-center shadow-xl transition-all active:scale-95 touch-manipulation",
-                                isRunning
-                                    ? "bg-white border-2 border-amber-100 text-amber-500"
-                                    : "bg-amber-500 text-white shadow-amber-200"
-                            )}
-                        >
-                            {isRunning ? (
-                                <Pause size={28} weight="fill" className="sm:w-9 sm:h-9" />
-                            ) : (
-                                <Play size={28} weight="fill" className="ml-1 sm:w-9 sm:h-9" />
-                            )}
-                        </button>
-
-                        {currentStepIndex === steps.length - 1 ? (
-                            <button
-                                onClick={handleComplete}
-                                className="flex flex-col items-center gap-1 text-green-600 hover:text-green-700 transition-colors p-2 active:scale-95 min-h-[44px] min-w-[44px]"
-                            >
-                                <div className="p-3 rounded-full bg-green-50">
-                                    <CheckCircle size={24} weight="fill" />
-                                </div>
-                                <span className="text-xs font-medium">完了</span>
-                            </button>
-                        ) : (
-                            <button
-                                onClick={goToNextStep}
-                                className="flex flex-col items-center gap-1 text-gray-400 hover:text-gray-600 transition-colors p-2 active:scale-95 min-h-[44px] min-w-[44px]"
-                            >
-                                <div className="p-3 rounded-full bg-gray-50">
-                                    <ArrowRight size={24} />
-                                </div>
-                                <span className="text-xs font-medium">次へ</span>
-                            </button>
-                        )}
-
-                        <Link
-                            href="/drip-guide"
-                            className="flex flex-col items-center gap-1 text-gray-400 hover:text-gray-600 transition-colors p-2 active:scale-95 min-h-[44px] min-w-[44px]"
-                        >
-                            <div className="p-3 rounded-full bg-gray-50">
-                                <X size={24} />
-                            </div>
-                            <span className="text-xs font-medium">終了</span>
-                        </Link>
-                    </div>
-                ) : (
-                    // Auto mode controls (existing)
-                    <div className="flex items-center justify-center gap-10">
-                        <button
-                            onClick={resetTimer}
-                            className="flex flex-col items-center gap-1 text-gray-400 hover:text-gray-600 transition-colors p-2 active:scale-95"
-                        >
-                            <div className="p-3 rounded-full bg-gray-50">
-                                <ArrowCounterClockwise size={24} />
-                            </div>
-                            <span className="text-xs font-medium">リセット</span>
-                        </button>
-
-                        <button
-                            onClick={toggleTimer}
-                            className={clsx(
-                                "w-20 h-20 rounded-full flex items-center justify-center shadow-xl transition-all active:scale-95 touch-manipulation",
-                                isRunning
-                                    ? "bg-white border-2 border-amber-100 text-amber-500"
-                                    : "bg-amber-500 text-white shadow-amber-200"
-                            )}
-                        >
-                            {isRunning ? (
-                                <Pause size={36} weight="fill" />
-                            ) : (
-                                <Play size={36} weight="fill" className="ml-1" />
-                            )}
-                        </button>
-
-                        <Link
-                            href="/drip-guide"
-                            className="flex flex-col items-center gap-1 text-gray-400 hover:text-gray-600 transition-colors p-2 active:scale-95"
-                        >
-                            <div className="p-3 rounded-full bg-gray-50">
-                                <X size={24} />
-                            </div>
-                            <span className="text-xs font-medium">終了</span>
-                        </Link>
-                    </div>
-                )}
-            </div>
+            <FooterControls
+                isManualMode={isManualMode}
+                isRunning={isRunning}
+                nextStep={nextStep}
+                manualStepIndex={manualStepIndex}
+                stepsLength={steps.length}
+                currentStepIndex={currentStepIndex}
+                onToggleTimer={toggleTimer}
+                onResetTimer={resetTimer}
+                onGoToNextStep={goToNextStep}
+                onGoToPrevStep={goToPrevStep}
+                onComplete={handleComplete}
+            />
         </div>
     );
 };

--- a/components/drip-guide/Start46Dialog.tsx
+++ b/components/drip-guide/Start46Dialog.tsx
@@ -1,24 +1,22 @@
 'use client';
 
-import React, { useEffect, useCallback, useState, useMemo } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import { AnimatePresence, motion, type MotionProps } from 'framer-motion';
-import { Coffee, Timer, Drop } from 'phosphor-react';
 import { useRouter } from 'next/navigation';
-import { generateRecipe46, TASTE_LABELS, STRENGTH_LABELS, type Taste46, type Strength46 } from '@/lib/drip-guide/recipe46';
+import { generateRecipe46, type Taste46, type Strength46 } from '@/lib/drip-guide/recipe46';
 import { getLast46Taste, getLast46Strength, setLast46Taste, setLast46Strength } from '@/lib/localStorage';
-import { RECIPE46_DESCRIPTION_SECTIONS } from '@/lib/drip-guide/recipe46Content';
+import { useDialogKeyboard } from '@/hooks/drip-guide/useDialogKeyboard';
+import { DialogOverlay } from './dialogs/shared/DialogOverlay';
+import { Dialog46Header } from './dialogs/46/Dialog46Header';
+import { Dialog46Form } from './dialogs/46/Dialog46Form';
+import { Dialog46Preview } from './dialogs/46/Dialog46Preview';
+import { Dialog46DescriptionModal } from './dialogs/46/Dialog46DescriptionModal';
 
 interface Start46DialogProps {
     isOpen: boolean;
     onClose: () => void;
     initialServings?: number;
 }
-
-const overlayMotion = {
-    initial: { opacity: 0 },
-    animate: { opacity: 1 },
-    exit: { opacity: 0 },
-};
 
 const dialogMotion: MotionProps = {
     initial: { opacity: 0, scale: 0.96, y: 12 },
@@ -46,66 +44,46 @@ export const Start46Dialog: React.FC<Start46DialogProps> = ({
         const lastStrength = getLast46Strength();
 
         if (lastTaste === 'basic' || lastTaste === 'sweet' || lastTaste === 'bright') {
-             
             setTaste(lastTaste);
         }
         if (lastStrength === 'light' || lastStrength === 'strong2' || lastStrength === 'strong3') {
-             
             setStrength(lastStrength);
         }
     }, [isOpen]);
 
-    // 人前が変更された場合に更新
     useEffect(() => {
         setServings(initialServings);
     }, [initialServings]);
 
-    const handleKeyDown = useCallback(
-        (event: KeyboardEvent) => {
-            if (!isOpen) return;
-            if (event.key === 'Escape') {
-                event.preventDefault();
+    useDialogKeyboard({
+        isOpen,
+        onClose,
+        onEscape: () => {
+            if (isDescriptionModalOpen) {
+                setIsDescriptionModalOpen(false);
+            } else {
                 onClose();
             }
         },
-        [isOpen, onClose]
-    );
+    });
 
-    useEffect(() => {
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [handleKeyDown]);
-
-    // レシピを生成してプレビュー表示用のデータを作成
     const previewRecipe = useMemo(() => {
         return generateRecipe46(servings, taste, strength);
     }, [servings, taste, strength]);
 
     const handleStartGuide = () => {
-        // 前回の選択を保存
         setLast46Taste(taste);
         setLast46Strength(strength);
 
-        // /drip-guide/run へ遷移
         router.push(`/drip-guide/run?id=recipe-046&servings=${servings}&taste=${taste}&strength=${strength}`);
         onClose();
-    };
-
-    const formatTime = (seconds: number): string => {
-        const min = Math.floor(seconds / 60);
-        const sec = seconds % 60;
-        return `${min}:${sec.toString().padStart(2, '0')}`;
     };
 
     return (
         <AnimatePresence>
             {isOpen && (
                 <>
-                    <motion.div
-                        {...overlayMotion}
-                        className="fixed inset-0 z-50 bg-black/55"
-                        onClick={onClose}
-                    />
+                    <DialogOverlay onClick={onClose} />
                     <motion.div
                         {...dialogMotion}
                         className="fixed inset-0 z-50 flex items-center justify-center p-4 overflow-y-auto"
@@ -115,161 +93,19 @@ export const Start46Dialog: React.FC<Start46DialogProps> = ({
                             className="w-full max-w-2xl rounded-2xl border border-amber-100 bg-white shadow-2xl my-8"
                             onClick={(e) => e.stopPropagation()}
                         >
-                            <div className="flex items-start gap-3 px-5 pt-5">
-                                <div className="flex h-11 w-11 items-center justify-center rounded-full bg-amber-50 text-amber-700">
-                                    <Coffee size={24} weight="duotone" />
-                                </div>
-                                <div className="flex-1">
-                                    <p className="text-xs font-semibold uppercase tracking-wide text-amber-700">
-                                        4:6メソッド（粕谷）
-                                    </p>
-                                    <h3 className="mt-1 text-lg font-bold text-gray-900">
-                                        条件を選択してください
-                                    </h3>
-                                </div>
-                            </div>
+                            <Dialog46Header />
 
-                            <div className="px-5 py-4 space-y-4">
-                                {/* 4:6メソッドのポイント（解説ボタン） */}
-                                <button
-                                    type="button"
-                                    onClick={() => setIsDescriptionModalOpen(true)}
-                                    className="w-full rounded-lg bg-amber-50 border border-amber-100 p-3 text-left hover:bg-amber-100 transition-colors"
-                                >
-                                    <div className="flex items-center justify-between">
-                                        <span className="text-sm font-semibold text-amber-800">
-                                            4:6メソッドのポイント（必読）
-                                        </span>
-                                        <span className="text-amber-600 text-xs">クリックして開く</span>
-                                    </div>
-                                </button>
+                            <Dialog46Form
+                                servings={servings}
+                                taste={taste}
+                                strength={strength}
+                                onServingsChange={setServings}
+                                onTasteChange={setTaste}
+                                onStrengthChange={setStrength}
+                                onDescriptionClick={() => setIsDescriptionModalOpen(true)}
+                            />
 
-                                {/* 人前選択 */}
-                                <div>
-                                    <label htmlFor="servings-46" className="block text-sm font-semibold text-gray-900 mb-2">
-                                        人前
-                                    </label>
-                                    <select
-                                        id="servings-46"
-                                        value={servings}
-                                        onChange={(e) => setServings(parseInt(e.target.value, 10))}
-                                        className="w-full py-2 px-3 pr-10 rounded-lg text-sm font-medium transition-colors min-h-[44px] bg-white border border-gray-300 text-gray-700 hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500 appearance-none cursor-pointer"
-                                        aria-label="人前を選択"
-                                    >
-                                        {[1, 2, 3, 4, 5, 6, 7, 8].map((s) => (
-                                            <option key={s} value={s}>
-                                                {s}人前 ({s * 10}g / {s * 150}g)
-                                            </option>
-                                        ))}
-                                    </select>
-                                </div>
-
-                                {/* 味わい選択 */}
-                                <div>
-                                    <label className="block text-sm font-semibold text-gray-900 mb-2">
-                                        味わい
-                                    </label>
-                                    <div className="grid grid-cols-3 gap-2">
-                                        {(['basic', 'sweet', 'bright'] as Taste46[]).map((t) => (
-                                            <button
-                                                key={t}
-                                                type="button"
-                                                onClick={() => setTaste(t)}
-                                                className={`py-3 px-4 rounded-lg text-sm font-medium transition-all min-h-[44px] ${taste === t
-                                                    ? 'bg-amber-500 text-white shadow-md'
-                                                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                                                    }`}
-                                            >
-                                                {TASTE_LABELS[t]}
-                                            </button>
-                                        ))}
-                                    </div>
-                                </div>
-
-                                {/* 濃度選択 */}
-                                <div>
-                                    <label className="block text-sm font-semibold text-gray-900 mb-2">
-                                        濃度
-                                    </label>
-                                    <div className="grid grid-cols-3 gap-2">
-                                        {(['light', 'strong2', 'strong3'] as Strength46[]).map((s) => (
-                                            <button
-                                                key={s}
-                                                type="button"
-                                                onClick={() => setStrength(s)}
-                                                className={`py-3 px-4 rounded-lg text-sm font-medium transition-all min-h-[44px] ${strength === s
-                                                    ? 'bg-amber-500 text-white shadow-md'
-                                                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                                                    }`}
-                                            >
-                                                {STRENGTH_LABELS[s]}
-                                            </button>
-                                        ))}
-                                    </div>
-                                </div>
-
-                                {/* プレビュー情報 */}
-                                <div className="pt-4 border-t border-gray-200">
-                                    <div className="grid grid-cols-2 gap-4 mb-4">
-                                        <div className="flex items-center gap-2">
-                                            <Coffee size={20} className="text-amber-700" />
-                                            <span className="text-sm text-gray-600">豆量:</span>
-                                            <span className="text-sm font-semibold text-gray-900">
-                                                {previewRecipe.beanAmountGram}g
-                                            </span>
-                                        </div>
-                                        <div className="flex items-center gap-2">
-                                            <Drop size={20} className="text-blue-500" />
-                                            <span className="text-sm text-gray-600">総湯量:</span>
-                                            <span className="text-sm font-semibold text-gray-900">
-                                                {previewRecipe.totalWaterGram}g
-                                            </span>
-                                        </div>
-                                    </div>
-
-                                    {/* ステッププレビューテーブル */}
-                                    <div className="overflow-x-auto">
-                                        <table className="w-full text-sm">
-                                            <thead>
-                                                <tr className="border-b border-gray-200">
-                                                    <th className="text-left py-2 px-2 font-semibold text-gray-700">開始時刻</th>
-                                                    <th className="text-left py-2 px-2 font-semibold text-gray-700">タイトル</th>
-                                                    <th className="text-right py-2 px-2 font-semibold text-gray-700">注湯量(g)</th>
-                                                    <th className="text-right py-2 px-2 font-semibold text-gray-700">累積(g)</th>
-                                                </tr>
-                                            </thead>
-                                            <tbody>
-                                                {previewRecipe.steps.map((step, index) => {
-                                                    const prevTarget = index > 0 ? previewRecipe.steps[index - 1].targetTotalWater || 0 : 0;
-                                                    const currentTarget = step.targetTotalWater || 0;
-                                                    const pourAmount = currentTarget - prevTarget;
-                                                    return (
-                                                        <tr key={step.id} className="border-b border-gray-100">
-                                                            <td className="py-2 px-2 text-gray-700 font-mono">
-                                                                {formatTime(step.startTimeSec)}
-                                                            </td>
-                                                            <td className="py-2 px-2 text-gray-700">{step.title}</td>
-                                                            <td className="py-2 px-2 text-right text-gray-900 font-semibold">
-                                                                {pourAmount}
-                                                            </td>
-                                                            <td className="py-2 px-2 text-right text-gray-900 font-semibold">
-                                                                {currentTarget}
-                                                            </td>
-                                                        </tr>
-                                                    );
-                                                })}
-                                            </tbody>
-                                        </table>
-                                    </div>
-
-                                    <div className="mt-4 flex items-center gap-2 text-xs text-gray-500">
-                                        <Timer size={16} />
-                                        <span>
-                                            総時間: {formatTime(previewRecipe.totalDurationSec)} ({Math.floor(previewRecipe.totalDurationSec / 60)}分{previewRecipe.totalDurationSec % 60}秒)
-                                        </span>
-                                    </div>
-                                </div>
-                            </div>
+                            <Dialog46Preview recipe={previewRecipe} />
 
                             <div className="flex items-center justify-between px-5 pb-5 pt-1">
                                 <button
@@ -291,76 +127,10 @@ export const Start46Dialog: React.FC<Start46DialogProps> = ({
                         </div>
                     </motion.div>
 
-                    {/* 4:6メソッドのポイント説明モーダル */}
-                    <AnimatePresence>
-                        {isDescriptionModalOpen && (
-                            <>
-                                <motion.div
-                                    {...overlayMotion}
-                                    className="fixed inset-0 z-[60] bg-black/40"
-                                    onClick={() => setIsDescriptionModalOpen(false)}
-                                />
-                                <motion.div
-                                    {...dialogMotion}
-                                    className="fixed inset-0 z-[60] flex items-center justify-center p-4 overflow-y-auto"
-                                    onClick={() => setIsDescriptionModalOpen(false)}
-                                >
-                                    <div
-                                        className="w-full max-w-xl rounded-2xl bg-white shadow-xl relative overflow-hidden flex flex-col"
-                                        style={{ maxHeight: '90vh' }}
-                                        onClick={(e) => e.stopPropagation()}
-                                    >
-                                        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
-                                            <h3 className="text-xl font-bold text-gray-900">
-                                                4:6メソッドのポイント
-                                            </h3>
-                                            <button
-                                                type="button"
-                                                onClick={() => setIsDescriptionModalOpen(false)}
-                                                className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-full transition-colors"
-                                            >
-                                                <span className="text-2xl leading-none">×</span>
-                                            </button>
-                                        </div>
-
-                                        <div className="flex-1 overflow-y-auto px-6 py-6 space-y-6">
-                                            {RECIPE46_DESCRIPTION_SECTIONS.map((section, idx) => (
-                                                <div
-                                                    key={idx}
-                                                    className="flex gap-4"
-                                                >
-                                                    <div className="flex-shrink-0 w-10 h-10 rounded-full bg-amber-50 text-amber-700 flex items-center justify-center">
-                                                        {section.icon === 'target' && <Drop size={20} weight="bold" />}
-                                                        {section.icon === 'rule' && <Coffee size={20} weight="bold" />}
-                                                        {section.icon === 'timer' && <Timer size={20} weight="bold" />}
-                                                        {section.icon === 'thermometer' && <Drop size={20} weight="duotone" />}
-                                                    </div>
-                                                    <div className="flex-1 border-b border-gray-50 pb-4">
-                                                        <h4 className="font-bold text-gray-900 mb-1 text-base">
-                                                            {section.title}
-                                                        </h4>
-                                                        <p className="text-[15px] leading-relaxed text-gray-600 whitespace-pre-wrap">
-                                                            {section.content}
-                                                        </p>
-                                                    </div>
-                                                </div>
-                                            ))}
-                                        </div>
-
-                                        <div className="px-6 py-4 bg-gray-50 border-t border-gray-100 flex justify-end">
-                                            <button
-                                                type="button"
-                                                onClick={() => setIsDescriptionModalOpen(false)}
-                                                className="bg-gray-900 text-white px-8 py-2.5 rounded-lg font-bold text-sm hover:bg-black transition-colors"
-                                            >
-                                                閉じる
-                                            </button>
-                                        </div>
-                                    </div>
-                                </motion.div>
-                            </>
-                        )}
-                    </AnimatePresence>
+                    <Dialog46DescriptionModal
+                        isOpen={isDescriptionModalOpen}
+                        onClose={() => setIsDescriptionModalOpen(false)}
+                    />
                 </>
             )}
         </AnimatePresence>

--- a/components/drip-guide/StartHoffmannDialog.tsx
+++ b/components/drip-guide/StartHoffmannDialog.tsx
@@ -1,27 +1,24 @@
 'use client';
 
-import React, { useEffect, useCallback, useState, useMemo } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import { AnimatePresence, motion, type MotionProps } from 'framer-motion';
-import { Coffee, Timer, Drop, Spiral, SpinnerGap } from 'phosphor-react';
 import { useRouter } from 'next/navigation';
-import {
-    RECIPE_HOFFMANN_DESCRIPTION_SECTIONS,
-    RECIPE_HOFFMANN_STEP_DETAILS,
-} from '@/lib/drip-guide/recipeHoffmannContent';
 import { calculateRecipeForServings } from '@/lib/drip-guide/recipeCalculator';
 import { MOCK_RECIPES } from '@/lib/drip-guide/mockData';
+import { RECIPE_HOFFMANN_STEP_DETAILS } from '@/lib/drip-guide/recipeHoffmannContent';
+import { useDialogKeyboard } from '@/hooks/drip-guide/useDialogKeyboard';
+import { DialogOverlay } from './dialogs/shared/DialogOverlay';
+import { HoffmannDialogHeader } from './dialogs/hoffmann/HoffmannDialogHeader';
+import { HoffmannDialogForm } from './dialogs/hoffmann/HoffmannDialogForm';
+import { HoffmannPreview } from './dialogs/hoffmann/HoffmannPreview';
+import { HoffmannDescriptionModal } from './dialogs/hoffmann/HoffmannDescriptionModal';
+import { HoffmannStepDetailModal } from './dialogs/hoffmann/HoffmannStepDetailModal';
 
 interface StartHoffmannDialogProps {
     isOpen: boolean;
     onClose: () => void;
     initialServings?: number;
 }
-
-const overlayMotion = {
-    initial: { opacity: 0 },
-    animate: { opacity: 1 },
-    exit: { opacity: 0 },
-};
 
 const dialogMotion: MotionProps = {
     initial: { opacity: 0, scale: 0.96, y: 12 },
@@ -30,7 +27,6 @@ const dialogMotion: MotionProps = {
     transition: { type: 'spring', stiffness: 240, damping: 28 },
 };
 
-// ステップ詳細の型
 type StepDetailKey = keyof typeof RECIPE_HOFFMANN_STEP_DETAILS;
 
 export const StartHoffmannDialog: React.FC<StartHoffmannDialogProps> = ({
@@ -43,34 +39,24 @@ export const StartHoffmannDialog: React.FC<StartHoffmannDialogProps> = ({
     const [isDescriptionModalOpen, setIsDescriptionModalOpen] = useState(false);
     const [selectedStepDetail, setSelectedStepDetail] = useState<StepDetailKey | null>(null);
 
-    // 人前が変更された場合に更新
     useEffect(() => {
         setServings(initialServings);
     }, [initialServings]);
 
-    const handleKeyDown = useCallback(
-        (event: KeyboardEvent) => {
-            if (!isOpen) return;
-            if (event.key === 'Escape') {
-                event.preventDefault();
-                if (selectedStepDetail) {
-                    setSelectedStepDetail(null);
-                } else if (isDescriptionModalOpen) {
-                    setIsDescriptionModalOpen(false);
-                } else {
-                    onClose();
-                }
+    useDialogKeyboard({
+        isOpen,
+        onClose,
+        onEscape: () => {
+            if (selectedStepDetail) {
+                setSelectedStepDetail(null);
+            } else if (isDescriptionModalOpen) {
+                setIsDescriptionModalOpen(false);
+            } else {
+                onClose();
             }
         },
-        [isOpen, onClose, isDescriptionModalOpen, selectedStepDetail]
-    );
+    });
 
-    useEffect(() => {
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [handleKeyDown]);
-
-    // Hoffmannレシピを取得して人前に応じて計算
     const baseRecipe = useMemo(() => {
         return MOCK_RECIPES.find((r) => r.id === 'recipe-hoffmann');
     }, []);
@@ -85,57 +71,13 @@ export const StartHoffmannDialog: React.FC<StartHoffmannDialogProps> = ({
         onClose();
     };
 
-    const formatTime = (seconds: number): string => {
-        const min = Math.floor(seconds / 60);
-        const sec = seconds % 60;
-        return `${min}:${sec.toString().padStart(2, '0')}`;
-    };
-
-    // ステップからステップ詳細へのマッピング
-    const stepToDetailKey = (stepTitle: string): StepDetailKey | null => {
-        if (stepTitle.includes('蒸らし')) return 'bloom';
-        if (stepTitle.includes('第1注湯')) return 'pour1';
-        if (stepTitle.includes('第2注湯')) return 'pour2';
-        if (stepTitle.includes('かき混ぜ')) return 'stir';
-        if (stepTitle.includes('落ち切り')) return 'drawdown';
-        return null;
-    };
-
-    // アイコン取得
-    const getIcon = (iconName: string) => {
-        switch (iconName) {
-            case 'target':
-                return <Drop size={20} weight="bold" />;
-            case 'rule':
-                return <Coffee size={20} weight="bold" />;
-            case 'swirl':
-                return <Spiral size={20} weight="bold" />;
-            case 'thermometer':
-                return <Timer size={20} weight="bold" />;
-            case 'bloom':
-                return <Drop size={20} weight="fill" />;
-            case 'pour':
-                return <Drop size={20} weight="duotone" />;
-            case 'stir':
-                return <SpinnerGap size={20} weight="bold" />;
-            case 'timer':
-                return <Timer size={20} weight="duotone" />;
-            default:
-                return <Coffee size={20} weight="bold" />;
-        }
-    };
-
     if (!previewRecipe) return null;
 
     return (
         <AnimatePresence>
             {isOpen && (
                 <>
-                    <motion.div
-                        {...overlayMotion}
-                        className="fixed inset-0 z-50 bg-black/55"
-                        onClick={onClose}
-                    />
+                    <DialogOverlay onClick={onClose} />
                     <motion.div
                         {...dialogMotion}
                         className="fixed inset-0 z-50 flex items-center justify-center p-4 overflow-y-auto"
@@ -145,123 +87,18 @@ export const StartHoffmannDialog: React.FC<StartHoffmannDialogProps> = ({
                             className="w-full max-w-2xl rounded-2xl border border-amber-100 bg-white shadow-2xl my-8"
                             onClick={(e) => e.stopPropagation()}
                         >
-                            <div className="flex items-start gap-3 px-5 pt-5">
-                                <div className="flex h-11 w-11 items-center justify-center rounded-full bg-amber-50 text-amber-700">
-                                    <Coffee size={24} weight="duotone" />
-                                </div>
-                                <div className="flex-1">
-                                    <p className="text-xs font-semibold uppercase tracking-wide text-amber-700">
-                                        James Hoffmann V60
-                                    </p>
-                                    <h3 className="mt-1 text-lg font-bold text-gray-900">
-                                        Ultimate V60 Technique
-                                    </h3>
-                                </div>
-                            </div>
+                            <HoffmannDialogHeader />
 
-                            <div className="px-5 py-4 space-y-4">
-                                {/* メソッドのポイント（解説ボタン） */}
-                                <button
-                                    type="button"
-                                    onClick={() => setIsDescriptionModalOpen(true)}
-                                    className="w-full rounded-lg bg-amber-50 border border-amber-100 p-3 text-left hover:bg-amber-100 transition-colors"
-                                >
-                                    <div className="flex items-center justify-between">
-                                        <span className="text-sm font-semibold text-amber-800">
-                                            Hoffmann V60のポイント（必読）
-                                        </span>
-                                        <span className="text-amber-600 text-xs">クリックして開く</span>
-                                    </div>
-                                </button>
+                            <HoffmannDialogForm
+                                servings={servings}
+                                onServingsChange={setServings}
+                                onDescriptionClick={() => setIsDescriptionModalOpen(true)}
+                            />
 
-                                {/* 人前選択 */}
-                                <div>
-                                    <label htmlFor="servings-hoffmann" className="block text-sm font-semibold text-gray-900 mb-2">
-                                        人前
-                                    </label>
-                                    <select
-                                        id="servings-hoffmann"
-                                        value={servings}
-                                        onChange={(e) => setServings(parseInt(e.target.value, 10))}
-                                        className="w-full py-2 px-3 pr-10 rounded-lg text-sm font-medium transition-colors min-h-[44px] bg-white border border-gray-300 text-gray-700 hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500 appearance-none cursor-pointer"
-                                        aria-label="人前を選択"
-                                    >
-                                        {[1, 2, 3, 4, 5, 6, 7, 8].map((s) => (
-                                            <option key={s} value={s}>
-                                                {s}人前 ({s * 15}g / {s * 250}g)
-                                            </option>
-                                        ))}
-                                    </select>
-                                </div>
-
-                                {/* プレビュー情報 */}
-                                <div className="pt-4 border-t border-gray-200">
-                                    <div className="grid grid-cols-2 gap-4 mb-4">
-                                        <div className="flex items-center gap-2">
-                                            <Coffee size={20} className="text-amber-700" />
-                                            <span className="text-sm text-gray-600">豆量:</span>
-                                            <span className="text-sm font-semibold text-gray-900">
-                                                {previewRecipe.beanAmountGram}g
-                                            </span>
-                                        </div>
-                                        <div className="flex items-center gap-2">
-                                            <Drop size={20} className="text-blue-500" />
-                                            <span className="text-sm text-gray-600">総湯量:</span>
-                                            <span className="text-sm font-semibold text-gray-900">
-                                                {previewRecipe.totalWaterGram}g
-                                            </span>
-                                        </div>
-                                    </div>
-
-                                    {/* ステッププレビューテーブル */}
-                                    <div className="overflow-x-auto">
-                                        <table className="w-full text-sm">
-                                            <thead>
-                                                <tr className="border-b border-gray-200">
-                                                    <th className="text-left py-2 px-2 font-semibold text-gray-700">開始時刻</th>
-                                                    <th className="text-left py-2 px-2 font-semibold text-gray-700">ステップ</th>
-                                                    <th className="text-right py-2 px-2 font-semibold text-gray-700">累積(g)</th>
-                                                    <th className="text-center py-2 px-2 font-semibold text-gray-700">詳細</th>
-                                                </tr>
-                                            </thead>
-                                            <tbody>
-                                                {previewRecipe.steps.map((step) => {
-                                                    const detailKey = stepToDetailKey(step.title);
-                                                    return (
-                                                        <tr key={step.id} className="border-b border-gray-100">
-                                                            <td className="py-2 px-2 text-gray-700 font-mono">
-                                                                {formatTime(step.startTimeSec)}
-                                                            </td>
-                                                            <td className="py-2 px-2 text-gray-700">{step.title}</td>
-                                                            <td className="py-2 px-2 text-right text-gray-900 font-semibold">
-                                                                {step.targetTotalWater ?? '-'}
-                                                            </td>
-                                                            <td className="py-2 px-2 text-center">
-                                                                {detailKey && (
-                                                                    <button
-                                                                        type="button"
-                                                                        onClick={() => setSelectedStepDetail(detailKey)}
-                                                                        className="text-amber-600 hover:text-amber-800 text-xs underline"
-                                                                    >
-                                                                        詳細
-                                                                    </button>
-                                                                )}
-                                                            </td>
-                                                        </tr>
-                                                    );
-                                                })}
-                                            </tbody>
-                                        </table>
-                                    </div>
-
-                                    <div className="mt-4 flex items-center gap-2 text-xs text-gray-500">
-                                        <Timer size={16} />
-                                        <span>
-                                            総時間: {formatTime(previewRecipe.totalDurationSec)} ({Math.floor(previewRecipe.totalDurationSec / 60)}分{previewRecipe.totalDurationSec % 60}秒)
-                                        </span>
-                                    </div>
-                                </div>
-                            </div>
+                            <HoffmannPreview
+                                recipe={previewRecipe}
+                                onStepDetailClick={setSelectedStepDetail}
+                            />
 
                             <div className="flex items-center justify-between px-5 pb-5 pt-1">
                                 <button
@@ -283,149 +120,15 @@ export const StartHoffmannDialog: React.FC<StartHoffmannDialogProps> = ({
                         </div>
                     </motion.div>
 
-                    {/* メソッドのポイント説明モーダル */}
-                    <AnimatePresence>
-                        {isDescriptionModalOpen && (
-                            <>
-                                <motion.div
-                                    {...overlayMotion}
-                                    className="fixed inset-0 z-[60] bg-black/40"
-                                    onClick={() => setIsDescriptionModalOpen(false)}
-                                />
-                                <motion.div
-                                    {...dialogMotion}
-                                    className="fixed inset-0 z-[60] flex items-center justify-center p-4 overflow-y-auto"
-                                    onClick={() => setIsDescriptionModalOpen(false)}
-                                >
-                                    <div
-                                        className="w-full max-w-xl rounded-2xl bg-white shadow-xl relative overflow-hidden flex flex-col"
-                                        style={{ maxHeight: '90vh' }}
-                                        onClick={(e) => e.stopPropagation()}
-                                    >
-                                        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
-                                            <h3 className="text-xl font-bold text-gray-900">
-                                                Hoffmann V60のポイント
-                                            </h3>
-                                            <button
-                                                type="button"
-                                                onClick={() => setIsDescriptionModalOpen(false)}
-                                                className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-full transition-colors"
-                                            >
-                                                <span className="text-2xl leading-none">×</span>
-                                            </button>
-                                        </div>
+                    <HoffmannDescriptionModal
+                        isOpen={isDescriptionModalOpen}
+                        onClose={() => setIsDescriptionModalOpen(false)}
+                    />
 
-                                        <div className="flex-1 overflow-y-auto px-6 py-6 space-y-6">
-                                            {RECIPE_HOFFMANN_DESCRIPTION_SECTIONS.map((section, idx) => (
-                                                <div
-                                                    key={idx}
-                                                    className="flex gap-4"
-                                                >
-                                                    <div className="flex-shrink-0 w-10 h-10 rounded-full bg-amber-50 text-amber-700 flex items-center justify-center">
-                                                        {getIcon(section.icon)}
-                                                    </div>
-                                                    <div className="flex-1 border-b border-gray-50 pb-4">
-                                                        <h4 className="font-bold text-gray-900 mb-1 text-base">
-                                                            {section.title}
-                                                        </h4>
-                                                        <p className="text-[15px] leading-relaxed text-gray-600 whitespace-pre-wrap">
-                                                            {section.content}
-                                                        </p>
-                                                    </div>
-                                                </div>
-                                            ))}
-                                        </div>
-
-                                        <div className="px-6 py-4 bg-gray-50 border-t border-gray-100 flex justify-end">
-                                            <button
-                                                type="button"
-                                                onClick={() => setIsDescriptionModalOpen(false)}
-                                                className="bg-gray-900 text-white px-8 py-2.5 rounded-lg font-bold text-sm hover:bg-black transition-colors"
-                                            >
-                                                閉じる
-                                            </button>
-                                        </div>
-                                    </div>
-                                </motion.div>
-                            </>
-                        )}
-                    </AnimatePresence>
-
-                    {/* ステップ詳細モーダル */}
-                    <AnimatePresence>
-                        {selectedStepDetail && (
-                            <>
-                                <motion.div
-                                    {...overlayMotion}
-                                    className="fixed inset-0 z-[60] bg-black/40"
-                                    onClick={() => setSelectedStepDetail(null)}
-                                />
-                                <motion.div
-                                    {...dialogMotion}
-                                    className="fixed inset-0 z-[60] flex items-center justify-center p-4 overflow-y-auto"
-                                    onClick={() => setSelectedStepDetail(null)}
-                                >
-                                    <div
-                                        className="w-full max-w-md rounded-2xl bg-white shadow-xl relative overflow-hidden"
-                                        onClick={(e) => e.stopPropagation()}
-                                    >
-                                        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
-                                            <div className="flex items-center gap-3">
-                                                <div className="w-10 h-10 rounded-full bg-amber-50 text-amber-700 flex items-center justify-center">
-                                                    {getIcon(RECIPE_HOFFMANN_STEP_DETAILS[selectedStepDetail].icon)}
-                                                </div>
-                                                <div>
-                                                    <h3 className="text-lg font-bold text-gray-900">
-                                                        {RECIPE_HOFFMANN_STEP_DETAILS[selectedStepDetail].title}
-                                                    </h3>
-                                                    <p className="text-xs text-amber-700 font-medium">
-                                                        {RECIPE_HOFFMANN_STEP_DETAILS[selectedStepDetail].technique}
-                                                    </p>
-                                                </div>
-                                            </div>
-                                            <button
-                                                type="button"
-                                                onClick={() => setSelectedStepDetail(null)}
-                                                className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-full transition-colors"
-                                            >
-                                                <span className="text-2xl leading-none">×</span>
-                                            </button>
-                                        </div>
-
-                                        <div className="px-6 py-5 space-y-4">
-                                            <p className="text-gray-700 leading-relaxed">
-                                                {RECIPE_HOFFMANN_STEP_DETAILS[selectedStepDetail].description}
-                                            </p>
-
-                                            <div className="bg-amber-50 rounded-lg p-4">
-                                                <h4 className="font-semibold text-amber-800 mb-2 text-sm">
-                                                    ポイント
-                                                </h4>
-                                                <ul className="space-y-2">
-                                                    {RECIPE_HOFFMANN_STEP_DETAILS[selectedStepDetail].tips.map((tip, idx) => (
-                                                        <li key={idx} className="flex items-start gap-2 text-sm text-amber-900">
-                                                            <span className="text-amber-600 mt-0.5">•</span>
-                                                            <span>{tip}</span>
-                                                        </li>
-                                                    ))}
-                                                </ul>
-                                            </div>
-                                        </div>
-
-                                        <div className="px-6 py-4 bg-gray-50 border-t border-gray-100 flex justify-end">
-                                            <button
-                                                type="button"
-                                                onClick={() => setSelectedStepDetail(null)}
-                                                className="bg-gray-900 text-white px-6 py-2 rounded-lg font-bold text-sm hover:bg-black transition-colors"
-                                            >
-                                                閉じる
-                                            </button>
-                                        </div>
-                                    </div>
-                                </motion.div>
-                            </>
-                        )}
-                    </AnimatePresence>
+                    <HoffmannStepDetailModal
+                        detailKey={selectedStepDetail}
+                        onClose={() => setSelectedStepDetail(null)}
+                    />
                 </>
             )}
         </AnimatePresence>

--- a/components/drip-guide/dialogs/46/Dialog46DescriptionModal.tsx
+++ b/components/drip-guide/dialogs/46/Dialog46DescriptionModal.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import React from 'react';
+import { AnimatePresence, motion, type MotionProps } from 'framer-motion';
+import { Coffee, Timer, Drop } from 'phosphor-react';
+import { RECIPE46_DESCRIPTION_SECTIONS } from '@/lib/drip-guide/recipe46Content';
+
+const overlayMotion = {
+    initial: { opacity: 0 },
+    animate: { opacity: 1 },
+    exit: { opacity: 0 },
+};
+
+const dialogMotion: MotionProps = {
+    initial: { opacity: 0, scale: 0.96, y: 12 },
+    animate: { opacity: 1, scale: 1, y: 0 },
+    exit: { opacity: 0, scale: 0.96, y: 12 },
+    transition: { type: 'spring', stiffness: 240, damping: 28 },
+};
+
+interface Dialog46DescriptionModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+export const Dialog46DescriptionModal: React.FC<Dialog46DescriptionModalProps> = ({
+    isOpen,
+    onClose,
+}) => {
+    return (
+        <AnimatePresence>
+            {isOpen && (
+                <>
+                    <motion.div
+                        {...overlayMotion}
+                        className="fixed inset-0 z-[60] bg-black/40"
+                        onClick={onClose}
+                    />
+                    <motion.div
+                        {...dialogMotion}
+                        className="fixed inset-0 z-[60] flex items-center justify-center p-4 overflow-y-auto"
+                        onClick={onClose}
+                    >
+                        <div
+                            className="w-full max-w-xl rounded-2xl bg-white shadow-xl relative overflow-hidden flex flex-col"
+                            style={{ maxHeight: '90vh' }}
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+                                <h3 className="text-xl font-bold text-gray-900">
+                                    4:6メソッドのポイント
+                                </h3>
+                                <button
+                                    type="button"
+                                    onClick={onClose}
+                                    className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-full transition-colors"
+                                >
+                                    <span className="text-2xl leading-none">×</span>
+                                </button>
+                            </div>
+
+                            <div className="flex-1 overflow-y-auto px-6 py-6 space-y-6">
+                                {RECIPE46_DESCRIPTION_SECTIONS.map((section, idx) => (
+                                    <div key={idx} className="flex gap-4">
+                                        <div className="flex-shrink-0 w-10 h-10 rounded-full bg-amber-50 text-amber-700 flex items-center justify-center">
+                                            {section.icon === 'target' && <Drop size={20} weight="bold" />}
+                                            {section.icon === 'rule' && <Coffee size={20} weight="bold" />}
+                                            {section.icon === 'timer' && <Timer size={20} weight="bold" />}
+                                            {section.icon === 'thermometer' && (
+                                                <Drop size={20} weight="duotone" />
+                                            )}
+                                        </div>
+                                        <div className="flex-1 border-b border-gray-50 pb-4">
+                                            <h4 className="font-bold text-gray-900 mb-1 text-base">
+                                                {section.title}
+                                            </h4>
+                                            <p className="text-[15px] leading-relaxed text-gray-600 whitespace-pre-wrap">
+                                                {section.content}
+                                            </p>
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+
+                            <div className="px-6 py-4 bg-gray-50 border-t border-gray-100 flex justify-end">
+                                <button
+                                    type="button"
+                                    onClick={onClose}
+                                    className="bg-gray-900 text-white px-8 py-2.5 rounded-lg font-bold text-sm hover:bg-black transition-colors"
+                                >
+                                    閉じる
+                                </button>
+                            </div>
+                        </div>
+                    </motion.div>
+                </>
+            )}
+        </AnimatePresence>
+    );
+};

--- a/components/drip-guide/dialogs/46/Dialog46Form.tsx
+++ b/components/drip-guide/dialogs/46/Dialog46Form.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import React from 'react';
+import { TASTE_LABELS, STRENGTH_LABELS, type Taste46, type Strength46 } from '@/lib/drip-guide/recipe46';
+
+interface Dialog46FormProps {
+    servings: number;
+    taste: Taste46;
+    strength: Strength46;
+    onServingsChange: (servings: number) => void;
+    onTasteChange: (taste: Taste46) => void;
+    onStrengthChange: (strength: Strength46) => void;
+    onDescriptionClick: () => void;
+}
+
+export const Dialog46Form: React.FC<Dialog46FormProps> = ({
+    servings,
+    taste,
+    strength,
+    onServingsChange,
+    onTasteChange,
+    onStrengthChange,
+    onDescriptionClick,
+}) => {
+    return (
+        <div className="px-5 py-4 space-y-4">
+            {/* 4:6メソッドのポイント（解説ボタン） */}
+            <button
+                type="button"
+                onClick={onDescriptionClick}
+                className="w-full rounded-lg bg-amber-50 border border-amber-100 p-3 text-left hover:bg-amber-100 transition-colors"
+            >
+                <div className="flex items-center justify-between">
+                    <span className="text-sm font-semibold text-amber-800">
+                        4:6メソッドのポイント（必読）
+                    </span>
+                    <span className="text-amber-600 text-xs">クリックして開く</span>
+                </div>
+            </button>
+
+            {/* 人前選択 */}
+            <div>
+                <label htmlFor="servings-46" className="block text-sm font-semibold text-gray-900 mb-2">
+                    人前
+                </label>
+                <select
+                    id="servings-46"
+                    value={servings}
+                    onChange={(e) => onServingsChange(parseInt(e.target.value, 10))}
+                    className="w-full py-2 px-3 pr-10 rounded-lg text-sm font-medium transition-colors min-h-[44px] bg-white border border-gray-300 text-gray-700 hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500 appearance-none cursor-pointer"
+                    aria-label="人前を選択"
+                >
+                    {[1, 2, 3, 4, 5, 6, 7, 8].map((s) => (
+                        <option key={s} value={s}>
+                            {s}人前 ({s * 10}g / {s * 150}g)
+                        </option>
+                    ))}
+                </select>
+            </div>
+
+            {/* 味わい選択 */}
+            <div>
+                <label className="block text-sm font-semibold text-gray-900 mb-2">味わい</label>
+                <div className="grid grid-cols-3 gap-2">
+                    {(['basic', 'sweet', 'bright'] as Taste46[]).map((t) => (
+                        <button
+                            key={t}
+                            type="button"
+                            onClick={() => onTasteChange(t)}
+                            className={`py-3 px-4 rounded-lg text-sm font-medium transition-all min-h-[44px] ${
+                                taste === t
+                                    ? 'bg-amber-500 text-white shadow-md'
+                                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                            }`}
+                        >
+                            {TASTE_LABELS[t]}
+                        </button>
+                    ))}
+                </div>
+            </div>
+
+            {/* 濃度選択 */}
+            <div>
+                <label className="block text-sm font-semibold text-gray-900 mb-2">濃度</label>
+                <div className="grid grid-cols-3 gap-2">
+                    {(['light', 'strong2', 'strong3'] as Strength46[]).map((s) => (
+                        <button
+                            key={s}
+                            type="button"
+                            onClick={() => onStrengthChange(s)}
+                            className={`py-3 px-4 rounded-lg text-sm font-medium transition-all min-h-[44px] ${
+                                strength === s
+                                    ? 'bg-amber-500 text-white shadow-md'
+                                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                            }`}
+                        >
+                            {STRENGTH_LABELS[s]}
+                        </button>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/components/drip-guide/dialogs/46/Dialog46Header.tsx
+++ b/components/drip-guide/dialogs/46/Dialog46Header.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import React from 'react';
+import { Coffee } from 'phosphor-react';
+
+export const Dialog46Header: React.FC = () => {
+    return (
+        <div className="flex items-start gap-3 px-5 pt-5">
+            <div className="flex h-11 w-11 items-center justify-center rounded-full bg-amber-50 text-amber-700">
+                <Coffee size={24} weight="duotone" />
+            </div>
+            <div className="flex-1">
+                <p className="text-xs font-semibold uppercase tracking-wide text-amber-700">
+                    4:6メソッド（粕谷）
+                </p>
+                <h3 className="mt-1 text-lg font-bold text-gray-900">条件を選択してください</h3>
+            </div>
+        </div>
+    );
+};

--- a/components/drip-guide/dialogs/46/Dialog46Preview.tsx
+++ b/components/drip-guide/dialogs/46/Dialog46Preview.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import React from 'react';
+import { DripRecipe } from '@/lib/drip-guide/types';
+import { RecipeSummary } from '../shared/RecipeSummary';
+import { RecipeStepTable } from '../shared/RecipeStepTable';
+
+interface Dialog46PreviewProps {
+    recipe: DripRecipe;
+}
+
+export const Dialog46Preview: React.FC<Dialog46PreviewProps> = ({ recipe }) => {
+    return (
+        <div className="px-5 pt-0 pb-4">
+            <div className="pt-4 border-t border-gray-200">
+                <RecipeSummary
+                    beanAmountGram={recipe.beanAmountGram}
+                    totalWaterGram={recipe.totalWaterGram}
+                    totalDurationSec={recipe.totalDurationSec}
+                />
+
+                <div className="mt-4">
+                    <RecipeStepTable steps={recipe.steps} showPourAmount={true} />
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/components/drip-guide/dialogs/hoffmann/HoffmannDescriptionModal.tsx
+++ b/components/drip-guide/dialogs/hoffmann/HoffmannDescriptionModal.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import React from 'react';
+import { AnimatePresence, motion, type MotionProps } from 'framer-motion';
+import { Coffee, Timer, Drop, Spiral } from 'phosphor-react';
+import { RECIPE_HOFFMANN_DESCRIPTION_SECTIONS } from '@/lib/drip-guide/recipeHoffmannContent';
+
+const overlayMotion = {
+    initial: { opacity: 0 },
+    animate: { opacity: 1 },
+    exit: { opacity: 0 },
+};
+
+const dialogMotion: MotionProps = {
+    initial: { opacity: 0, scale: 0.96, y: 12 },
+    animate: { opacity: 1, scale: 1, y: 0 },
+    exit: { opacity: 0, scale: 0.96, y: 12 },
+    transition: { type: 'spring', stiffness: 240, damping: 28 },
+};
+
+interface HoffmannDescriptionModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+const getIcon = (iconName: string) => {
+    switch (iconName) {
+        case 'target':
+            return <Drop size={20} weight="bold" />;
+        case 'rule':
+            return <Coffee size={20} weight="bold" />;
+        case 'swirl':
+            return <Spiral size={20} weight="bold" />;
+        case 'thermometer':
+            return <Timer size={20} weight="bold" />;
+        default:
+            return <Coffee size={20} weight="bold" />;
+    }
+};
+
+export const HoffmannDescriptionModal: React.FC<HoffmannDescriptionModalProps> = ({
+    isOpen,
+    onClose,
+}) => {
+    return (
+        <AnimatePresence>
+            {isOpen && (
+                <>
+                    <motion.div
+                        {...overlayMotion}
+                        className="fixed inset-0 z-[60] bg-black/40"
+                        onClick={onClose}
+                    />
+                    <motion.div
+                        {...dialogMotion}
+                        className="fixed inset-0 z-[60] flex items-center justify-center p-4 overflow-y-auto"
+                        onClick={onClose}
+                    >
+                        <div
+                            className="w-full max-w-xl rounded-2xl bg-white shadow-xl relative overflow-hidden flex flex-col"
+                            style={{ maxHeight: '90vh' }}
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+                                <h3 className="text-xl font-bold text-gray-900">
+                                    Hoffmann V60のポイント
+                                </h3>
+                                <button
+                                    type="button"
+                                    onClick={onClose}
+                                    className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-full transition-colors"
+                                >
+                                    <span className="text-2xl leading-none">×</span>
+                                </button>
+                            </div>
+
+                            <div className="flex-1 overflow-y-auto px-6 py-6 space-y-6">
+                                {RECIPE_HOFFMANN_DESCRIPTION_SECTIONS.map((section, idx) => (
+                                    <div key={idx} className="flex gap-4">
+                                        <div className="flex-shrink-0 w-10 h-10 rounded-full bg-amber-50 text-amber-700 flex items-center justify-center">
+                                            {getIcon(section.icon)}
+                                        </div>
+                                        <div className="flex-1 border-b border-gray-50 pb-4">
+                                            <h4 className="font-bold text-gray-900 mb-1 text-base">
+                                                {section.title}
+                                            </h4>
+                                            <p className="text-[15px] leading-relaxed text-gray-600 whitespace-pre-wrap">
+                                                {section.content}
+                                            </p>
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+
+                            <div className="px-6 py-4 bg-gray-50 border-t border-gray-100 flex justify-end">
+                                <button
+                                    type="button"
+                                    onClick={onClose}
+                                    className="bg-gray-900 text-white px-8 py-2.5 rounded-lg font-bold text-sm hover:bg-black transition-colors"
+                                >
+                                    閉じる
+                                </button>
+                            </div>
+                        </div>
+                    </motion.div>
+                </>
+            )}
+        </AnimatePresence>
+    );
+};

--- a/components/drip-guide/dialogs/hoffmann/HoffmannDialogForm.tsx
+++ b/components/drip-guide/dialogs/hoffmann/HoffmannDialogForm.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import React from 'react';
+
+interface HoffmannDialogFormProps {
+    servings: number;
+    onServingsChange: (servings: number) => void;
+    onDescriptionClick: () => void;
+}
+
+export const HoffmannDialogForm: React.FC<HoffmannDialogFormProps> = ({
+    servings,
+    onServingsChange,
+    onDescriptionClick,
+}) => {
+    return (
+        <div className="px-5 py-4 space-y-4">
+            {/* メソッドのポイント（解説ボタン） */}
+            <button
+                type="button"
+                onClick={onDescriptionClick}
+                className="w-full rounded-lg bg-amber-50 border border-amber-100 p-3 text-left hover:bg-amber-100 transition-colors"
+            >
+                <div className="flex items-center justify-between">
+                    <span className="text-sm font-semibold text-amber-800">
+                        Hoffmann V60のポイント（必読）
+                    </span>
+                    <span className="text-amber-600 text-xs">クリックして開く</span>
+                </div>
+            </button>
+
+            {/* 人前選択 */}
+            <div>
+                <label htmlFor="servings-hoffmann" className="block text-sm font-semibold text-gray-900 mb-2">
+                    人前
+                </label>
+                <select
+                    id="servings-hoffmann"
+                    value={servings}
+                    onChange={(e) => onServingsChange(parseInt(e.target.value, 10))}
+                    className="w-full py-2 px-3 pr-10 rounded-lg text-sm font-medium transition-colors min-h-[44px] bg-white border border-gray-300 text-gray-700 hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500 appearance-none cursor-pointer"
+                    aria-label="人前を選択"
+                >
+                    {[1, 2, 3, 4, 5, 6, 7, 8].map((s) => (
+                        <option key={s} value={s}>
+                            {s}人前 ({s * 15}g / {s * 250}g)
+                        </option>
+                    ))}
+                </select>
+            </div>
+        </div>
+    );
+};

--- a/components/drip-guide/dialogs/hoffmann/HoffmannDialogHeader.tsx
+++ b/components/drip-guide/dialogs/hoffmann/HoffmannDialogHeader.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import React from 'react';
+import { Coffee } from 'phosphor-react';
+
+export const HoffmannDialogHeader: React.FC = () => {
+    return (
+        <div className="flex items-start gap-3 px-5 pt-5">
+            <div className="flex h-11 w-11 items-center justify-center rounded-full bg-amber-50 text-amber-700">
+                <Coffee size={24} weight="duotone" />
+            </div>
+            <div className="flex-1">
+                <p className="text-xs font-semibold uppercase tracking-wide text-amber-700">
+                    James Hoffmann V60
+                </p>
+                <h3 className="mt-1 text-lg font-bold text-gray-900">Ultimate V60 Technique</h3>
+            </div>
+        </div>
+    );
+};

--- a/components/drip-guide/dialogs/hoffmann/HoffmannPreview.tsx
+++ b/components/drip-guide/dialogs/hoffmann/HoffmannPreview.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import React from 'react';
+import { DripRecipe } from '@/lib/drip-guide/types';
+import { RecipeSummary } from '../shared/RecipeSummary';
+import { RecipeStepTable } from '../shared/RecipeStepTable';
+import { RECIPE_HOFFMANN_STEP_DETAILS } from '@/lib/drip-guide/recipeHoffmannContent';
+
+type StepDetailKey = keyof typeof RECIPE_HOFFMANN_STEP_DETAILS;
+
+interface HoffmannPreviewProps {
+    recipe: DripRecipe;
+    onStepDetailClick: (detailKey: StepDetailKey) => void;
+}
+
+const stepToDetailKey = (stepTitle: string): StepDetailKey | null => {
+    if (stepTitle.includes('蒸らし')) return 'bloom';
+    if (stepTitle.includes('第1注湯')) return 'pour1';
+    if (stepTitle.includes('第2注湯')) return 'pour2';
+    if (stepTitle.includes('かき混ぜ')) return 'stir';
+    if (stepTitle.includes('落ち切り')) return 'drawdown';
+    return null;
+};
+
+export const HoffmannPreview: React.FC<HoffmannPreviewProps> = ({ recipe, onStepDetailClick }) => {
+    const handleStepClick = (_stepId: string, stepTitle: string) => {
+        const detailKey = stepToDetailKey(stepTitle);
+        if (detailKey) {
+            onStepDetailClick(detailKey);
+        }
+    };
+
+    return (
+        <div className="px-5 pt-0 pb-4">
+            <div className="pt-4 border-t border-gray-200">
+                <RecipeSummary
+                    beanAmountGram={recipe.beanAmountGram}
+                    totalWaterGram={recipe.totalWaterGram}
+                    totalDurationSec={recipe.totalDurationSec}
+                />
+
+                <div className="mt-4">
+                    <RecipeStepTable steps={recipe.steps} onStepDetailClick={handleStepClick} />
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/components/drip-guide/dialogs/hoffmann/HoffmannStepDetailModal.tsx
+++ b/components/drip-guide/dialogs/hoffmann/HoffmannStepDetailModal.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import React from 'react';
+import { AnimatePresence, motion, type MotionProps } from 'framer-motion';
+import { Drop, Timer, SpinnerGap } from 'phosphor-react';
+import { RECIPE_HOFFMANN_STEP_DETAILS } from '@/lib/drip-guide/recipeHoffmannContent';
+
+type StepDetailKey = keyof typeof RECIPE_HOFFMANN_STEP_DETAILS;
+
+const overlayMotion = {
+    initial: { opacity: 0 },
+    animate: { opacity: 1 },
+    exit: { opacity: 0 },
+};
+
+const dialogMotion: MotionProps = {
+    initial: { opacity: 0, scale: 0.96, y: 12 },
+    animate: { opacity: 1, scale: 1, y: 0 },
+    exit: { opacity: 0, scale: 0.96, y: 12 },
+    transition: { type: 'spring', stiffness: 240, damping: 28 },
+};
+
+interface HoffmannStepDetailModalProps {
+    detailKey: StepDetailKey | null;
+    onClose: () => void;
+}
+
+const getIcon = (iconName: string) => {
+    switch (iconName) {
+        case 'bloom':
+            return <Drop size={20} weight="fill" />;
+        case 'pour':
+            return <Drop size={20} weight="duotone" />;
+        case 'stir':
+            return <SpinnerGap size={20} weight="bold" />;
+        case 'timer':
+            return <Timer size={20} weight="duotone" />;
+        default:
+            return <Drop size={20} weight="bold" />;
+    }
+};
+
+export const HoffmannStepDetailModal: React.FC<HoffmannStepDetailModalProps> = ({
+    detailKey,
+    onClose,
+}) => {
+    if (!detailKey) return null;
+
+    const detail = RECIPE_HOFFMANN_STEP_DETAILS[detailKey];
+
+    return (
+        <AnimatePresence>
+            {detailKey && (
+                <>
+                    <motion.div
+                        {...overlayMotion}
+                        className="fixed inset-0 z-[60] bg-black/40"
+                        onClick={onClose}
+                    />
+                    <motion.div
+                        {...dialogMotion}
+                        className="fixed inset-0 z-[60] flex items-center justify-center p-4 overflow-y-auto"
+                        onClick={onClose}
+                    >
+                        <div
+                            className="w-full max-w-md rounded-2xl bg-white shadow-xl relative overflow-hidden"
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+                                <div className="flex items-center gap-3">
+                                    <div className="w-10 h-10 rounded-full bg-amber-50 text-amber-700 flex items-center justify-center">
+                                        {getIcon(detail.icon)}
+                                    </div>
+                                    <div>
+                                        <h3 className="text-lg font-bold text-gray-900">{detail.title}</h3>
+                                        <p className="text-xs text-amber-700 font-medium">
+                                            {detail.technique}
+                                        </p>
+                                    </div>
+                                </div>
+                                <button
+                                    type="button"
+                                    onClick={onClose}
+                                    className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-full transition-colors"
+                                >
+                                    <span className="text-2xl leading-none">×</span>
+                                </button>
+                            </div>
+
+                            <div className="px-6 py-5 space-y-4">
+                                <p className="text-gray-700 leading-relaxed">{detail.description}</p>
+
+                                <div className="bg-amber-50 rounded-lg p-4">
+                                    <h4 className="font-semibold text-amber-800 mb-2 text-sm">ポイント</h4>
+                                    <ul className="space-y-2">
+                                        {detail.tips.map((tip, idx) => (
+                                            <li
+                                                key={idx}
+                                                className="flex items-start gap-2 text-sm text-amber-900"
+                                            >
+                                                <span className="text-amber-600 mt-0.5">•</span>
+                                                <span>{tip}</span>
+                                            </li>
+                                        ))}
+                                    </ul>
+                                </div>
+                            </div>
+
+                            <div className="px-6 py-4 bg-gray-50 border-t border-gray-100 flex justify-end">
+                                <button
+                                    type="button"
+                                    onClick={onClose}
+                                    className="bg-gray-900 text-white px-6 py-2 rounded-lg font-bold text-sm hover:bg-black transition-colors"
+                                >
+                                    閉じる
+                                </button>
+                            </div>
+                        </div>
+                    </motion.div>
+                </>
+            )}
+        </AnimatePresence>
+    );
+};

--- a/components/drip-guide/dialogs/shared/DialogOverlay.tsx
+++ b/components/drip-guide/dialogs/shared/DialogOverlay.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import React from 'react';
+import { motion } from 'framer-motion';
+
+const overlayMotion = {
+    initial: { opacity: 0 },
+    animate: { opacity: 1 },
+    exit: { opacity: 0 },
+};
+
+interface DialogOverlayProps {
+    onClick: () => void;
+    zIndex?: string;
+}
+
+export const DialogOverlay: React.FC<DialogOverlayProps> = ({ onClick, zIndex = 'z-50' }) => {
+    return (
+        <motion.div
+            {...overlayMotion}
+            className={`fixed inset-0 ${zIndex} bg-black/55`}
+            onClick={onClick}
+        />
+    );
+};

--- a/components/drip-guide/dialogs/shared/RecipeStepTable.tsx
+++ b/components/drip-guide/dialogs/shared/RecipeStepTable.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import React from 'react';
+import { DripStep } from '@/lib/drip-guide/types';
+import { formatTime } from '@/lib/drip-guide/formatTime';
+
+interface RecipeStepTableProps {
+    steps: DripStep[];
+    onStepDetailClick?: (stepId: string, stepTitle: string) => void;
+    showPourAmount?: boolean;
+}
+
+export const RecipeStepTable: React.FC<RecipeStepTableProps> = ({
+    steps,
+    onStepDetailClick,
+    showPourAmount = false,
+}) => {
+    return (
+        <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+                <thead>
+                    <tr className="border-b border-gray-200">
+                        <th className="text-left py-2 px-2 font-semibold text-gray-700">開始時刻</th>
+                        <th className="text-left py-2 px-2 font-semibold text-gray-700">
+                            {showPourAmount ? 'タイトル' : 'ステップ'}
+                        </th>
+                        {showPourAmount && (
+                            <th className="text-right py-2 px-2 font-semibold text-gray-700">注湯量(g)</th>
+                        )}
+                        <th className="text-right py-2 px-2 font-semibold text-gray-700">累積(g)</th>
+                        {onStepDetailClick && (
+                            <th className="text-center py-2 px-2 font-semibold text-gray-700">詳細</th>
+                        )}
+                    </tr>
+                </thead>
+                <tbody>
+                    {steps.map((step, index) => {
+                        const prevTarget = index > 0 ? steps[index - 1].targetTotalWater || 0 : 0;
+                        const currentTarget = step.targetTotalWater || 0;
+                        const pourAmount = currentTarget - prevTarget;
+
+                        return (
+                            <tr key={step.id} className="border-b border-gray-100">
+                                <td className="py-2 px-2 text-gray-700 font-mono">
+                                    {formatTime(step.startTimeSec)}
+                                </td>
+                                <td className="py-2 px-2 text-gray-700">{step.title}</td>
+                                {showPourAmount && (
+                                    <td className="py-2 px-2 text-right text-gray-900 font-semibold">
+                                        {pourAmount}
+                                    </td>
+                                )}
+                                <td className="py-2 px-2 text-right text-gray-900 font-semibold">
+                                    {step.targetTotalWater ?? '-'}
+                                </td>
+                                {onStepDetailClick && (
+                                    <td className="py-2 px-2 text-center">
+                                        <button
+                                            type="button"
+                                            onClick={() => onStepDetailClick(step.id, step.title)}
+                                            className="text-amber-600 hover:text-amber-800 text-xs underline"
+                                        >
+                                            詳細
+                                        </button>
+                                    </td>
+                                )}
+                            </tr>
+                        );
+                    })}
+                </tbody>
+            </table>
+        </div>
+    );
+};

--- a/components/drip-guide/dialogs/shared/RecipeSummary.tsx
+++ b/components/drip-guide/dialogs/shared/RecipeSummary.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import React from 'react';
+import { Coffee, Drop, Timer } from 'phosphor-react';
+import { formatTime } from '@/lib/drip-guide/formatTime';
+
+interface RecipeSummaryProps {
+    beanAmountGram: number;
+    totalWaterGram: number;
+    totalDurationSec: number;
+}
+
+export const RecipeSummary: React.FC<RecipeSummaryProps> = ({
+    beanAmountGram,
+    totalWaterGram,
+    totalDurationSec,
+}) => {
+    return (
+        <>
+            <div className="grid grid-cols-2 gap-4 mb-4">
+                <div className="flex items-center gap-2">
+                    <Coffee size={20} className="text-amber-700" />
+                    <span className="text-sm text-gray-600">豆量:</span>
+                    <span className="text-sm font-semibold text-gray-900">{beanAmountGram}g</span>
+                </div>
+                <div className="flex items-center gap-2">
+                    <Drop size={20} className="text-blue-500" />
+                    <span className="text-sm text-gray-600">総湯量:</span>
+                    <span className="text-sm font-semibold text-gray-900">{totalWaterGram}g</span>
+                </div>
+            </div>
+
+            <div className="mt-4 flex items-center gap-2 text-xs text-gray-500">
+                <Timer size={16} />
+                <span>
+                    総時間: {formatTime(totalDurationSec)} ({Math.floor(totalDurationSec / 60)}分
+                    {totalDurationSec % 60}秒)
+                </span>
+            </div>
+        </>
+    );
+};

--- a/components/drip-guide/runner/CompletionScreen.tsx
+++ b/components/drip-guide/runner/CompletionScreen.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import React, { useEffect, useState, useRef } from 'react';
+import Link from 'next/link';
+import Lottie, { LottieRefCurrentProps } from 'lottie-react';
+
+interface CompletionScreenProps {
+    onReset: () => void;
+}
+
+export const CompletionScreen: React.FC<CompletionScreenProps> = ({ onReset }) => {
+    const [animationData, setAnimationData] = useState<unknown>(null);
+    const lottieRef = useRef<LottieRefCurrentProps>(null);
+
+    useEffect(() => {
+        const loadAnimation = async () => {
+            try {
+                const response = await fetch('/animations/Break Time.json');
+                if (response.ok) {
+                    const data = await response.json();
+                    setAnimationData(data);
+                } else {
+                    console.error('Failed to load Lottie animation');
+                }
+            } catch (error) {
+                console.error('Error loading Lottie animation:', error);
+            }
+        };
+
+        loadAnimation();
+    }, []);
+
+    useEffect(() => {
+        if (lottieRef.current) {
+            lottieRef.current.setSpeed(0.5);
+        }
+    }, [animationData]);
+
+    return (
+        <div className="flex flex-col items-center justify-center h-[100dvh] text-center p-6">
+            <div className="mb-6 flex items-center justify-center">
+                {animationData ? (
+                    <Lottie
+                        lottieRef={lottieRef}
+                        animationData={animationData}
+                        loop={false}
+                        style={{ width: 160, height: 160 }}
+                        onDOMLoaded={() => {
+                            lottieRef.current?.setSpeed(0.5);
+                        }}
+                    />
+                ) : (
+                    <div className="w-40 h-40 flex items-center justify-center">
+                        <div className="w-8 h-8 border-4 border-amber-500 border-t-transparent rounded-full animate-spin"></div>
+                    </div>
+                )}
+            </div>
+            <h2 className="text-3xl font-bold text-gray-800 mb-2">抽出完了！</h2>
+            <p className="text-gray-600 mb-8">お疲れ様でした。美味しいコーヒーを楽しみましょう。</p>
+
+            <div className="flex gap-4">
+                <button
+                    onClick={onReset}
+                    className="px-6 py-2 border border-gray-300 rounded-full text-gray-600 hover:bg-gray-50 transition-colors"
+                >
+                    もう一度淹れる
+                </button>
+                <Link
+                    href="/drip-guide"
+                    className="px-6 py-2 bg-amber-600 text-white rounded-full hover:bg-amber-700 transition-colors"
+                >
+                    一覧に戻る
+                </Link>
+            </div>
+        </div>
+    );
+};

--- a/components/drip-guide/runner/FooterControls.tsx
+++ b/components/drip-guide/runner/FooterControls.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Play, Pause, ArrowCounterClockwise, X, ArrowLeft, ArrowRight, CheckCircle } from 'phosphor-react';
+import { clsx } from 'clsx';
+import Link from 'next/link';
+import { DripStep } from '@/lib/drip-guide/types';
+import { formatTime } from '@/lib/drip-guide/formatTime';
+
+interface FooterControlsProps {
+    isManualMode: boolean;
+    isRunning: boolean;
+    nextStep: DripStep | null;
+    manualStepIndex: number;
+    stepsLength: number;
+    currentStepIndex: number;
+    onToggleTimer: () => void;
+    onResetTimer: () => void;
+    onGoToNextStep: () => void;
+    onGoToPrevStep: () => void;
+    onComplete: () => void;
+}
+
+export const FooterControls: React.FC<FooterControlsProps> = ({
+    isManualMode,
+    isRunning,
+    nextStep,
+    manualStepIndex,
+    stepsLength,
+    currentStepIndex,
+    onToggleTimer,
+    onResetTimer,
+    onGoToNextStep,
+    onGoToPrevStep,
+    onComplete,
+}) => {
+    return (
+        <div className="flex-none bg-white border-t border-gray-100 pb-8 pt-4 px-6 safe-area-bottom">
+            {/* Next Step Preview */}
+            {!isManualMode && (
+                <div className="h-8 mb-4 flex justify-center items-center">
+                    {nextStep && (
+                        <motion.div
+                            initial={{ opacity: 0 }}
+                            animate={{ opacity: 1 }}
+                            className="text-gray-400 text-xs font-medium bg-gray-50 px-3 py-1 rounded-full"
+                        >
+                            Next: {formatTime(nextStep.startTimeSec)} - {nextStep.title}
+                        </motion.div>
+                    )}
+                </div>
+            )}
+
+            {isManualMode ? (
+                // Manual mode controls
+                <div className="flex items-center justify-center gap-4 sm:gap-6">
+                    <button
+                        onClick={onResetTimer}
+                        className="flex flex-col items-center gap-1 text-gray-400 hover:text-gray-600 transition-colors p-2 active:scale-95 min-h-[44px] min-w-[44px]"
+                    >
+                        <div className="p-3 rounded-full bg-gray-50">
+                            <ArrowCounterClockwise size={24} />
+                        </div>
+                        <span className="text-xs font-medium">リセット</span>
+                    </button>
+
+                    <button
+                        onClick={onGoToPrevStep}
+                        disabled={manualStepIndex === 0}
+                        className={clsx(
+                            'flex flex-col items-center gap-1 transition-colors p-2 active:scale-95 min-h-[44px] min-w-[44px]',
+                            manualStepIndex === 0
+                                ? 'text-gray-300 cursor-not-allowed'
+                                : 'text-gray-400 hover:text-gray-600'
+                        )}
+                    >
+                        <div
+                            className={clsx(
+                                'p-3 rounded-full',
+                                manualStepIndex === 0 ? 'bg-gray-50' : 'bg-gray-50'
+                            )}
+                        >
+                            <ArrowLeft size={24} />
+                        </div>
+                        <span className="text-xs font-medium">前へ</span>
+                    </button>
+
+                    <button
+                        onClick={onToggleTimer}
+                        className={clsx(
+                            'w-16 h-16 sm:w-20 sm:h-20 rounded-full flex items-center justify-center shadow-xl transition-all active:scale-95 touch-manipulation',
+                            isRunning
+                                ? 'bg-white border-2 border-amber-100 text-amber-500'
+                                : 'bg-amber-500 text-white shadow-amber-200'
+                        )}
+                    >
+                        {isRunning ? (
+                            <Pause size={28} weight="fill" className="sm:w-9 sm:h-9" />
+                        ) : (
+                            <Play size={28} weight="fill" className="ml-1 sm:w-9 sm:h-9" />
+                        )}
+                    </button>
+
+                    {currentStepIndex === stepsLength - 1 ? (
+                        <button
+                            onClick={onComplete}
+                            className="flex flex-col items-center gap-1 text-green-600 hover:text-green-700 transition-colors p-2 active:scale-95 min-h-[44px] min-w-[44px]"
+                        >
+                            <div className="p-3 rounded-full bg-green-50">
+                                <CheckCircle size={24} weight="fill" />
+                            </div>
+                            <span className="text-xs font-medium">完了</span>
+                        </button>
+                    ) : (
+                        <button
+                            onClick={onGoToNextStep}
+                            className="flex flex-col items-center gap-1 text-gray-400 hover:text-gray-600 transition-colors p-2 active:scale-95 min-h-[44px] min-w-[44px]"
+                        >
+                            <div className="p-3 rounded-full bg-gray-50">
+                                <ArrowRight size={24} />
+                            </div>
+                            <span className="text-xs font-medium">次へ</span>
+                        </button>
+                    )}
+
+                    <Link
+                        href="/drip-guide"
+                        className="flex flex-col items-center gap-1 text-gray-400 hover:text-gray-600 transition-colors p-2 active:scale-95 min-h-[44px] min-w-[44px]"
+                    >
+                        <div className="p-3 rounded-full bg-gray-50">
+                            <X size={24} />
+                        </div>
+                        <span className="text-xs font-medium">終了</span>
+                    </Link>
+                </div>
+            ) : (
+                // Auto mode controls
+                <div className="flex items-center justify-center gap-10">
+                    <button
+                        onClick={onResetTimer}
+                        className="flex flex-col items-center gap-1 text-gray-400 hover:text-gray-600 transition-colors p-2 active:scale-95"
+                    >
+                        <div className="p-3 rounded-full bg-gray-50">
+                            <ArrowCounterClockwise size={24} />
+                        </div>
+                        <span className="text-xs font-medium">リセット</span>
+                    </button>
+
+                    <button
+                        onClick={onToggleTimer}
+                        className={clsx(
+                            'w-20 h-20 rounded-full flex items-center justify-center shadow-xl transition-all active:scale-95 touch-manipulation',
+                            isRunning
+                                ? 'bg-white border-2 border-amber-100 text-amber-500'
+                                : 'bg-amber-500 text-white shadow-amber-200'
+                        )}
+                    >
+                        {isRunning ? (
+                            <Pause size={36} weight="fill" />
+                        ) : (
+                            <Play size={36} weight="fill" className="ml-1" />
+                        )}
+                    </button>
+
+                    <Link
+                        href="/drip-guide"
+                        className="flex flex-col items-center gap-1 text-gray-400 hover:text-gray-600 transition-colors p-2 active:scale-95"
+                    >
+                        <div className="p-3 rounded-full bg-gray-50">
+                            <X size={24} />
+                        </div>
+                        <span className="text-xs font-medium">終了</span>
+                    </Link>
+                </div>
+            )}
+        </div>
+    );
+};

--- a/components/drip-guide/runner/ProgressBar.tsx
+++ b/components/drip-guide/runner/ProgressBar.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import React from 'react';
+import { motion } from 'framer-motion';
+
+interface ProgressBarProps {
+    progressPercent: number;
+}
+
+export const ProgressBar: React.FC<ProgressBarProps> = ({ progressPercent }) => {
+    return (
+        <div className="flex-none h-1 bg-gray-100 w-full">
+            <motion.div
+                className="h-full bg-amber-500"
+                initial={{ width: 0 }}
+                animate={{ width: `${progressPercent}%` }}
+                transition={{ duration: 1, ease: 'linear' }}
+            />
+        </div>
+    );
+};

--- a/components/drip-guide/runner/RunnerHeader.tsx
+++ b/components/drip-guide/runner/RunnerHeader.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import { ArrowLeft } from 'phosphor-react';
+
+interface RunnerHeaderProps {
+    recipeName: string;
+}
+
+export const RunnerHeader: React.FC<RunnerHeaderProps> = ({ recipeName }) => {
+    return (
+        <div className="flex-none px-4 py-3 flex items-center justify-between border-b border-gray-100 bg-white z-10">
+            <Link
+                href="/drip-guide"
+                className="p-2 -ml-2 text-gray-500 hover:text-gray-800 transition-colors rounded-full active:bg-gray-100"
+            >
+                <ArrowLeft size={24} />
+            </Link>
+            <h1 className="font-bold text-gray-800 text-lg truncate max-w-[200px] text-center">
+                {recipeName}
+            </h1>
+            <div className="w-10" />
+        </div>
+    );
+};

--- a/components/drip-guide/runner/StepInfo.tsx
+++ b/components/drip-guide/runner/StepInfo.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import React from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { Lightbulb } from 'phosphor-react';
+import { DripStep } from '@/lib/drip-guide/types';
+
+interface StepInfoProps {
+    currentStep: DripStep | null;
+}
+
+export const StepInfo: React.FC<StepInfoProps> = ({ currentStep }) => {
+    return (
+        <div className="w-full max-w-md text-center flex-shrink-0 flex flex-col justify-center">
+            <AnimatePresence mode="wait">
+                {currentStep ? (
+                    <motion.div
+                        key={currentStep.id}
+                        initial={{ opacity: 0, y: 20 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0, y: -20 }}
+                        transition={{ duration: 0.3 }}
+                        className="flex flex-col items-center"
+                    >
+                        <h3 className="text-3xl sm:text-2xl md:text-3xl font-bold text-amber-700 mb-4 sm:mb-3">
+                            {currentStep.title}
+                        </h3>
+
+                        {currentStep.targetTotalWater && (
+                            <div className="mb-4 sm:mb-3">
+                                <span className="inline-block bg-blue-50 text-blue-600 px-6 py-3 sm:px-5 sm:py-2 rounded-full font-bold text-xl sm:text-lg shadow-sm border border-blue-100">
+                                    {currentStep.targetTotalWater}g{' '}
+                                    <span className="text-base sm:text-sm font-normal text-blue-400">
+                                        まで注ぐ
+                                    </span>
+                                </span>
+                            </div>
+                        )}
+
+                        <p className="text-lg sm:text-base md:text-lg text-gray-600 leading-relaxed mb-4 sm:mb-3 max-w-xs mx-auto">
+                            {currentStep.description}
+                        </p>
+
+                        {currentStep.note && (
+                            <div className="bg-amber-50 p-4 sm:p-3 rounded-xl border border-amber-100 text-amber-800 text-base sm:text-sm max-w-xs mx-auto flex items-start gap-2">
+                                <Lightbulb
+                                    size={20}
+                                    className="sm:w-4 sm:h-4 text-amber-600 flex-shrink-0 mt-0.5"
+                                    weight="fill"
+                                />
+                                <span>{currentStep.note}</span>
+                            </div>
+                        )}
+                    </motion.div>
+                ) : (
+                    <motion.div
+                        key="start"
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        className="text-gray-400 text-base py-4"
+                    >
+                        準備ができたら
+                        <br />
+                        スタートボタンを押してください
+                    </motion.div>
+                )}
+            </AnimatePresence>
+        </div>
+    );
+};

--- a/components/drip-guide/runner/StepMiniMap.tsx
+++ b/components/drip-guide/runner/StepMiniMap.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import React, { useRef, useEffect } from 'react';
+import { motion } from 'framer-motion';
+import { clsx } from 'clsx';
+import { DripStep } from '@/lib/drip-guide/types';
+import { formatTime } from '@/lib/drip-guide/formatTime';
+
+interface StepMiniMapProps {
+    steps: DripStep[];
+    currentStep: DripStep | null;
+    currentTime: number;
+    totalDurationSec: number;
+    isManualMode: boolean;
+    currentStepIndex: number;
+    scrollKey: number;
+}
+
+export const StepMiniMap: React.FC<StepMiniMapProps> = ({
+    steps,
+    currentStep,
+    currentTime,
+    totalDurationSec,
+    isManualMode,
+    currentStepIndex,
+    scrollKey,
+}) => {
+    const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        if (currentStep && scrollContainerRef.current) {
+            const activeStepElement = document.getElementById(`step-card-${currentStep.id}`);
+            if (activeStepElement) {
+                activeStepElement.scrollIntoView({
+                    behavior: 'smooth',
+                    block: 'nearest',
+                    inline: 'center',
+                });
+            }
+        }
+    }, [currentStep, scrollKey]);
+
+    return (
+        <div className="w-full max-w-2xl mb-2 sm:mb-3 px-2 flex-shrink-0">
+            <div className="overflow-x-auto scrollbar-hide pb-1 -mx-2 px-2" ref={scrollContainerRef}>
+                <div className="flex gap-2 sm:gap-2 min-w-max">
+                    {steps.map((step, index) => {
+                        const stepEndTime =
+                            index < steps.length - 1 ? steps[index + 1].startTimeSec : totalDurationSec;
+                        const isStepCompleted = isManualMode
+                            ? index < currentStepIndex
+                            : currentTime > stepEndTime;
+                        const isCurrent = currentStep?.id === step.id;
+
+                        return (
+                            <motion.div
+                                key={step.id}
+                                id={`step-card-${step.id}`}
+                                initial={{ opacity: 0, scale: 0.9 }}
+                                animate={{ opacity: 1, scale: 1 }}
+                                className={clsx(
+                                    'flex-shrink-0 rounded-lg px-3 py-2 sm:px-3 sm:py-2 min-w-[120px] sm:min-w-[120px] border-2 transition-all',
+                                    isCurrent
+                                        ? 'bg-amber-50 border-amber-400 shadow-md'
+                                        : isStepCompleted
+                                        ? 'bg-gray-50 border-gray-200'
+                                        : 'bg-gray-100 border-gray-200 opacity-60'
+                                )}
+                            >
+                                <div
+                                    className={clsx(
+                                        'text-sm sm:text-sm font-bold truncate',
+                                        isCurrent
+                                            ? 'text-amber-800'
+                                            : isStepCompleted
+                                            ? 'text-gray-700'
+                                            : 'text-gray-500'
+                                    )}
+                                >
+                                    {step.title}
+                                </div>
+                                {!isManualMode && (
+                                    <div
+                                        className={clsx(
+                                            'text-xs sm:text-xs font-semibold mt-0.5 sm:mt-0.5',
+                                            isCurrent
+                                                ? 'text-amber-700'
+                                                : isStepCompleted
+                                                ? 'text-gray-600'
+                                                : 'text-gray-400'
+                                        )}
+                                    >
+                                        {formatTime(step.startTimeSec)} - {formatTime(stepEndTime)}
+                                    </div>
+                                )}
+                                {step.targetTotalWater && (
+                                    <div
+                                        className={clsx(
+                                            'text-xs sm:text-xs mt-0.5 sm:mt-0.5',
+                                            isCurrent
+                                                ? 'text-amber-600'
+                                                : isStepCompleted
+                                                ? 'text-gray-500'
+                                                : 'text-gray-400'
+                                        )}
+                                    >
+                                        {step.targetTotalWater}gまで注ぐ
+                                    </div>
+                                )}
+                                {isCurrent && !isManualMode && (
+                                    <motion.div
+                                        initial={{ width: 0 }}
+                                        animate={{
+                                            width: `${Math.min(
+                                                ((currentTime - step.startTimeSec) /
+                                                    (stepEndTime - step.startTimeSec)) *
+                                                    100,
+                                                100
+                                            )}%`,
+                                        }}
+                                        className="h-1 sm:h-1 bg-amber-500 rounded-full mt-1.5 sm:mt-1.5"
+                                        transition={{ duration: 1, ease: 'linear' }}
+                                    />
+                                )}
+                            </motion.div>
+                        );
+                    })}
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/components/drip-guide/runner/TimerDisplay.tsx
+++ b/components/drip-guide/runner/TimerDisplay.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import React from 'react';
+import { formatTime } from '@/lib/drip-guide/formatTime';
+
+interface TimerDisplayProps {
+    currentTime: number;
+}
+
+export const TimerDisplay: React.FC<TimerDisplayProps> = ({ currentTime }) => {
+    return (
+        <div className="text-center mb-4 sm:mb-6 flex-shrink-0 -mt-4 sm:mt-0">
+            <div
+                className="text-8xl sm:text-7xl md:text-8xl lg:text-9xl tabular-nums font-bold text-gray-800 tracking-tighter leading-none"
+                style={{ fontFamily: 'var(--font-nunito), sans-serif' }}
+            >
+                {formatTime(currentTime)}
+            </div>
+        </div>
+    );
+};

--- a/hooks/drip-guide/useDialogKeyboard.ts
+++ b/hooks/drip-guide/useDialogKeyboard.ts
@@ -1,0 +1,32 @@
+import { useEffect, useCallback } from 'react';
+
+interface UseDialogKeyboardProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onEscape?: () => void;
+}
+
+/**
+ * ダイアログのキーボード操作を管理するカスタムフック
+ */
+export const useDialogKeyboard = ({ isOpen, onClose, onEscape }: UseDialogKeyboardProps) => {
+    const handleKeyDown = useCallback(
+        (event: KeyboardEvent) => {
+            if (!isOpen) return;
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                if (onEscape) {
+                    onEscape();
+                } else {
+                    onClose();
+                }
+            }
+        },
+        [isOpen, onClose, onEscape]
+    );
+
+    useEffect(() => {
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [handleKeyDown]);
+};

--- a/hooks/drip-guide/useRunnerTimer.ts
+++ b/hooks/drip-guide/useRunnerTimer.ts
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from 'react';
+
+interface UseRunnerTimerProps {
+    isRunning: boolean;
+    isManualMode: boolean;
+    totalDurationSec: number;
+    onTick: (time: number) => void;
+    onComplete: () => void;
+}
+
+/**
+ * ドリップガイドのタイマーロジックを管理するカスタムフック
+ */
+export const useRunnerTimer = ({
+    isRunning,
+    isManualMode,
+    totalDurationSec,
+    onTick,
+    onComplete,
+}: UseRunnerTimerProps) => {
+    const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+    useEffect(() => {
+        if (!isRunning) {
+            if (timerRef.current) {
+                clearInterval(timerRef.current);
+            }
+            return;
+        }
+
+        timerRef.current = setInterval(() => {
+            onTick((prev) => {
+                const next = prev + 1;
+                if (!isManualMode && next >= totalDurationSec) {
+                    onComplete();
+                    return totalDurationSec;
+                }
+                return next;
+            });
+        }, 1000);
+
+        return () => {
+            if (timerRef.current) clearInterval(timerRef.current);
+        };
+    }, [isRunning, isManualMode, totalDurationSec, onTick, onComplete]);
+
+    return timerRef;
+};

--- a/lib/drip-guide/formatTime.ts
+++ b/lib/drip-guide/formatTime.ts
@@ -1,0 +1,8 @@
+/**
+ * 秒数を MM:SS 形式にフォーマット
+ */
+export const formatTime = (seconds: number): string => {
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return `${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
+};


### PR DESCRIPTION
## 概要
Issue #89 の実装。3つの大規模コンポーネントを小さな再利用可能なコンポーネントとフックに分割。

## 変更内容
- DripGuideRunner.tsx: 524行 → 148行
- StartHoffmannDialog.tsx: 433行 → 136行
- Start46Dialog.tsx: 368行 → 138行

全てのファイルが300行以内に収まり、可読性と保守性が大幅に向上しました。

Closes #89

🤖 Generated with [Claude Code](https://claude.ai/code)) | [View Branch](https://github.com/IKcoding-jp/Roast-Plus/tree/claude/issue-89-20260203-0356) | [View job run](https://github.com/IKcoding-jp/Roast-Plus/actions/runs/21616333235