### PR TITLE
refactor(ui): ログインページ・検索フィルターのUIコンポーネント統一 [Issue #126]

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { createUserWithEmailAndPassword, signInWithEmailAndPassword } from 'firebase/auth';
 import { auth } from '@/lib/firebase';
 import { Loading } from '@/components/Loading';
+import { Input, Button } from '@/components/ui';
 
 type TabType = 'login' | 'signup';
 
@@ -13,8 +14,6 @@ function LoginForm() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
-  const [showPassword, setShowPassword] = useState(false);
-  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const router = useRouter();
@@ -89,7 +88,7 @@ function LoginForm() {
       <div className="w-full max-w-md rounded-lg bg-white p-8 shadow-md">
         <div className="mb-8 flex flex-col items-center bg-[#1a1412] py-6 rounded-xl shadow-inner">
           <h1 className="text-4xl font-bold text-white tracking-tight font-[var(--font-playfair)]">
-            Roast<span className="text-orange-500">Plus</span>
+            Roast<span className="text-amber-500">Plus</span>
           </h1>
         </div>
 
@@ -98,185 +97,68 @@ function LoginForm() {
           <button
             type="button"
             onClick={() => {
-              setActiveTab('login');
-              setError(null);
-              setConfirmPassword('');
-            }}
-            className={`flex-1 rounded-md py-2 text-center text-sm font-medium transition-colors ${activeTab === 'login'
-              ? 'bg-orange-500 text-white'
-              : 'text-gray-700 hover:text-gray-900'
-              }`}
-          >
-            ログイン
-          </button>
-          <button
-            type="button"
-            onClick={() => {
               setActiveTab('signup');
               setError(null);
             }}
-            className={`flex-1 rounded-md py-2 text-center text-sm font-medium transition-colors ${activeTab === 'signup'
-              ? 'bg-orange-500 text-white'
+            className={`flex-1 rounded-lg py-2.5 text-center text-sm font-semibold transition-colors ${activeTab === 'signup'
+              ? 'bg-amber-600 text-white'
               : 'text-gray-700 hover:text-gray-900'
               }`}
           >
             新規登録
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setActiveTab('login');
+              setError(null);
+              setConfirmPassword('');
+            }}
+            className={`flex-1 rounded-lg py-2.5 text-center text-sm font-semibold transition-colors ${activeTab === 'login'
+              ? 'bg-amber-600 text-white'
+              : 'text-gray-700 hover:text-gray-900'
+              }`}
+          >
+            ログイン
           </button>
         </div>
 
         {/* フォーム */}
         <form onSubmit={handleSubmit} className="space-y-4">
           {/* メールアドレス */}
-          <div>
-            <label
-              htmlFor="email"
-              className="mb-1 block text-sm font-medium text-gray-700"
-            >
-              メールアドレス
-            </label>
-            <input
-              id="email"
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="example@example.com"
-              required
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 placeholder-gray-400 focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500"
-            />
-          </div>
+          <Input
+            label="メールアドレス"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="example@example.com"
+            required
+          />
 
           {/* パスワード */}
-          <div>
-            <label
-              htmlFor="password"
-              className="mb-1 block text-sm font-medium text-gray-700"
-            >
-              パスワード
-            </label>
-            <div className="relative">
-              <input
-                id="password"
-                type={showPassword ? 'text' : 'password'}
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                placeholder="6文字以上"
-                required
-                minLength={6}
-                className="w-full rounded-md border border-gray-300 px-3 py-2 pr-10 text-gray-900 placeholder-gray-400 focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500"
-              />
-              <button
-                type="button"
-                onClick={() => setShowPassword(!showPassword)}
-                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
-                aria-label={showPassword ? 'パスワードを非表示' : 'パスワードを表示'}
-              >
-                {showPassword ? (
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    className="h-5 w-5"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
-                    />
-                  </svg>
-                ) : (
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    className="h-5 w-5"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                    />
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-                    />
-                  </svg>
-                )}
-              </button>
-            </div>
-          </div>
+          <Input
+            label="パスワード"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="6文字以上"
+            required
+            minLength={6}
+            showPasswordToggle
+          />
 
           {/* パスワード確認（新規登録時のみ） */}
           {activeTab === 'signup' && (
-            <div>
-              <label
-                htmlFor="confirmPassword"
-                className="mb-1 block text-sm font-medium text-gray-700"
-              >
-                パスワード（確認）
-              </label>
-              <div className="relative">
-                <input
-                  id="confirmPassword"
-                  type={showConfirmPassword ? 'text' : 'password'}
-                  value={confirmPassword}
-                  onChange={(e) => setConfirmPassword(e.target.value)}
-                  placeholder="6文字以上"
-                  required
-                  minLength={6}
-                  className="w-full rounded-md border border-gray-300 px-3 py-2 pr-10 text-gray-900 placeholder-gray-400 focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
-                  aria-label={showConfirmPassword ? 'パスワードを非表示' : 'パスワードを表示'}
-                >
-                  {showConfirmPassword ? (
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      className="h-5 w-5"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
-                      />
-                    </svg>
-                  ) : (
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      className="h-5 w-5"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                      />
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-                      />
-                    </svg>
-                  )}
-                </button>
-              </div>
-            </div>
+            <Input
+              label="パスワード（確認）"
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              placeholder="6文字以上"
+              required
+              minLength={6}
+              showPasswordToggle
+            />
           )}
 
           {error && (
@@ -284,13 +166,14 @@ function LoginForm() {
           )}
 
           {/* 送信ボタン */}
-          <button
+          <Button
             type="submit"
             disabled={loading}
-            className="w-full rounded-md bg-orange-500 px-4 py-3 font-medium text-white transition-colors hover:bg-orange-600 disabled:cursor-not-allowed disabled:opacity-50"
+            loading={loading}
+            fullWidth
           >
-            {loading ? '処理中...' : activeTab === 'login' ? 'ログイン' : '新規登録'}
-          </button>
+            {activeTab === 'login' ? 'ログイン' : '新規登録'}
+          </Button>
         </form>
       </div>
     </div>
@@ -313,4 +196,3 @@ export default function LoginPage() {
     </Suspense>
   );
 }
-

--- a/app/ui-test/page.tsx
+++ b/app/ui-test/page.tsx
@@ -9,6 +9,7 @@ import { HiArrowLeft } from 'react-icons/hi';
 export default function UITestPage() {
   const { isChristmasMode, toggleChristmasMode } = useChristmasMode();
   const [name, setName] = useState('');
+  const [password, setPassword] = useState('');
   const [category, setCategory] = useState('');
   const [memo, setMemo] = useState('');
   const [loading, setLoading] = useState(false);
@@ -61,6 +62,7 @@ export default function UITestPage() {
             <Button variant="primary" isChristmasMode={isChristmasMode}>Primary</Button>
             <Button variant="secondary" isChristmasMode={isChristmasMode}>Secondary</Button>
             <Button variant="danger" isChristmasMode={isChristmasMode}>Danger</Button>
+            <Button variant="success" isChristmasMode={isChristmasMode}>Success</Button>
             <Button variant="outline" isChristmasMode={isChristmasMode}>Outline</Button>
             <Button variant="ghost" isChristmasMode={isChristmasMode}>Ghost</Button>
           </div>
@@ -103,6 +105,15 @@ export default function UITestPage() {
               placeholder="山田太郎"
               value={name}
               onChange={(e) => setName(e.target.value)}
+              isChristmasMode={isChristmasMode}
+            />
+            <Input
+              label="パスワード（トグル付き）"
+              type="password"
+              placeholder="パスワードを入力"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              showPasswordToggle
               isChristmasMode={isChristmasMode}
             />
             <Input

--- a/components/defect-beans/SearchFilterSection.tsx
+++ b/components/defect-beans/SearchFilterSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { HiSearch, HiCollection, HiCheckCircle, HiXCircle } from 'react-icons/hi';
+import { Input, Button } from '@/components/ui';
 
 type FilterOption = 'all' | 'shouldRemove' | 'shouldNotRemove';
 
@@ -23,55 +24,49 @@ export function SearchFilterSection({
         {/* 検索 */}
         <div className="flex-1">
           <div className="relative">
-            <HiSearch className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
-            <input
+            <HiSearch className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400 z-10" />
+            <Input
               type="text"
               value={searchQuery}
               onChange={(e) => onSearchChange(e.target.value)}
               placeholder="名称や特徴で検索..."
-              className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent min-h-[40px] text-sm text-gray-900 bg-white placeholder:text-gray-400"
+              className="pl-10 !py-2 !text-sm !min-h-[40px]"
             />
           </div>
         </div>
 
         {/* フィルタ */}
         <div className="flex gap-1.5">
-          <button
+          <Button
+            variant={filterOption === 'all' ? 'primary' : 'secondary'}
+            size="sm"
             onClick={() => onFilterChange('all')}
-            className={`px-3 py-1.5 rounded-lg transition-colors min-h-[36px] flex items-center gap-1.5 text-sm ${
-              filterOption === 'all'
-                ? 'bg-primary text-white'
-                : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
-            }`}
+            className={`!px-3 !py-1.5 !min-h-[36px] ${filterOption !== 'all' ? '!bg-gray-200 !text-gray-700 hover:!bg-gray-300' : ''}`}
             title="全て表示"
           >
-            <HiCollection className="h-4 w-4" />
+            <HiCollection className="h-4 w-4 mr-1" />
             <span className="text-xs sm:text-sm">全て</span>
-          </button>
-          <button
+          </Button>
+          <Button
+            variant={filterOption === 'shouldRemove' ? 'danger' : 'secondary'}
+            size="sm"
             onClick={() => onFilterChange('shouldRemove')}
-            className={`px-3 py-1.5 rounded-lg transition-colors min-h-[36px] flex items-center gap-1.5 text-sm ${
-              filterOption === 'shouldRemove'
-                ? 'bg-red-500 text-white'
-                : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
-            }`}
+            className={`!px-3 !py-1.5 !min-h-[36px] ${filterOption !== 'shouldRemove' ? '!bg-gray-200 !text-gray-700 hover:!bg-gray-300' : ''}`}
             title="省く設定のもの"
           >
-            <HiXCircle className="h-4 w-4" />
+            <HiXCircle className="h-4 w-4 mr-1" />
             <span className="text-xs sm:text-sm">省く</span>
-          </button>
-          <button
+          </Button>
+          <Button
+            variant={filterOption === 'shouldNotRemove' ? 'success' : 'secondary'}
+            size="sm"
             onClick={() => onFilterChange('shouldNotRemove')}
-            className={`px-3 py-1.5 rounded-lg transition-colors min-h-[36px] flex items-center gap-1.5 text-sm ${
-              filterOption === 'shouldNotRemove'
-                ? 'bg-green-500 text-white'
-                : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
-            }`}
+            className={`!px-3 !py-1.5 !min-h-[36px] ${filterOption !== 'shouldNotRemove' ? '!bg-gray-200 !text-gray-700 hover:!bg-gray-300' : ''}`}
             title="省かない設定のもの"
           >
-            <HiCheckCircle className="h-4 w-4" />
+            <HiCheckCircle className="h-4 w-4 mr-1" />
             <span className="text-xs sm:text-sm">省かない</span>
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -47,7 +47,7 @@ import { forwardRef } from 'react';
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /** ボタンのスタイルバリエーション */
-  variant?: 'primary' | 'secondary' | 'danger' | 'outline' | 'ghost';
+  variant?: 'primary' | 'secondary' | 'danger' | 'success' | 'outline' | 'ghost';
   /** ボタンのサイズ */
   size?: 'sm' | 'md' | 'lg';
   /** ローディング状態 */
@@ -88,6 +88,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       primary: 'bg-amber-600 text-white hover:bg-amber-700',
       secondary: 'bg-gray-600 text-white hover:bg-gray-700',
       danger: 'bg-red-600 text-white hover:bg-red-700',
+      success: 'bg-green-600 text-white hover:bg-green-700',
       outline: 'border-2 border-amber-200 text-amber-700 bg-gradient-to-r from-amber-50 to-amber-100 hover:from-amber-100 hover:to-amber-200',
       ghost: 'text-amber-600 hover:text-amber-700 hover:bg-amber-50',
     };
@@ -97,6 +98,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       primary: 'bg-[#6d1a1a] text-white hover:bg-[#8b2323] border border-[#d4af37]/40',
       secondary: 'bg-[#3a3a3a] text-[#f8f1e7] hover:bg-[#4a4a4a]',
       danger: 'bg-red-800 text-white hover:bg-red-900',
+      success: 'bg-green-800 text-white hover:bg-green-900',
       outline: 'border-2 border-[#d4af37]/60 text-[#d4af37] bg-[#d4af37]/10 hover:bg-[#d4af37]/20',
       ghost: 'text-[#d4af37] hover:text-[#e8c65f] hover:bg-[#d4af37]/10',
     };

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { forwardRef } from 'react';
+import { forwardRef, useState, useId } from 'react';
+import { HiEye, HiEyeOff } from 'react-icons/hi';
 
 /**
  * 統一されたテキスト入力コンポーネント
@@ -42,11 +43,19 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
   error?: string;
   /** クリスマスモードの有効/無効 */
   isChristmasMode?: boolean;
+  /** パスワード表示/非表示トグルを表示（type="password"時のみ有効） */
+  showPasswordToggle?: boolean;
 }
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ label, error, isChristmasMode = false, className = '', id, ...props }, ref) => {
-    const inputId = id || `input-${Math.random().toString(36).substr(2, 9)}`;
+  ({ label, error, isChristmasMode = false, showPasswordToggle = false, className = '', id, type, ...props }, ref) => {
+    const generatedId = useId();
+    const inputId = id || generatedId;
+    const [showPassword, setShowPassword] = useState(false);
+
+    // パスワードトグルが有効で、元のtypeがpasswordの場合
+    const isPasswordField = type === 'password' && showPasswordToggle;
+    const inputType = isPasswordField && showPassword ? 'text' : type;
 
     const baseStyles = 'w-full rounded-lg border-2 px-4 py-3.5 text-lg transition-all duration-200 shadow-sm min-h-[44px]';
 
@@ -76,6 +85,10 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       ? 'text-red-400 text-sm mt-1'
       : 'text-red-500 text-sm mt-1';
 
+    const toggleButtonStyles = isChristmasMode
+      ? 'text-[#d4af37]/70 hover:text-[#d4af37]'
+      : 'text-gray-400 hover:text-gray-600';
+
     return (
       <div>
         {label && (
@@ -83,14 +96,31 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             {label}
           </label>
         )}
-        <input
-          ref={ref}
-          id={inputId}
-          className={inputStyles}
-          aria-invalid={error ? 'true' : 'false'}
-          aria-describedby={error ? `${inputId}-error` : undefined}
-          {...props}
-        />
+        <div className="relative">
+          <input
+            ref={ref}
+            id={inputId}
+            type={inputType}
+            className={`${inputStyles} ${isPasswordField ? 'pr-12' : ''}`}
+            aria-invalid={error ? 'true' : 'false'}
+            aria-describedby={error ? `${inputId}-error` : undefined}
+            {...props}
+          />
+          {isPasswordField && (
+            <button
+              type="button"
+              onClick={() => setShowPassword(!showPassword)}
+              className={`absolute right-3 top-1/2 -translate-y-1/2 p-1 transition-colors ${toggleButtonStyles}`}
+              aria-label={showPassword ? 'パスワードを非表示' : 'パスワードを表示'}
+            >
+              {showPassword ? (
+                <HiEyeOff className="h-5 w-5" />
+              ) : (
+                <HiEye className="h-5 w-5" />
+              )}
+            </button>
+          )}
+        </div>
         {error && (
           <p id={`${inputId}-error`} className={errorTextStyles} role="alert">
             {error}


### PR DESCRIPTION
## 概要
Issue #126 を解決。ログインページと検索フィルターでUIコンポーネントを統一。

## 変更内容

### UI Input 拡張
- パスワード表示/非表示トグル機能を追加（`showPasswordToggle` prop）
- `useId` フックで安定したID生成（Math.random廃止）

### UI Button 拡張
- `success` バリアント（緑）を追加

### ログインページ (`app/login/page.tsx`)
- 独自input → UI Inputコンポーネントに置き換え
- 独自button → UI Buttonコンポーネントに置き換え
- パスワードトグルをUI Inputの機能で実装
- タブ順序を「新規登録」→「ログイン」に修正
- ロゴの色を `orange-500` → `amber-500` に統一

### 検索フィルター (`components/defect-beans/SearchFilterSection.tsx`)
- 独自input → UI Inputコンポーネントに置き換え
- 独自button → UI Buttonコンポーネントに置き換え
- フィルタボタンの色分け: primary(全て), danger(省く), success(省かない)

### UIカタログページ (`app/ui-test/page.tsx`)
- Successバリアントボタンのデモ追加
- パスワードトグル付きInputのデモ追加

## テスト
- [x] lint通過
- [ ] ログインページで入力・ログインが動作する
- [ ] パスワード表示/非表示トグルが動作する
- [ ] 検索フィルターが動作する
- [ ] UIカタログで新機能が確認できる

Closes #126
