### PR TITLE
[Issue #127] NotificationCard・VersionCardをUI Cardに統一

### DIFF
--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -7,8 +7,10 @@ import { MdHistory } from 'react-icons/md';
 import type { ChangelogEntryType } from '@/types';
 import { ChangeTypeFilter, ChangelogTimeline } from '@/components/changelog';
 import { DETAILED_CHANGELOG } from '@/data/dev-stories/detailed-changelog';
+import { useChristmasMode } from '@/hooks/useChristmasMode';
 
 export default function ChangelogPage() {
+  const { isChristmasMode } = useChristmasMode();
   const [selectedTypes, setSelectedTypes] = useState<ChangelogEntryType[]>([]);
 
   const handleToggleType = (type: ChangelogEntryType) => {
@@ -72,7 +74,7 @@ export default function ChangelogPage() {
 
         {/* メインコンテンツ */}
         <main className="flex-1">
-          <ChangelogTimeline entries={filteredEntries} />
+          <ChangelogTimeline entries={filteredEntries} isChristmasMode={isChristmasMode} />
         </main>
 
         {/* フッター */}

--- a/app/notifications/page.tsx
+++ b/app/notifications/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import { useAuth } from '@/lib/auth';
 import { useNotifications } from '@/hooks/useNotifications';
 import { useDeveloperMode } from '@/hooks/useDeveloperMode';
+import { useChristmasMode } from '@/hooks/useChristmasMode';
 import { Loading } from '@/components/Loading';
 import { NotificationModal } from '@/components/notifications/NotificationModal';
 import { NotificationCard } from '@/components/notifications/NotificationCard';
@@ -18,6 +19,7 @@ export default function NotificationsPage() {
   const { user, loading: authLoading } = useAuth();
   const { notifications, readIds, markAllAsRead, addNotification, updateNotification, deleteNotification, isLoading } = useNotifications();
   const { isEnabled: isDeveloperMode, isLoading: isDeveloperModeLoading } = useDeveloperMode();
+  const { isChristmasMode } = useChristmasMode();
   const router = useRouter();
   const [showModal, setShowModal] = useState(false);
   const [editingNotification, setEditingNotification] = useState<Notification | null>(null);
@@ -200,6 +202,7 @@ export default function NotificationsPage() {
                     isFirst={isFirst}
                     isLast={isLast}
                     isDeveloperMode={isDeveloperMode}
+                    isChristmasMode={isChristmasMode}
                     onEdit={handleEditClick}
                     onDelete={handleDeleteClick}
                     onMoveUp={handleMoveUp}

--- a/components/changelog/ChangelogTimeline.tsx
+++ b/components/changelog/ChangelogTimeline.tsx
@@ -7,9 +7,10 @@ import { MdHistory } from 'react-icons/md';
 
 interface ChangelogTimelineProps {
   entries: ChangelogEntry[];
+  isChristmasMode?: boolean;
 }
 
-export const ChangelogTimeline: React.FC<ChangelogTimelineProps> = ({ entries }) => {
+export const ChangelogTimeline: React.FC<ChangelogTimelineProps> = ({ entries, isChristmasMode = false }) => {
   if (entries.length === 0) {
     return (
       <div className="text-center py-12">
@@ -27,7 +28,7 @@ export const ChangelogTimeline: React.FC<ChangelogTimelineProps> = ({ entries })
   return (
     <div className="space-y-4">
       {entries.map((entry) => (
-        <VersionCard key={entry.id} entry={entry} />
+        <VersionCard key={entry.id} entry={entry} isChristmasMode={isChristmasMode} />
       ))}
     </div>
   );

--- a/components/changelog/VersionCard.tsx
+++ b/components/changelog/VersionCard.tsx
@@ -3,12 +3,14 @@
 import React from 'react';
 import type { ChangelogEntry } from '@/types';
 import { CHANGE_TYPE_CONFIG } from '@/data/dev-stories/detailed-changelog';
+import { Card } from '@/components/ui/Card';
 
 interface VersionCardProps {
   entry: ChangelogEntry;
+  isChristmasMode?: boolean;
 }
 
-export const VersionCard: React.FC<VersionCardProps> = ({ entry }) => {
+export const VersionCard: React.FC<VersionCardProps> = ({ entry, isChristmasMode = false }) => {
   const typeConfig = CHANGE_TYPE_CONFIG[entry.type];
 
   const formatDate = (dateString: string) => {
@@ -21,7 +23,7 @@ export const VersionCard: React.FC<VersionCardProps> = ({ entry }) => {
   };
 
   return (
-    <div className="bg-white rounded-lg shadow-sm border border-gray-100 p-4 sm:p-5 hover:shadow-md transition-shadow">
+    <Card variant="hoverable" isChristmasMode={isChristmasMode} className="p-4 sm:p-5">
       {/* ヘッダー部分 */}
       <div className="flex flex-wrap items-center gap-2 mb-3">
         {entry.version && (
@@ -38,28 +40,28 @@ export const VersionCard: React.FC<VersionCardProps> = ({ entry }) => {
       </div>
 
       {/* タイトル */}
-      <h3 className="text-lg font-semibold text-gray-800 mb-2">
+      <h3 className={`text-lg font-semibold mb-2 ${isChristmasMode ? 'text-white' : 'text-gray-800'}`}>
         {entry.title}
       </h3>
 
       {/* 内容 */}
-      <div className="text-sm text-gray-600 whitespace-pre-line leading-relaxed">
+      <div className={`text-sm whitespace-pre-line leading-relaxed ${isChristmasMode ? 'text-gray-300' : 'text-gray-600'}`}>
         {entry.content}
       </div>
 
       {/* タグ */}
       {entry.tags && entry.tags.length > 0 && (
-        <div className="flex flex-wrap gap-1.5 mt-3 pt-3 border-t border-gray-100">
+        <div className={`flex flex-wrap gap-1.5 mt-3 pt-3 border-t ${isChristmasMode ? 'border-[#d4af37]/20' : 'border-gray-100'}`}>
           {entry.tags.map((tag) => (
             <span
               key={tag}
-              className="px-2 py-0.5 bg-gray-50 text-gray-500 text-xs rounded"
+              className={`px-2 py-0.5 text-xs rounded ${isChristmasMode ? 'bg-white/10 text-gray-400' : 'bg-gray-50 text-gray-500'}`}
             >
               #{tag}
             </span>
           ))}
         </div>
       )}
-    </div>
+    </Card>
   );
 };

--- a/components/notifications/NotificationCard.tsx
+++ b/components/notifications/NotificationCard.tsx
@@ -2,12 +2,14 @@
 
 import { IoCreateOutline, IoTrashOutline, IoChevronUp, IoChevronDown } from 'react-icons/io5';
 import type { Notification } from '@/types';
+import { Card } from '@/components/ui/Card';
 
 interface NotificationCardProps {
   notification: Notification;
   isFirst: boolean;
   isLast: boolean;
   isDeveloperMode: boolean;
+  isChristmasMode?: boolean;
   onEdit: (notification: Notification) => void;
   onDelete: (id: string) => void;
   onMoveUp: (id: string) => void;
@@ -61,13 +63,14 @@ export function NotificationCard({
   isFirst,
   isLast,
   isDeveloperMode,
+  isChristmasMode = false,
   onEdit,
   onDelete,
   onMoveUp,
   onMoveDown,
 }: NotificationCardProps) {
   return (
-    <div className="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow">
+    <Card variant="hoverable" isChristmasMode={isChristmasMode} className="p-6">
       <div className="flex items-start justify-between mb-2">
         <div className="flex items-center gap-2">
           {/* 開発者モード時のみ表示:上/下移動ボタン */}
@@ -98,7 +101,7 @@ export function NotificationCard({
           <span className={`px-2 py-1 text-xs font-medium rounded ${getTypeColor(notification.type)}`}>
             {getTypeLabel(notification.type)}
           </span>
-          <span className="text-sm text-gray-500">{formatDate(notification.date)}</span>
+          <span className={`text-sm ${isChristmasMode ? 'text-gray-400' : 'text-gray-500'}`}>{formatDate(notification.date)}</span>
         </div>
         {/* 開発者モード時のみ表示:編集・削除ボタン */}
         {isDeveloperMode && (
@@ -120,8 +123,8 @@ export function NotificationCard({
           </div>
         )}
       </div>
-      <h2 className="text-lg font-semibold text-gray-800 mb-2">{notification.title}</h2>
-      <p className="text-gray-600 whitespace-pre-wrap">{notification.content}</p>
-    </div>
+      <h2 className={`text-lg font-semibold mb-2 ${isChristmasMode ? 'text-white' : 'text-gray-800'}`}>{notification.title}</h2>
+      <p className={`whitespace-pre-wrap ${isChristmasMode ? 'text-gray-300' : 'text-gray-600'}`}>{notification.content}</p>
+    </Card>
   );
 }


### PR DESCRIPTION
## 概要
Issue #127 を解決: NotificationCardとVersionCardを共通UI Cardコンポーネントに統一

## 変更内容
- **NotificationCard**: 独自`<div>`要素を`<Card variant="hoverable">`に置換し、クリスマスモード対応を追加
- **VersionCard**: 独自`<div>`要素を`<Card variant="hoverable">`に置換し、クリスマスモード対応を追加
- **ChangelogTimeline**: `isChristmasMode`プロパティを追加してVersionCardに伝播
- **親ページ**: `useChristmasMode`フックを追加し、各コンポーネントに渡す
- **テキストスタイル**: タイトル、本文、日付、タグのテキストカラーをクリスマスモード対応

## 受け入れ条件の達成状況
- [x] NotificationCardがUI Cardコンポーネントを使用
- [x] VersionCardがUI Cardコンポーネントを使用
- [x] クリスマスモード対応が維持されている
- [x] 既存の機能・レイアウトが維持されている

## テスト
- [x] lint / eslint通過
- [ ] 実機動作確認（通知ページ）
- [ ] 実機動作確認（更新履歴ページ）
- [ ] クリスマスモードON/OFF切替確認

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)
