### PR TITLE
refactor(pages): ページコンポーネント分割（6ファイル）

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -2,11 +2,12 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import { HiArrowLeft, HiMail, HiCheckCircle, HiExclamationCircle } from 'react-icons/hi';
+import { HiArrowLeft, HiMail, HiExclamationCircle } from 'react-icons/hi';
+import { ContactSuccessScreen } from '@/components/contact/ContactSuccessScreen';
+import { ContactFormFields } from '@/components/contact/ContactFormFields';
 import {
   sendContactEmail,
   isEmailJSConfigured,
-  CONTACT_TYPES,
   ContactFormData,
 } from '@/lib/emailjs';
 
@@ -91,31 +92,7 @@ export default function ContactPage() {
   };
 
   if (status === 'success') {
-    return (
-      <div className="min-h-screen py-4 sm:py-6 lg:py-8 px-4 sm:px-6 lg:px-8" style={{ backgroundColor: '#F7F7F5' }}>
-        <div className="max-w-2xl mx-auto">
-          <div className="bg-white rounded-lg shadow-md p-8 text-center">
-            <div className="mb-6">
-              <HiCheckCircle className="h-16 w-16 text-green-500 mx-auto" />
-            </div>
-            <h1 className="text-2xl font-bold text-gray-800 mb-4">
-              送信完了
-            </h1>
-            <p className="text-gray-600 mb-6">
-              お問い合わせありがとうございます。<br />
-              内容を確認のうえ、ご返信いたします。
-            </p>
-            <Link
-              href="/settings"
-              className="inline-flex items-center px-6 py-3 bg-orange-500 text-white rounded-lg hover:bg-orange-600 transition-colors font-medium"
-            >
-              <HiArrowLeft className="h-5 w-5 mr-2" />
-              設定に戻る
-            </Link>
-          </div>
-        </div>
-      </div>
-    );
+    return <ContactSuccessScreen />;
   }
 
   return (
@@ -163,87 +140,11 @@ export default function ContactPage() {
             )}
 
             <form onSubmit={handleSubmit} className="space-y-6">
-              {/* お名前 */}
-              <div>
-                <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-2">
-                  お名前
-                  <span className="text-gray-400 text-xs ml-2">（任意）</span>
-                </label>
-                <input
-                  type="text"
-                  id="name"
-                  name="name"
-                  value={formData.name}
-                  onChange={handleInputChange}
-                  className="w-full px-4 py-3 border border-gray-300 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
-                  placeholder="山田 太郎"
-                />
-              </div>
-
-              {/* メールアドレス */}
-              <div>
-                <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
-                  メールアドレス
-                  <span className="text-red-500 text-xs ml-2">（必須）</span>
-                </label>
-                <input
-                  type="email"
-                  id="email"
-                  name="email"
-                  value={formData.email}
-                  onChange={handleInputChange}
-                  className={`w-full px-4 py-3 border rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent ${
-                    validationErrors.email ? 'border-red-500' : 'border-gray-300'
-                  }`}
-                  placeholder="example@email.com"
-                />
-                {validationErrors.email && (
-                  <p className="mt-2 text-sm text-red-600">{validationErrors.email}</p>
-                )}
-              </div>
-
-              {/* お問い合わせ種別 */}
-              <div>
-                <label htmlFor="type" className="block text-sm font-medium text-gray-700 mb-2">
-                  お問い合わせ種別
-                  <span className="text-red-500 text-xs ml-2">（必須）</span>
-                </label>
-                <select
-                  id="type"
-                  name="type"
-                  value={formData.type}
-                  onChange={handleInputChange}
-                  className="w-full px-4 py-3 border border-gray-300 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent bg-white"
-                >
-                  {CONTACT_TYPES.map((type) => (
-                    <option key={type.value} value={type.value}>
-                      {type.label}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              {/* お問い合わせ内容 */}
-              <div>
-                <label htmlFor="message" className="block text-sm font-medium text-gray-700 mb-2">
-                  お問い合わせ内容
-                  <span className="text-red-500 text-xs ml-2">（必須）</span>
-                </label>
-                <textarea
-                  id="message"
-                  name="message"
-                  value={formData.message}
-                  onChange={handleInputChange}
-                  rows={6}
-                  className={`w-full px-4 py-3 border rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent resize-none ${
-                    validationErrors.message ? 'border-red-500' : 'border-gray-300'
-                  }`}
-                  placeholder="お問い合わせ内容をご記入ください"
-                />
-                {validationErrors.message && (
-                  <p className="mt-2 text-sm text-red-600">{validationErrors.message}</p>
-                )}
-              </div>
+              <ContactFormFields
+                formData={formData}
+                validationErrors={validationErrors}
+                onInputChange={handleInputChange}
+              />
 
               {/* 送信ボタン */}
               <div className="pt-4">

--- a/app/notifications/page.tsx
+++ b/app/notifications/page.tsx
@@ -7,9 +7,12 @@ import { useAuth } from '@/lib/auth';
 import { useNotifications } from '@/hooks/useNotifications';
 import { useDeveloperMode } from '@/hooks/useDeveloperMode';
 import { Loading } from '@/components/Loading';
+import { NotificationModal } from '@/components/notifications/NotificationModal';
+import { NotificationCard } from '@/components/notifications/NotificationCard';
+import { DeleteConfirmDialog } from '@/components/notifications/DeleteConfirmDialog';
 import { HiArrowLeft } from 'react-icons/hi';
-import { IoAdd, IoCreateOutline, IoTrashOutline, IoChevronUp, IoChevronDown } from 'react-icons/io5';
-import type { Notification, NotificationType } from '@/types';
+import { IoAdd } from 'react-icons/io5';
+import type { Notification } from '@/types';
 
 export default function NotificationsPage() {
   const { user, loading: authLoading } = useAuth();
@@ -74,48 +77,6 @@ export default function NotificationsPage() {
   if (!user) {
     return null;
   }
-
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    const year = date.getFullYear();
-    const month = date.getMonth() + 1;
-    const day = date.getDate();
-    return `${year}年${month}月${day}日`;
-  };
-
-  const getTypeLabel = (type: string) => {
-    switch (type) {
-      case 'update':
-        return 'アップデート';
-      case 'announcement':
-        return 'お知らせ';
-      case 'improvement':
-        return '改善';
-      case 'request':
-        return 'お願い';
-      case 'bugfix':
-        return 'バグ修正';
-      default:
-        return '通知';
-    }
-  };
-
-  const getTypeColor = (type: string) => {
-    switch (type) {
-      case 'update':
-        return 'bg-orange-100 text-orange-800';
-      case 'announcement':
-        return 'bg-orange-100 text-orange-800';
-      case 'improvement':
-        return 'bg-blue-100 text-blue-800';
-      case 'request':
-        return 'bg-green-100 text-green-800';
-      case 'bugfix':
-        return 'bg-red-100 text-red-800';
-      default:
-        return 'bg-gray-100 text-gray-800';
-    }
-  };
 
   const handleAddClick = () => {
     setEditingNotification(null);
@@ -233,71 +194,17 @@ export default function NotificationsPage() {
                 const isLast = index === sortedNotifications.length - 1;
 
                 return (
-                  <div
+                  <NotificationCard
                     key={notification.id}
-                    className="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow"
-                  >
-                    <div className="flex items-start justify-between mb-2">
-                      <div className="flex items-center gap-2">
-                        {/* 開発者モード時のみ表示：上/下移動ボタン */}
-                        {isDeveloperMode && (
-                          <div className="flex flex-col gap-1">
-                            <button
-                              onClick={() => handleMoveUp(notification.id)}
-                              disabled={isFirst}
-                              className={`p-1 text-gray-400 hover:text-orange-500 hover:bg-orange-50 rounded transition-colors ${
-                                isFirst ? 'opacity-30 cursor-not-allowed' : ''
-                              }`}
-                              aria-label="上に移動"
-                            >
-                              <IoChevronUp className="h-4 w-4" />
-                            </button>
-                            <button
-                              onClick={() => handleMoveDown(notification.id)}
-                              disabled={isLast}
-                              className={`p-1 text-gray-400 hover:text-orange-500 hover:bg-orange-50 rounded transition-colors ${
-                                isLast ? 'opacity-30 cursor-not-allowed' : ''
-                              }`}
-                              aria-label="下に移動"
-                            >
-                              <IoChevronDown className="h-4 w-4" />
-                            </button>
-                          </div>
-                        )}
-                        <span className={`px-2 py-1 text-xs font-medium rounded ${getTypeColor(notification.type)}`}>
-                          {getTypeLabel(notification.type)}
-                        </span>
-                        <span className="text-sm text-gray-500">
-                          {formatDate(notification.date)}
-                        </span>
-                      </div>
-                      {/* 開発者モード時のみ表示：編集・削除ボタン */}
-                      {isDeveloperMode && (
-                        <div className="flex items-center gap-2">
-                          <button
-                            onClick={() => handleEditClick(notification)}
-                            className="p-2 text-gray-600 hover:text-orange-500 hover:bg-orange-50 rounded transition-colors"
-                            aria-label="編集"
-                          >
-                            <IoCreateOutline className="h-5 w-5" />
-                          </button>
-                          <button
-                            onClick={() => handleDeleteClick(notification.id)}
-                            className="p-2 text-gray-600 hover:text-red-500 hover:bg-red-50 rounded transition-colors"
-                            aria-label="削除"
-                          >
-                            <IoTrashOutline className="h-5 w-5" />
-                          </button>
-                        </div>
-                      )}
-                    </div>
-                    <h2 className="text-lg font-semibold text-gray-800 mb-2">
-                      {notification.title}
-                    </h2>
-                    <p className="text-gray-600 whitespace-pre-wrap">
-                      {notification.content}
-                    </p>
-                  </div>
+                    notification={notification}
+                    isFirst={isFirst}
+                    isLast={isLast}
+                    isDeveloperMode={isDeveloperMode}
+                    onEdit={handleEditClick}
+                    onDelete={handleDeleteClick}
+                    onMoveUp={handleMoveUp}
+                    onMoveDown={handleMoveDown}
+                  />
                 );
               })}
             </div>
@@ -327,205 +234,11 @@ export default function NotificationsPage() {
 
         {/* 削除確認ダイアログ */}
         {deleteConfirmId && (
-          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-            <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-6">
-              <h3 className="text-xl font-semibold text-gray-800 mb-4">
-                通知を削除
-              </h3>
-              <p className="text-gray-600 mb-6">
-                この通知を削除してもよろしいですか？この操作は取り消せません。
-              </p>
-              <div className="flex gap-3 justify-end">
-                <button
-                  onClick={handleDeleteCancel}
-                  className="px-4 py-2 text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors"
-                >
-                  キャンセル
-                </button>
-                <button
-                  onClick={handleDeleteConfirm}
-                  className="px-4 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors"
-                >
-                  削除
-                </button>
-              </div>
-            </div>
-          </div>
+          <DeleteConfirmDialog
+            onConfirm={handleDeleteConfirm}
+            onCancel={handleDeleteCancel}
+          />
         )}
-      </div>
-    </div>
-  );
-}
-
-// 通知追加・編集モーダルコンポーネント
-interface NotificationModalProps {
-  notification: Notification | null;
-  onSave: (notification: Omit<Notification, 'id'>) => void;
-  onCancel: () => void;
-}
-
-function NotificationModal({ notification, onSave, onCancel }: NotificationModalProps) {
-  const [title, setTitle] = useState(notification?.title || '');
-  const [content, setContent] = useState(notification?.content || '');
-  const [date, setDate] = useState(notification?.date || new Date().toISOString().split('T')[0]);
-  const [type, setType] = useState<NotificationType>(notification?.type || 'announcement');
-  const [errors, setErrors] = useState<{ title?: string; content?: string; date?: string }>({});
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    
-    // バリデーション
-    const newErrors: { title?: string; content?: string; date?: string } = {};
-    if (!title.trim()) {
-      newErrors.title = 'タイトルを入力してください';
-    }
-    if (!content.trim()) {
-      newErrors.content = '内容を入力してください';
-    }
-    if (!date) {
-      newErrors.date = '日付を選択してください';
-    }
-
-    if (Object.keys(newErrors).length > 0) {
-      setErrors(newErrors);
-      return;
-    }
-
-    setErrors({});
-    onSave({
-      title: title.trim(),
-      content: content.trim(),
-      date,
-      type,
-    });
-  };
-
-  return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
-        <div className="p-6 text-gray-900">
-          <h3 className="text-xl font-semibold text-gray-900 mb-6">
-            {notification ? '通知を編集' : '通知を追加'}
-          </h3>
-          <form onSubmit={handleSubmit}>
-            <div className="space-y-4">
-              {/* タイトル */}
-              <div>
-                <label
-                  htmlFor="title"
-                  className="block text-sm font-medium text-gray-700 mb-2"
-                >
-                  タイトル <span className="text-red-500">*</span>
-                </label>
-                <input
-                  type="text"
-                  id="title"
-                  value={title}
-                  onChange={(e) => {
-                    setTitle(e.target.value);
-                    if (errors.title) setErrors({ ...errors, title: undefined });
-                  }}
-                  className={`w-full px-4 py-2 border rounded-lg text-gray-900 bg-white focus:outline-none focus:ring-2 focus:ring-orange-500 ${
-                    errors.title ? 'border-red-500' : 'border-gray-300'
-                  }`}
-                  placeholder="通知のタイトルを入力"
-                />
-                {errors.title && (
-                  <p className="mt-1 text-sm text-red-600">{errors.title}</p>
-                )}
-              </div>
-
-              {/* 内容 */}
-              <div>
-                <label
-                  htmlFor="content"
-                  className="block text-sm font-medium text-gray-700 mb-2"
-                >
-                  内容 <span className="text-red-500">*</span>
-                </label>
-                <textarea
-                  id="content"
-                  value={content}
-                  onChange={(e) => {
-                    setContent(e.target.value);
-                    if (errors.content) setErrors({ ...errors, content: undefined });
-                  }}
-                  rows={6}
-                  className={`w-full px-4 py-2 border rounded-lg text-gray-900 bg-white focus:outline-none focus:ring-2 focus:ring-orange-500 ${
-                    errors.content ? 'border-red-500' : 'border-gray-300'
-                  }`}
-                  placeholder="通知の内容を入力"
-                />
-                {errors.content && (
-                  <p className="mt-1 text-sm text-red-600">{errors.content}</p>
-                )}
-              </div>
-
-              {/* 日付 */}
-              <div>
-                <label
-                  htmlFor="date"
-                  className="block text-sm font-medium text-gray-700 mb-2"
-                >
-                  日付 <span className="text-red-500">*</span>
-                </label>
-                <input
-                  type="date"
-                  id="date"
-                  value={date}
-                  onChange={(e) => {
-                    setDate(e.target.value);
-                    if (errors.date) setErrors({ ...errors, date: undefined });
-                  }}
-                  className={`w-full px-4 py-2 border rounded-lg text-gray-900 bg-white focus:outline-none focus:ring-2 focus:ring-orange-500 ${
-                    errors.date ? 'border-red-500' : 'border-gray-300'
-                  }`}
-                />
-                {errors.date && (
-                  <p className="mt-1 text-sm text-red-600">{errors.date}</p>
-                )}
-              </div>
-
-              {/* 種類 */}
-              <div>
-                <label
-                  htmlFor="type"
-                  className="block text-sm font-medium text-gray-700 mb-2"
-                >
-                  種類 <span className="text-red-500">*</span>
-                </label>
-                <select
-                  id="type"
-                  value={type}
-                  onChange={(e) => setType(e.target.value as NotificationType)}
-                  className="w-full px-4 py-2 border border-gray-300 rounded-lg text-gray-900 bg-white focus:outline-none focus:ring-2 focus:ring-orange-500"
-                >
-                  <option value="announcement">お知らせ</option>
-                  <option value="update">アップデート</option>
-                  <option value="improvement">改善</option>
-                  <option value="request">お願い</option>
-                  <option value="bugfix">バグ修正</option>
-                </select>
-              </div>
-            </div>
-
-            <div className="flex gap-3 justify-end mt-6">
-              <button
-                type="button"
-                onClick={onCancel}
-                className="px-4 py-2 text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors"
-              >
-                キャンセル
-              </button>
-              <button
-                type="submit"
-                className="px-4 py-2 bg-orange-500 text-white rounded-lg hover:bg-orange-600 transition-colors"
-              >
-                {notification ? '更新' : '追加'}
-              </button>
-            </div>
-          </form>
-        </div>
       </div>
     </div>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,7 @@ import { MdCoffeeMaker, MdTimer, MdTimeline } from 'react-icons/md';
 import { PiCoffeeBeanFill } from 'react-icons/pi';
 import { RiBookFill, RiCalendarScheduleFill } from 'react-icons/ri';
 import { Loading } from '@/components/Loading';
+import { ActionCard } from '@/components/home/ActionCard';
 import { useDeveloperMode } from '@/hooks/useDeveloperMode';
 import { useChristmasMode } from '@/hooks/useChristmasMode';
 import { useAuth } from '@/lib/auth';
@@ -20,10 +21,9 @@ import dynamic from 'next/dynamic';
 const Snowfall = dynamic(() => import('@/components/Snowfall').then(mod => ({ default: mod.Snowfall })), {
   ssr: false,
 });
-import { FaTree, FaGift, FaSnowflake, FaHollyBerry, FaStar } from 'react-icons/fa';
+import { FaTree, FaGift, FaSnowflake, FaStar } from 'react-icons/fa';
 import { PiBellFill } from 'react-icons/pi';
 import { GiCandyCanes, GiGingerbreadMan } from 'react-icons/gi';
-import { BsStars } from 'react-icons/bs';
 import { HiClock } from 'react-icons/hi';
 
 const SPLASH_DISPLAY_TIME = 3000; // スプラッシュ画面の表示時間 (ms)
@@ -383,62 +383,17 @@ export default function HomePage(_props: HomePageProps = {}) {
             const Icon = isChristmasMode ? (CHRISTMAS_ICONS[key] || DefaultIcon) : DefaultIcon;
 
             return (
-              <button
+              <ActionCard
                 key={key}
-                onClick={() => router.push(href)}
-                className={`group relative flex h-full flex-col items-center justify-center gap-3 rounded-2xl p-5 shadow-2xl transition-all hover:-translate-y-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 animate-home-card ${isChristmasMode
-                  ? 'bg-white/5 backdrop-blur-xl border border-[#d4af37]/40 hover:bg-white/10 hover:border-[#d4af37]/70 hover:shadow-[0_20px_50px_rgba(0,0,0,0.3)] focus-visible:ring-[#d4af37] focus-visible:ring-offset-[#051a0e]'
-                  : 'bg-white text-[#1F2A44] border border-gray-300 hover:border-gray-400 shadow-[0_10px_30px_rgba(0,0,0,0.04)] hover:shadow-[0_16px_40px_rgba(0,0,0,0.08)] focus-visible:ring-primary focus-visible:ring-offset-[#F5F2EB]'
-                  }`}
-                style={{
-                  ...(cardHeight ? { height: `${cardHeight}px` } : {}),
-                  animationDelay: `${index * 60}ms`,
-                }}
-                aria-label={title}
-              >
-                {/* バッジ表示 */}
-                {badge && (
-                  <div className="absolute -top-1 -right-1 z-20 animate-pulse-scale sm:-top-2 sm:-right-2">
-                    <span className={`flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] whitespace-nowrap font-bold text-white shadow-lg ${badge === 'NEW' ? 'new-label-gradient' : 'completed-label-gradient'} ring-2 ring-white/20 sm:px-3 sm:py-1`}>
-                      <BsStars className="text-[10px]" />
-                      {badge}
-                    </span>
-                  </div>
-                )}
-                {/* クリスマス飾りの装飾 ( corners ) */}
-                {isChristmasMode && (
-                  <div className="absolute top-2 right-2 opacity-40 group-hover:opacity-100 transition-opacity">
-                    <FaHollyBerry className="text-[#d4af37] text-[10px]" />
-                  </div>
-                )}
-
-                <span className={`relative flex h-14 w-14 items-center justify-center rounded-full transition-all duration-300 ${isChristmasMode
-                  ? 'bg-gradient-to-br from-[#d4af37]/20 to-[#d4af37]/5 text-[#d4af37] border border-[#d4af37]/30 group-hover:scale-110 group-hover:shadow-[0_0_20px_rgba(212,175,55,0.3)] shadow-[0_0_15px_rgba(212,175,55,0.1)]'
-                  : 'bg-primary/10 text-primary group-hover:bg-primary/15'
-                  }`}>
-                  <Icon className="h-8 w-8 relative z-10" />
-                  {isChristmasMode && (
-                    <div className="absolute inset-0 bg-[#d4af37]/20 rounded-full blur-md opacity-0 group-hover:opacity-100 transition-opacity"></div>
-                  )}
-                </span>
-                <div className="space-y-1 text-center relative z-10">
-                  <p className={`font-bold transition-colors ${isChristmasMode
-                    ? 'text-[#f8f1e7] group-hover:text-[#d4af37]'
-                    : 'text-slate-900'
-                    } ${title === 'ハンドピックタイマー' ? 'text-xs md:text-sm' : 'text-base md:text-lg'}`}>
-                    {title}
-                  </p>
-                  <p className={`text-xs transition-colors ${isChristmasMode ? 'text-[#f8f1e7]/60 group-hover:text-[#f8f1e7]/90' : 'text-slate-500'
-                    } md:text-sm`}>
-                    {description}
-                  </p>
-                </div>
-
-                {/* カード下部のゴールドライン */}
-                {isChristmasMode && (
-                  <div className="absolute bottom-0 left-0 right-0 h-[2px] bg-gradient-to-r from-transparent via-[#d4af37]/50 to-transparent scale-x-0 group-hover:scale-x-100 transition-transform duration-500"></div>
-                )}
-              </button>
+                title={title}
+                description={description}
+                href={href}
+                icon={Icon}
+                badge={badge}
+                index={index}
+                cardHeight={cardHeight}
+                isChristmasMode={isChristmasMode}
+              />
             );
           })}
         </div>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -9,6 +9,8 @@ import { useChristmasMode } from '@/hooks/useChristmasMode';
 import { useAppVersion } from '@/hooks/useAppVersion';
 import { Loading } from '@/components/Loading';
 import { useToastContext } from '@/components/Toast';
+import { ToggleSwitch } from '@/components/settings/ToggleSwitch';
+import { PasswordModal } from '@/components/settings/PasswordModal';
 import { HiArrowLeft, HiDocumentText, HiShieldCheck, HiLogout, HiMail } from 'react-icons/hi';
 import { MdHistory } from 'react-icons/md';
 import LoginPage from '@/app/login/page';
@@ -25,8 +27,6 @@ export default function SettingsPage() {
     const { showToast } = useToastContext();
     const { version, isUpdateAvailable, isChecking, checkForUpdates, applyUpdate } = useAppVersion();
     const [showPasswordModal, setShowPasswordModal] = useState(false);
-    const [password, setPassword] = useState('');
-    const [passwordError, setPasswordError] = useState<string | null>(null);
     const [userConsent, setUserConsent] = useState<UserConsent | null>(null);
 
     const { isChristmasMode, setChristmasMode } = useChristmasMode();
@@ -60,30 +60,22 @@ export default function SettingsPage() {
         if (checked) {
             // ONにする場合はパスワード入力モーダルを表示
             setShowPasswordModal(true);
-            setPassword('');
-            setPasswordError(null);
         } else {
             // OFFにする場合は即座に無効化
             disableDeveloperMode();
         }
     };
 
-    const handlePasswordSubmit = (e: React.FormEvent) => {
-        e.preventDefault();
-        setPasswordError(null);
-
-        if (enableDeveloperMode(password)) {
+    const handlePasswordSubmit = (password: string): boolean => {
+        const success = enableDeveloperMode(password);
+        if (success) {
             setShowPasswordModal(false);
-            setPassword('');
-        } else {
-            setPasswordError('パスワードが正しくありません');
         }
+        return success;
     };
 
     const handleCancelPassword = () => {
         setShowPasswordModal(false);
-        setPassword('');
-        setPasswordError(null);
     };
 
     const handleLogout = async () => {
@@ -318,79 +310,13 @@ export default function SettingsPage() {
 
                 {/* パスワード入力モーダル */}
                 {showPasswordModal && (
-                    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-                        <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-6">
-                            <h3 className="text-xl font-semibold text-gray-800 mb-4">
-                                パスワードを入力
-                            </h3>
-                            <form onSubmit={handlePasswordSubmit}>
-                                <div className="mb-4">
-                                    <label
-                                        htmlFor="password"
-                                        className="block text-sm font-medium text-gray-700 mb-2"
-                                    >
-                                        パスワード
-                                    </label>
-                                    <input
-                                        type="password"
-                                        id="password"
-                                        value={password}
-                                        onChange={(e) => {
-                                            setPassword(e.target.value);
-                                            setPasswordError(null);
-                                        }}
-                                        className={`w-full px-4 py-2 border rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 ${passwordError ? 'border-red-500' : 'border-gray-300'
-                                            }`}
-                                        placeholder="パスワードを入力"
-                                        autoFocus
-                                    />
-                                    {passwordError && (
-                                        <p className="mt-2 text-sm text-red-600">{passwordError}</p>
-                                    )}
-                                </div>
-                                <div className="flex gap-3 justify-end">
-                                    <Button
-                                        type="button"
-                                        variant="secondary"
-                                        size="md"
-                                        onClick={handleCancelPassword}
-                                    >
-                                        キャンセル
-                                    </Button>
-                                    <Button type="submit" variant="primary" size="md">
-                                        確定
-                                    </Button>
-                                </div>
-                            </form>
-                        </div>
-                    </div>
+                    <PasswordModal
+                        onSubmit={handlePasswordSubmit}
+                        onCancel={handleCancelPassword}
+                    />
                 )}
 
             </div>
         </div>
-    );
-}
-
-// トグルスイッチコンポーネント
-interface ToggleSwitchProps {
-    checked: boolean;
-    onChange: (checked: boolean) => void;
-}
-
-function ToggleSwitch({ checked, onChange }: ToggleSwitchProps) {
-    return (
-        <button
-            type="button"
-            role="switch"
-            aria-checked={checked}
-            onClick={() => onChange(!checked)}
-            className={`relative inline-flex h-8 w-14 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 ${checked ? 'bg-orange-500' : 'bg-gray-300'
-                }`}
-        >
-            <span
-                className={`inline-block h-6 w-6 transform rounded-full bg-white transition-transform ${checked ? 'translate-x-7' : 'translate-x-1'
-                    }`}
-            />
-        </button>
     );
 }

--- a/components/contact/ContactFormFields.tsx
+++ b/components/contact/ContactFormFields.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { CONTACT_TYPES, ContactFormData } from '@/lib/emailjs';
+
+interface ContactFormFieldsProps {
+  formData: ContactFormData;
+  validationErrors: Record<string, string>;
+  onInputChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => void;
+}
+
+export function ContactFormFields({
+  formData,
+  validationErrors,
+  onInputChange,
+}: ContactFormFieldsProps) {
+  return (
+    <>
+      {/* お名前 */}
+      <div>
+        <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-2">
+          お名前
+          <span className="text-gray-400 text-xs ml-2">（任意）</span>
+        </label>
+        <input
+          type="text"
+          id="name"
+          name="name"
+          value={formData.name}
+          onChange={onInputChange}
+          className="w-full px-4 py-3 border border-gray-300 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+          placeholder="山田 太郎"
+        />
+      </div>
+
+      {/* メールアドレス */}
+      <div>
+        <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
+          メールアドレス
+          <span className="text-red-500 text-xs ml-2">（必須）</span>
+        </label>
+        <input
+          type="email"
+          id="email"
+          name="email"
+          value={formData.email}
+          onChange={onInputChange}
+          className={`w-full px-4 py-3 border rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent ${
+            validationErrors.email ? 'border-red-500' : 'border-gray-300'
+          }`}
+          placeholder="example@email.com"
+        />
+        {validationErrors.email && (
+          <p className="mt-2 text-sm text-red-600">{validationErrors.email}</p>
+        )}
+      </div>
+
+      {/* お問い合わせ種別 */}
+      <div>
+        <label htmlFor="type" className="block text-sm font-medium text-gray-700 mb-2">
+          お問い合わせ種別
+          <span className="text-red-500 text-xs ml-2">（必須）</span>
+        </label>
+        <select
+          id="type"
+          name="type"
+          value={formData.type}
+          onChange={onInputChange}
+          className="w-full px-4 py-3 border border-gray-300 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent bg-white"
+        >
+          {CONTACT_TYPES.map((type) => (
+            <option key={type.value} value={type.value}>
+              {type.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* お問い合わせ内容 */}
+      <div>
+        <label htmlFor="message" className="block text-sm font-medium text-gray-700 mb-2">
+          お問い合わせ内容
+          <span className="text-red-500 text-xs ml-2">（必須）</span>
+        </label>
+        <textarea
+          id="message"
+          name="message"
+          value={formData.message}
+          onChange={onInputChange}
+          rows={6}
+          className={`w-full px-4 py-3 border rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent resize-none ${
+            validationErrors.message ? 'border-red-500' : 'border-gray-300'
+          }`}
+          placeholder="お問い合わせ内容をご記入ください"
+        />
+        {validationErrors.message && (
+          <p className="mt-2 text-sm text-red-600">{validationErrors.message}</p>
+        )}
+      </div>
+    </>
+  );
+}

--- a/components/contact/ContactSuccessScreen.tsx
+++ b/components/contact/ContactSuccessScreen.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import Link from 'next/link';
+import { HiCheckCircle, HiArrowLeft } from 'react-icons/hi';
+
+export function ContactSuccessScreen() {
+  return (
+    <div className="min-h-screen py-4 sm:py-6 lg:py-8 px-4 sm:px-6 lg:px-8" style={{ backgroundColor: '#F7F7F5' }}>
+      <div className="max-w-2xl mx-auto">
+        <div className="bg-white rounded-lg shadow-md p-8 text-center">
+          <div className="mb-6">
+            <HiCheckCircle className="h-16 w-16 text-green-500 mx-auto" />
+          </div>
+          <h1 className="text-2xl font-bold text-gray-800 mb-4">送信完了</h1>
+          <p className="text-gray-600 mb-6">
+            お問い合わせありがとうございます。
+            <br />
+            内容を確認のうえ、ご返信いたします。
+          </p>
+          <Link
+            href="/settings"
+            className="inline-flex items-center px-6 py-3 bg-orange-500 text-white rounded-lg hover:bg-orange-600 transition-colors font-medium"
+          >
+            <HiArrowLeft className="h-5 w-5 mr-2" />
+            設定に戻る
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/defect-beans/EmptyState.tsx
+++ b/components/defect-beans/EmptyState.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { HiSearch, HiOutlineCollection, HiPlus } from 'react-icons/hi';
+
+interface EmptyStateProps {
+  hasSearchOrFilter: boolean;
+  onAddClick: () => void;
+}
+
+export function EmptyState({ hasSearchOrFilter, onAddClick }: EmptyStateProps) {
+  return (
+    <div className="py-12 sm:py-16 text-center">
+      <div className="flex flex-col items-center justify-center space-y-4 sm:space-y-6">
+        {/* アイコン */}
+        <div className="relative">
+          <div className="absolute inset-0 bg-amber-100 rounded-full blur-xl opacity-50"></div>
+          <div className="relative w-20 h-20 sm:w-24 sm:h-24 rounded-full bg-amber-50 flex items-center justify-center">
+            {hasSearchOrFilter ? (
+              <HiSearch className="w-10 h-10 sm:w-12 sm:h-12 text-amber-400" />
+            ) : (
+              <HiOutlineCollection className="w-10 h-10 sm:w-12 sm:h-12 text-amber-400" />
+            )}
+          </div>
+        </div>
+
+        {/* メッセージ */}
+        <div className="space-y-2">
+          <h3 className="text-lg sm:text-xl font-semibold text-gray-800">
+            {hasSearchOrFilter
+              ? '検索条件に一致する欠点豆がありません'
+              : '欠点豆が登録されていません'}
+          </h3>
+          <p className="text-sm sm:text-base text-gray-500 max-w-md mx-auto">
+            {hasSearchOrFilter
+              ? '別のキーワードで検索するか、フィルタを変更してみてください。'
+              : '最初の欠点豆を追加して、図鑑を始めましょう。'}
+          </p>
+        </div>
+
+        {/* アクションボタン（登録がない場合のみ表示） */}
+        {!hasSearchOrFilter && (
+          <button
+            onClick={onAddClick}
+            className="mt-2 px-6 py-3 bg-amber-600 text-white rounded-lg hover:bg-amber-700 transition-colors flex items-center gap-2 shadow-md hover:shadow-lg transform hover:-translate-y-0.5 transition-all min-h-[44px]"
+          >
+            <HiPlus className="w-5 h-5" />
+            <span className="font-medium">欠点豆を追加</span>
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/defect-beans/SearchFilterSection.tsx
+++ b/components/defect-beans/SearchFilterSection.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { HiSearch, HiCollection, HiCheckCircle, HiXCircle } from 'react-icons/hi';
+
+type FilterOption = 'all' | 'shouldRemove' | 'shouldNotRemove';
+
+interface SearchFilterSectionProps {
+  searchQuery: string;
+  onSearchChange: (query: string) => void;
+  filterOption: FilterOption;
+  onFilterChange: (option: FilterOption) => void;
+}
+
+export function SearchFilterSection({
+  searchQuery,
+  onSearchChange,
+  filterOption,
+  onFilterChange,
+}: SearchFilterSectionProps) {
+  return (
+    <div className="bg-white rounded-lg shadow-md p-3 sm:p-4 mb-4">
+      <div className="flex flex-col sm:flex-row gap-3">
+        {/* 検索 */}
+        <div className="flex-1">
+          <div className="relative">
+            <HiSearch className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => onSearchChange(e.target.value)}
+              placeholder="名称や特徴で検索..."
+              className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent min-h-[40px] text-sm text-gray-900 bg-white placeholder:text-gray-400"
+            />
+          </div>
+        </div>
+
+        {/* フィルタ */}
+        <div className="flex gap-1.5">
+          <button
+            onClick={() => onFilterChange('all')}
+            className={`px-3 py-1.5 rounded-lg transition-colors min-h-[36px] flex items-center gap-1.5 text-sm ${
+              filterOption === 'all'
+                ? 'bg-primary text-white'
+                : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+            }`}
+            title="全て表示"
+          >
+            <HiCollection className="h-4 w-4" />
+            <span className="text-xs sm:text-sm">全て</span>
+          </button>
+          <button
+            onClick={() => onFilterChange('shouldRemove')}
+            className={`px-3 py-1.5 rounded-lg transition-colors min-h-[36px] flex items-center gap-1.5 text-sm ${
+              filterOption === 'shouldRemove'
+                ? 'bg-red-500 text-white'
+                : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+            }`}
+            title="省く設定のもの"
+          >
+            <HiXCircle className="h-4 w-4" />
+            <span className="text-xs sm:text-sm">省く</span>
+          </button>
+          <button
+            onClick={() => onFilterChange('shouldNotRemove')}
+            className={`px-3 py-1.5 rounded-lg transition-colors min-h-[36px] flex items-center gap-1.5 text-sm ${
+              filterOption === 'shouldNotRemove'
+                ? 'bg-green-500 text-white'
+                : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+            }`}
+            title="省かない設定のもの"
+          >
+            <HiCheckCircle className="h-4 w-4" />
+            <span className="text-xs sm:text-sm">省かない</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/defect-beans/SortMenu.tsx
+++ b/components/defect-beans/SortMenu.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useRef, useEffect } from 'react';
+import { HiCheckCircle } from 'react-icons/hi';
+import { MdSort, MdArrowUpward, MdArrowDownward } from 'react-icons/md';
+
+type SortOption = 'default' | 'createdAtDesc' | 'createdAtAsc' | 'nameAsc' | 'nameDesc';
+
+interface SortMenuProps {
+  sortOption: SortOption;
+  onSortChange: (option: SortOption) => void;
+  showSortMenu: boolean;
+  onToggleMenu: () => void;
+  onClose: () => void;
+}
+
+const SORT_OPTIONS: SortOption[] = ['default', 'createdAtDesc', 'createdAtAsc', 'nameAsc', 'nameDesc'];
+
+const getSortLabel = (option: SortOption): string => {
+  switch (option) {
+    case 'default':
+      return 'デフォルト';
+    case 'createdAtDesc':
+      return '新しい順';
+    case 'createdAtAsc':
+      return '古い順';
+    case 'nameAsc':
+      return '名前昇順';
+    case 'nameDesc':
+      return '名前降順';
+  }
+};
+
+const getSortIcon = (option: SortOption) => {
+  if (option === 'default') {
+    return <MdSort className="h-5 w-5" />;
+  } else if (option === 'createdAtAsc' || option === 'nameAsc') {
+    return <MdArrowUpward className="h-5 w-5" />;
+  } else {
+    return <MdArrowDownward className="h-5 w-5" />;
+  }
+};
+
+export function SortMenu({
+  sortOption,
+  onSortChange,
+  showSortMenu,
+  onToggleMenu,
+  onClose,
+}: SortMenuProps) {
+  const sortMenuRef = useRef<HTMLDivElement>(null);
+
+  // メニュー外クリックで閉じる処理
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (sortMenuRef.current && !sortMenuRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+
+    if (showSortMenu) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [showSortMenu, onClose]);
+
+  return (
+    <div className="relative" ref={sortMenuRef}>
+      <button
+        onClick={onToggleMenu}
+        className={`px-3 py-2 text-sm rounded-lg transition-colors min-h-[44px] flex items-center gap-1.5 ${
+          showSortMenu
+            ? 'bg-amber-600 text-white hover:bg-amber-700 shadow-md'
+            : 'bg-white text-gray-700 rounded-lg shadow-md hover:bg-gray-50'
+        }`}
+        title="ソート"
+      >
+        {getSortIcon(sortOption)}
+        <span className="text-xs sm:text-sm">ソート</span>
+      </button>
+      {/* ドロップダウンメニュー */}
+      {showSortMenu && (
+        <div className="absolute right-0 mt-2 w-48 bg-white rounded-lg shadow-lg border border-gray-200 z-50">
+          <div className="py-1">
+            {SORT_OPTIONS.map((option) => (
+              <button
+                key={option}
+                onClick={() => {
+                  onSortChange(option);
+                  onClose();
+                }}
+                className={`w-full text-left px-4 py-2 text-sm transition-colors flex items-center gap-2 ${
+                  sortOption === option
+                    ? 'bg-amber-50 text-amber-700 font-medium'
+                    : 'text-gray-700 hover:bg-gray-50'
+                }`}
+              >
+                {sortOption === option && <HiCheckCircle className="h-4 w-4 text-amber-600" />}
+                <span>{getSortLabel(option)}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/home/ActionCard.tsx
+++ b/components/home/ActionCard.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import type { IconType } from 'react-icons';
+import { FaHollyBerry } from 'react-icons/fa';
+import { BsStars } from 'react-icons/bs';
+
+interface ActionCardProps {
+  title: string;
+  description: string;
+  href: string;
+  icon: IconType;
+  badge?: string;
+  index: number;
+  cardHeight: number | null;
+  isChristmasMode: boolean;
+}
+
+export function ActionCard({
+  title,
+  description,
+  href,
+  icon: Icon,
+  badge,
+  index,
+  cardHeight,
+  isChristmasMode,
+}: ActionCardProps) {
+  const router = useRouter();
+
+  return (
+    <button
+      onClick={() => router.push(href)}
+      className={`group relative flex h-full flex-col items-center justify-center gap-3 rounded-2xl p-5 shadow-2xl transition-all hover:-translate-y-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 animate-home-card ${
+        isChristmasMode
+          ? 'bg-white/5 backdrop-blur-xl border border-[#d4af37]/40 hover:bg-white/10 hover:border-[#d4af37]/70 hover:shadow-[0_20px_50px_rgba(0,0,0,0.3)] focus-visible:ring-[#d4af37] focus-visible:ring-offset-[#051a0e]'
+          : 'bg-white text-[#1F2A44] border border-gray-300 hover:border-gray-400 shadow-[0_10px_30px_rgba(0,0,0,0.04)] hover:shadow-[0_16px_40px_rgba(0,0,0,0.08)] focus-visible:ring-primary focus-visible:ring-offset-[#F5F2EB]'
+      }`}
+      style={{
+        ...(cardHeight ? { height: `${cardHeight}px` } : {}),
+        animationDelay: `${index * 60}ms`,
+      }}
+      aria-label={title}
+    >
+      {/* バッジ表示 */}
+      {badge && (
+        <div className="absolute -top-1 -right-1 z-20 animate-pulse-scale sm:-top-2 sm:-right-2">
+          <span
+            className={`flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] whitespace-nowrap font-bold text-white shadow-lg ${
+              badge === 'NEW' ? 'new-label-gradient' : 'completed-label-gradient'
+            } ring-2 ring-white/20 sm:px-3 sm:py-1`}
+          >
+            <BsStars className="text-[10px]" />
+            {badge}
+          </span>
+        </div>
+      )}
+      {/* クリスマス飾りの装飾 */}
+      {isChristmasMode && (
+        <div className="absolute top-2 right-2 opacity-40 group-hover:opacity-100 transition-opacity">
+          <FaHollyBerry className="text-[#d4af37] text-[10px]" />
+        </div>
+      )}
+
+      <span
+        className={`relative flex h-14 w-14 items-center justify-center rounded-full transition-all duration-300 ${
+          isChristmasMode
+            ? 'bg-gradient-to-br from-[#d4af37]/20 to-[#d4af37]/5 text-[#d4af37] border border-[#d4af37]/30 group-hover:scale-110 group-hover:shadow-[0_0_20px_rgba(212,175,55,0.3)] shadow-[0_0_15px_rgba(212,175,55,0.1)]'
+            : 'bg-primary/10 text-primary group-hover:bg-primary/15'
+        }`}
+      >
+        <Icon className="h-8 w-8 relative z-10" />
+        {isChristmasMode && (
+          <div className="absolute inset-0 bg-[#d4af37]/20 rounded-full blur-md opacity-0 group-hover:opacity-100 transition-opacity"></div>
+        )}
+      </span>
+      <div className="space-y-1 text-center relative z-10">
+        <p
+          className={`font-bold transition-colors ${
+            isChristmasMode ? 'text-[#f8f1e7] group-hover:text-[#d4af37]' : 'text-slate-900'
+          } ${title === 'ハンドピックタイマー' ? 'text-xs md:text-sm' : 'text-base md:text-lg'}`}
+        >
+          {title}
+        </p>
+        <p
+          className={`text-xs transition-colors ${
+            isChristmasMode ? 'text-[#f8f1e7]/60 group-hover:text-[#f8f1e7]/90' : 'text-slate-500'
+          } md:text-sm`}
+        >
+          {description}
+        </p>
+      </div>
+
+      {/* カード下部のゴールドライン */}
+      {isChristmasMode && (
+        <div className="absolute bottom-0 left-0 right-0 h-[2px] bg-gradient-to-r from-transparent via-[#d4af37]/50 to-transparent scale-x-0 group-hover:scale-x-100 transition-transform duration-500"></div>
+      )}
+    </button>
+  );
+}

--- a/components/notifications/DeleteConfirmDialog.tsx
+++ b/components/notifications/DeleteConfirmDialog.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+interface DeleteConfirmDialogProps {
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function DeleteConfirmDialog({ onConfirm, onCancel }: DeleteConfirmDialogProps) {
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-6">
+        <h3 className="text-xl font-semibold text-gray-800 mb-4">通知を削除</h3>
+        <p className="text-gray-600 mb-6">
+          この通知を削除してもよろしいですか？この操作は取り消せません。
+        </p>
+        <div className="flex gap-3 justify-end">
+          <button
+            onClick={onCancel}
+            className="px-4 py-2 text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors"
+          >
+            キャンセル
+          </button>
+          <button
+            onClick={onConfirm}
+            className="px-4 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors"
+          >
+            削除
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/notifications/NotificationCard.tsx
+++ b/components/notifications/NotificationCard.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { IoCreateOutline, IoTrashOutline, IoChevronUp, IoChevronDown } from 'react-icons/io5';
+import type { Notification } from '@/types';
+
+interface NotificationCardProps {
+  notification: Notification;
+  isFirst: boolean;
+  isLast: boolean;
+  isDeveloperMode: boolean;
+  onEdit: (notification: Notification) => void;
+  onDelete: (id: string) => void;
+  onMoveUp: (id: string) => void;
+  onMoveDown: (id: string) => void;
+}
+
+const formatDate = (dateString: string) => {
+  const date = new Date(dateString);
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  return `${year}年${month}月${day}日`;
+};
+
+const getTypeLabel = (type: string) => {
+  switch (type) {
+    case 'update':
+      return 'アップデート';
+    case 'announcement':
+      return 'お知らせ';
+    case 'improvement':
+      return '改善';
+    case 'request':
+      return 'お願い';
+    case 'bugfix':
+      return 'バグ修正';
+    default:
+      return '通知';
+  }
+};
+
+const getTypeColor = (type: string) => {
+  switch (type) {
+    case 'update':
+      return 'bg-orange-100 text-orange-800';
+    case 'announcement':
+      return 'bg-orange-100 text-orange-800';
+    case 'improvement':
+      return 'bg-blue-100 text-blue-800';
+    case 'request':
+      return 'bg-green-100 text-green-800';
+    case 'bugfix':
+      return 'bg-red-100 text-red-800';
+    default:
+      return 'bg-gray-100 text-gray-800';
+  }
+};
+
+export function NotificationCard({
+  notification,
+  isFirst,
+  isLast,
+  isDeveloperMode,
+  onEdit,
+  onDelete,
+  onMoveUp,
+  onMoveDown,
+}: NotificationCardProps) {
+  return (
+    <div className="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow">
+      <div className="flex items-start justify-between mb-2">
+        <div className="flex items-center gap-2">
+          {/* 開発者モード時のみ表示:上/下移動ボタン */}
+          {isDeveloperMode && (
+            <div className="flex flex-col gap-1">
+              <button
+                onClick={() => onMoveUp(notification.id)}
+                disabled={isFirst}
+                className={`p-1 text-gray-400 hover:text-orange-500 hover:bg-orange-50 rounded transition-colors ${
+                  isFirst ? 'opacity-30 cursor-not-allowed' : ''
+                }`}
+                aria-label="上に移動"
+              >
+                <IoChevronUp className="h-4 w-4" />
+              </button>
+              <button
+                onClick={() => onMoveDown(notification.id)}
+                disabled={isLast}
+                className={`p-1 text-gray-400 hover:text-orange-500 hover:bg-orange-50 rounded transition-colors ${
+                  isLast ? 'opacity-30 cursor-not-allowed' : ''
+                }`}
+                aria-label="下に移動"
+              >
+                <IoChevronDown className="h-4 w-4" />
+              </button>
+            </div>
+          )}
+          <span className={`px-2 py-1 text-xs font-medium rounded ${getTypeColor(notification.type)}`}>
+            {getTypeLabel(notification.type)}
+          </span>
+          <span className="text-sm text-gray-500">{formatDate(notification.date)}</span>
+        </div>
+        {/* 開発者モード時のみ表示:編集・削除ボタン */}
+        {isDeveloperMode && (
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => onEdit(notification)}
+              className="p-2 text-gray-600 hover:text-orange-500 hover:bg-orange-50 rounded transition-colors"
+              aria-label="編集"
+            >
+              <IoCreateOutline className="h-5 w-5" />
+            </button>
+            <button
+              onClick={() => onDelete(notification.id)}
+              className="p-2 text-gray-600 hover:text-red-500 hover:bg-red-50 rounded transition-colors"
+              aria-label="削除"
+            >
+              <IoTrashOutline className="h-5 w-5" />
+            </button>
+          </div>
+        )}
+      </div>
+      <h2 className="text-lg font-semibold text-gray-800 mb-2">{notification.title}</h2>
+      <p className="text-gray-600 whitespace-pre-wrap">{notification.content}</p>
+    </div>
+  );
+}

--- a/components/notifications/NotificationModal.tsx
+++ b/components/notifications/NotificationModal.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { useState } from 'react';
+import type { Notification, NotificationType } from '@/types';
+
+interface NotificationModalProps {
+  notification: Notification | null;
+  onSave: (notification: Omit<Notification, 'id'>) => void;
+  onCancel: () => void;
+}
+
+export function NotificationModal({ notification, onSave, onCancel }: NotificationModalProps) {
+  const [title, setTitle] = useState(notification?.title || '');
+  const [content, setContent] = useState(notification?.content || '');
+  const [date, setDate] = useState(notification?.date || new Date().toISOString().split('T')[0]);
+  const [type, setType] = useState<NotificationType>(notification?.type || 'announcement');
+  const [errors, setErrors] = useState<{ title?: string; content?: string; date?: string }>({});
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    // バリデーション
+    const newErrors: { title?: string; content?: string; date?: string } = {};
+    if (!title.trim()) {
+      newErrors.title = 'タイトルを入力してください';
+    }
+    if (!content.trim()) {
+      newErrors.content = '内容を入力してください';
+    }
+    if (!date) {
+      newErrors.date = '日付を選択してください';
+    }
+
+    if (Object.keys(newErrors).length > 0) {
+      setErrors(newErrors);
+      return;
+    }
+
+    setErrors({});
+    onSave({
+      title: title.trim(),
+      content: content.trim(),
+      date,
+      type,
+    });
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
+        <div className="p-6 text-gray-900">
+          <h3 className="text-xl font-semibold text-gray-900 mb-6">
+            {notification ? '通知を編集' : '通知を追加'}
+          </h3>
+          <form onSubmit={handleSubmit}>
+            <div className="space-y-4">
+              {/* タイトル */}
+              <div>
+                <label
+                  htmlFor="title"
+                  className="block text-sm font-medium text-gray-700 mb-2"
+                >
+                  タイトル <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="text"
+                  id="title"
+                  value={title}
+                  onChange={(e) => {
+                    setTitle(e.target.value);
+                    if (errors.title) setErrors({ ...errors, title: undefined });
+                  }}
+                  className={`w-full px-4 py-2 border rounded-lg text-gray-900 bg-white focus:outline-none focus:ring-2 focus:ring-orange-500 ${
+                    errors.title ? 'border-red-500' : 'border-gray-300'
+                  }`}
+                  placeholder="通知のタイトルを入力"
+                />
+                {errors.title && (
+                  <p className="mt-1 text-sm text-red-600">{errors.title}</p>
+                )}
+              </div>
+
+              {/* 内容 */}
+              <div>
+                <label
+                  htmlFor="content"
+                  className="block text-sm font-medium text-gray-700 mb-2"
+                >
+                  内容 <span className="text-red-500">*</span>
+                </label>
+                <textarea
+                  id="content"
+                  value={content}
+                  onChange={(e) => {
+                    setContent(e.target.value);
+                    if (errors.content) setErrors({ ...errors, content: undefined });
+                  }}
+                  rows={6}
+                  className={`w-full px-4 py-2 border rounded-lg text-gray-900 bg-white focus:outline-none focus:ring-2 focus:ring-orange-500 ${
+                    errors.content ? 'border-red-500' : 'border-gray-300'
+                  }`}
+                  placeholder="通知の内容を入力"
+                />
+                {errors.content && (
+                  <p className="mt-1 text-sm text-red-600">{errors.content}</p>
+                )}
+              </div>
+
+              {/* 日付 */}
+              <div>
+                <label
+                  htmlFor="date"
+                  className="block text-sm font-medium text-gray-700 mb-2"
+                >
+                  日付 <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="date"
+                  id="date"
+                  value={date}
+                  onChange={(e) => {
+                    setDate(e.target.value);
+                    if (errors.date) setErrors({ ...errors, date: undefined });
+                  }}
+                  className={`w-full px-4 py-2 border rounded-lg text-gray-900 bg-white focus:outline-none focus:ring-2 focus:ring-orange-500 ${
+                    errors.date ? 'border-red-500' : 'border-gray-300'
+                  }`}
+                />
+                {errors.date && (
+                  <p className="mt-1 text-sm text-red-600">{errors.date}</p>
+                )}
+              </div>
+
+              {/* 種類 */}
+              <div>
+                <label
+                  htmlFor="type"
+                  className="block text-sm font-medium text-gray-700 mb-2"
+                >
+                  種類 <span className="text-red-500">*</span>
+                </label>
+                <select
+                  id="type"
+                  value={type}
+                  onChange={(e) => setType(e.target.value as NotificationType)}
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg text-gray-900 bg-white focus:outline-none focus:ring-2 focus:ring-orange-500"
+                >
+                  <option value="announcement">お知らせ</option>
+                  <option value="update">アップデート</option>
+                  <option value="improvement">改善</option>
+                  <option value="request">お願い</option>
+                  <option value="bugfix">バグ修正</option>
+                </select>
+              </div>
+            </div>
+
+            <div className="flex gap-3 justify-end mt-6">
+              <button
+                type="button"
+                onClick={onCancel}
+                className="px-4 py-2 text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors"
+              >
+                キャンセル
+              </button>
+              <button
+                type="submit"
+                className="px-4 py-2 bg-orange-500 text-white rounded-lg hover:bg-orange-600 transition-colors"
+              >
+                {notification ? '更新' : '追加'}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/settings/PasswordModal.tsx
+++ b/components/settings/PasswordModal.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui';
+
+interface PasswordModalProps {
+  onSubmit: (password: string) => boolean;
+  onCancel: () => void;
+}
+
+export function PasswordModal({ onSubmit, onCancel }: PasswordModalProps) {
+  const [password, setPassword] = useState('');
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setPasswordError(null);
+
+    if (onSubmit(password)) {
+      setPassword('');
+    } else {
+      setPasswordError('パスワードが正しくありません');
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-6">
+        <h3 className="text-xl font-semibold text-gray-800 mb-4">パスワードを入力</h3>
+        <form onSubmit={handleSubmit}>
+          <div className="mb-4">
+            <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-2">
+              パスワード
+            </label>
+            <input
+              type="password"
+              id="password"
+              value={password}
+              onChange={(e) => {
+                setPassword(e.target.value);
+                setPasswordError(null);
+              }}
+              className={`w-full px-4 py-2 border rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 ${
+                passwordError ? 'border-red-500' : 'border-gray-300'
+              }`}
+              placeholder="パスワードを入力"
+              autoFocus
+            />
+            {passwordError && <p className="mt-2 text-sm text-red-600">{passwordError}</p>}
+          </div>
+          <div className="flex gap-3 justify-end">
+            <Button type="button" variant="secondary" size="md" onClick={onCancel}>
+              キャンセル
+            </Button>
+            <Button type="submit" variant="primary" size="md">
+              確定
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/components/settings/ToggleSwitch.tsx
+++ b/components/settings/ToggleSwitch.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+interface ToggleSwitchProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+export function ToggleSwitch({ checked, onChange }: ToggleSwitchProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onChange(!checked)}
+      className={`relative inline-flex h-8 w-14 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 ${
+        checked ? 'bg-orange-500' : 'bg-gray-300'
+      }`}
+    >
+      <span
+        className={`inline-block h-6 w-6 transform rounded-full bg-white transition-transform ${
+          checked ? 'translate-x-7' : 'translate-x-1'
+        }`}
+      />
+    </button>
+  );
+}


### PR DESCRIPTION
## 概要

Issue #91 の実装。各ページを300行以内に抑えるため、コンポーネント分割を実施。

## 変更内容

- defect-beans/page.tsx (540→383行): SearchFilterSection, SortMenu, EmptyState 抽出
- notifications/page.tsx (532→245行): NotificationModal, NotificationCard, DeleteConfirmDialog 抽出
- page.tsx (430→403行): ActionCard 抽出
- settings/page.tsx (396→322行): ToggleSwitch, PasswordModal 抽出
- contact/page.tsx (306→207行): ContactSuccessScreen, ContactFormFields 抽出

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)