### PR TITLE
[Issue #132] refactor(assignment): 担当表ページの共通UI化とテーマ対応

### DIFF
--- a/app/assignment/components/ManagerDialog.tsx
+++ b/app/assignment/components/ManagerDialog.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { HiX } from 'react-icons/hi';
 import type { Manager } from '@/types';
+import { Button, Input } from '@/components/ui';
 
 interface ManagerDialogProps {
   isOpen: boolean;
@@ -10,6 +11,7 @@ interface ManagerDialogProps {
   onClose: () => void;
   onSave: (name: string) => Promise<void>;
   onDelete: () => Promise<void>;
+  isChristmasMode?: boolean;
 }
 
 export function ManagerDialog({
@@ -18,6 +20,7 @@ export function ManagerDialog({
   onClose,
   onSave,
   onDelete,
+  isChristmasMode = false,
 }: ManagerDialogProps) {
   const [name, setName] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -74,58 +77,68 @@ export function ManagerDialog({
       onClick={onClose}
     >
       <div
-        className="bg-white rounded-lg p-6 max-w-sm w-full mx-4 shadow-xl"
+        className={`rounded-lg p-6 max-w-sm w-full mx-4 shadow-xl ${
+          isChristmasMode ? 'bg-[#1a1a1a] border border-[#d4af37]/30' : 'bg-white'
+        }`}
         onClick={(e) => e.stopPropagation()}
       >
         {/* ヘッダー */}
         <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-bold text-gray-800">
+          <h2 className={`text-lg font-bold ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
             {manager ? '管理者を編集' : '管理者を追加'}
           </h2>
-          <button
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={onClose}
-            className="p-1 text-gray-500 hover:text-gray-700 rounded transition-colors"
+            isChristmasMode={isChristmasMode}
+            className="!p-1 !min-h-0"
             aria-label="閉じる"
           >
             <HiX className="w-5 h-5" />
-          </button>
+          </Button>
         </div>
 
         {/* 入力フォーム */}
         <div className="mb-6">
-          <label className="block text-sm font-medium text-gray-700 mb-2">
-            名前
-          </label>
-          <input
+          <Input
+            label="名前"
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="管理者の名前を入力"
-            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500 text-gray-900"
             autoFocus
             disabled={isLoading}
+            isChristmasMode={isChristmasMode}
           />
         </div>
 
         {/* ボタン */}
         <div className="flex gap-3">
           {manager && (
-            <button
+            <Button
+              variant="danger"
+              size="md"
               onClick={handleDelete}
               disabled={isLoading}
-              className="flex-1 px-4 py-2 bg-white border border-red-300 text-red-600 rounded-lg hover:bg-red-50 transition-colors font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+              isChristmasMode={isChristmasMode}
+              className="flex-1"
             >
               削除
-            </button>
+            </Button>
           )}
-          <button
+          <Button
+            variant="primary"
+            size="md"
             onClick={handleSave}
             disabled={isLoading || !name.trim()}
-            className="flex-1 px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary-dark transition-colors font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+            loading={isLoading}
+            isChristmasMode={isChristmasMode}
+            className="flex-1"
           >
-            {isLoading ? '保存中...' : manager ? '更新' : '追加'}
-          </button>
+            {manager ? '更新' : '追加'}
+          </Button>
         </div>
       </div>
     </div>

--- a/app/assignment/components/MemberSettingsDialog.tsx
+++ b/app/assignment/components/MemberSettingsDialog.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Member, TaskLabel } from '../../../types';
+import { Button } from '@/components/ui';
 
 type Props = {
     member: Member;
@@ -7,6 +8,7 @@ type Props = {
     isOpen: boolean;
     onClose: () => void;
     onUpdateExclusions: (memberId: string, excludedTaskLabelIds: string[]) => void;
+    isChristmasMode?: boolean;
 };
 
 export const MemberSettingsDialog: React.FC<Props> = ({
@@ -15,6 +17,7 @@ export const MemberSettingsDialog: React.FC<Props> = ({
     isOpen,
     onClose,
     onUpdateExclusions,
+    isChristmasMode = false,
 }) => {
     if (!isOpen) return null;
 
@@ -28,14 +31,28 @@ export const MemberSettingsDialog: React.FC<Props> = ({
 
     return (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 p-4">
-            <div className="bg-white rounded-xl shadow-2xl w-full max-w-md overflow-hidden">
-                <div className="bg-primary px-6 py-4 flex justify-between items-center">
-                    <h3 className="text-white font-bold text-lg">{member.name} さんの設定</h3>
-                    <button onClick={onClose} className="text-white hover:text-gray-200 text-2xl">×</button>
+            <div className={`rounded-xl shadow-2xl w-full max-w-md overflow-hidden ${
+                isChristmasMode ? 'bg-[#1a1a1a] border border-[#d4af37]/30' : 'bg-white'
+            }`}>
+                <div className={`px-6 py-4 flex justify-between items-center ${
+                    isChristmasMode ? 'bg-[#6d1a1a]' : 'bg-primary'
+                }`}>
+                    <h3 className={`font-bold text-lg ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-white'}`}>
+                        {member.name} さんの設定
+                    </h3>
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={onClose}
+                        isChristmasMode={isChristmasMode}
+                        className="!p-1 !min-h-0 !text-white hover:!text-gray-200"
+                    >
+                        ×
+                    </Button>
                 </div>
 
                 <div className="p-6">
-                    <p className="text-gray-600 mb-4 text-sm">
+                    <p className={`mb-4 text-sm ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>
                         このメンバーが担当できない（または担当させたくない）作業にチェックを入れてください。
                         次回のシャッフルから除外されます。
                     </p>
@@ -44,14 +61,26 @@ export const MemberSettingsDialog: React.FC<Props> = ({
                         {taskLabels.map(task => {
                             const isExcluded = member.excludedTaskLabelIds?.includes(task.id);
                             return (
-                                <label key={task.id} className="flex items-center p-3 rounded-lg border hover:bg-gray-50 cursor-pointer transition-colors">
+                                <label key={task.id} className={`flex items-center p-3 rounded-lg border cursor-pointer transition-colors ${
+                                    isChristmasMode
+                                        ? 'border-[#d4af37]/20 hover:bg-white/5'
+                                        : 'border-gray-200 hover:bg-gray-50'
+                                }`}>
                                     <input
                                         type="checkbox"
                                         checked={isExcluded}
                                         onChange={() => handleToggle(task.id)}
-                                        className="w-5 h-5 text-primary border-gray-300 rounded focus:ring-primary"
+                                        className={`w-5 h-5 rounded focus:ring-2 ${
+                                            isChristmasMode
+                                                ? 'text-[#d4af37] border-[#d4af37]/40 focus:ring-[#d4af37]/20 bg-white/10'
+                                                : 'text-primary border-gray-300 focus:ring-primary'
+                                        }`}
                                     />
-                                    <span className={`ml-3 font-medium ${isExcluded ? 'text-red-500' : 'text-gray-700'}`}>
+                                    <span className={`ml-3 font-medium ${
+                                        isExcluded
+                                            ? 'text-red-500'
+                                            : isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'
+                                    }`}>
                                         {task.leftLabel} {task.rightLabel || ''}
                                     </span>
                                     {isExcluded && <span className="ml-auto text-xs text-red-500 font-bold">除外中</span>}
@@ -61,13 +90,15 @@ export const MemberSettingsDialog: React.FC<Props> = ({
                     </div>
                 </div>
 
-                <div className="p-4 bg-gray-50 flex justify-end">
-                    <button
+                <div className={`p-4 flex justify-end ${isChristmasMode ? 'bg-white/5' : 'bg-gray-50'}`}>
+                    <Button
+                        variant="secondary"
+                        size="md"
                         onClick={onClose}
-                        className="px-6 py-2 bg-gray-200 text-gray-700 rounded-lg font-bold hover:bg-gray-300 transition-colors"
+                        isChristmasMode={isChristmasMode}
                     >
                         閉じる
-                    </button>
+                    </Button>
                 </div>
             </div>
         </div>

--- a/app/assignment/components/PairExclusionSettingsModal.tsx
+++ b/app/assignment/components/PairExclusionSettingsModal.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo, useEffect } from 'react';
 import { HiX, HiTrash } from 'react-icons/hi';
 import type { Member, PairExclusion } from '@/types';
+import { Button, Select } from '@/components/ui';
 
 interface PairExclusionSettingsModalProps {
     isOpen: boolean;
@@ -11,6 +12,7 @@ interface PairExclusionSettingsModalProps {
     onClose: () => void;
     onAdd: (memberId1: string, memberId2: string) => Promise<void>;
     onDelete: (exclusionId: string) => Promise<void>;
+    isChristmasMode?: boolean;
 }
 
 export function PairExclusionSettingsModal({
@@ -20,6 +22,7 @@ export function PairExclusionSettingsModal({
     onClose,
     onAdd,
     onDelete,
+    isChristmasMode = false,
 }: PairExclusionSettingsModalProps) {
     const [memberId1, setMemberId1] = useState('');
     const [memberId2, setMemberId2] = useState('');
@@ -90,96 +93,95 @@ export function PairExclusionSettingsModal({
         }
     };
 
+    // メンバーのSelectオプションを生成
+    const memberOptions = activeMembers.map(member => ({
+        value: member.id,
+        label: member.name,
+    }));
+
     return (
         <div
             className="fixed inset-0 bg-black/30 flex items-center justify-center z-50"
             onClick={onClose}
         >
             <div
-                className="bg-white rounded-lg p-6 max-w-md w-full mx-4 shadow-xl max-h-[80vh] flex flex-col"
+                className={`rounded-lg p-6 max-w-md w-full mx-4 shadow-xl max-h-[80vh] flex flex-col ${
+                    isChristmasMode ? 'bg-[#1a1a1a] border border-[#d4af37]/30' : 'bg-white'
+                }`}
                 onClick={(e) => e.stopPropagation()}
             >
                 {/* ヘッダー */}
                 <div className="flex items-center justify-between mb-4">
-                    <h2 className="text-lg font-bold text-gray-800">
+                    <h2 className={`text-lg font-bold ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
                         ペア除外設定
                     </h2>
-                    <button
+                    <Button
+                        variant="ghost"
+                        size="sm"
                         onClick={onClose}
-                        className="p-1 text-gray-500 hover:text-gray-700 rounded transition-colors"
+                        isChristmasMode={isChristmasMode}
+                        className="!p-1 !min-h-0"
                         aria-label="閉じる"
                     >
                         <HiX className="w-5 h-5" />
-                    </button>
+                    </Button>
                 </div>
 
                 {/* 説明文 */}
-                <p className="text-sm text-gray-600 mb-4">
+                <p className={`text-sm mb-4 ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>
                     シャッフル時に同じ行（タスク）に配置しないメンバーの組み合わせを設定します。
                 </p>
 
                 {/* 追加フォーム */}
-                <div className="mb-6 p-4 bg-gray-50 rounded-lg">
+                <div className={`mb-6 p-4 rounded-lg ${isChristmasMode ? 'bg-white/5' : 'bg-gray-50'}`}>
                     <div className="grid grid-cols-2 gap-3 mb-3">
-                        <div>
-                            <label className="block text-xs font-medium text-gray-700 mb-1">
-                                メンバー1
-                            </label>
-                            <select
-                                value={memberId1}
-                                onChange={(e) => setMemberId1(e.target.value)}
-                                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500 text-gray-900 text-sm"
-                                disabled={isLoading}
-                            >
-                                <option value="">選択...</option>
-                                {activeMembers.map(member => (
-                                    <option key={member.id} value={member.id}>
-                                        {member.name}
-                                    </option>
-                                ))}
-                            </select>
-                        </div>
-                        <div>
-                            <label className="block text-xs font-medium text-gray-700 mb-1">
-                                メンバー2
-                            </label>
-                            <select
-                                value={memberId2}
-                                onChange={(e) => setMemberId2(e.target.value)}
-                                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500 text-gray-900 text-sm"
-                                disabled={isLoading}
-                            >
-                                <option value="">選択...</option>
-                                {activeMembers.map(member => (
-                                    <option key={member.id} value={member.id}>
-                                        {member.name}
-                                    </option>
-                                ))}
-                            </select>
-                        </div>
+                        <Select
+                            label="メンバー1"
+                            value={memberId1}
+                            onChange={(e) => setMemberId1(e.target.value)}
+                            options={memberOptions}
+                            placeholder="選択..."
+                            disabled={isLoading}
+                            isChristmasMode={isChristmasMode}
+                            className="!text-sm !py-2"
+                        />
+                        <Select
+                            label="メンバー2"
+                            value={memberId2}
+                            onChange={(e) => setMemberId2(e.target.value)}
+                            options={memberOptions}
+                            placeholder="選択..."
+                            disabled={isLoading}
+                            isChristmasMode={isChristmasMode}
+                            className="!text-sm !py-2"
+                        />
                     </div>
 
                     {error && (
-                        <p className="text-red-600 text-sm mb-3">{error}</p>
+                        <p className={`text-sm mb-3 ${isChristmasMode ? 'text-red-400' : 'text-red-600'}`}>{error}</p>
                     )}
 
-                    <button
+                    <Button
+                        variant="primary"
+                        size="sm"
                         onClick={handleAdd}
                         disabled={isLoading || !memberId1 || !memberId2}
-                        className="w-full px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary-dark transition-colors font-medium disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+                        loading={isLoading}
+                        fullWidth
+                        isChristmasMode={isChristmasMode}
                     >
-                        {isLoading ? '追加中...' : '追加'}
-                    </button>
+                        追加
+                    </Button>
                 </div>
 
                 {/* 既存の設定リスト */}
                 <div className="flex-1 overflow-y-auto">
-                    <h3 className="text-sm font-medium text-gray-700 mb-2">
+                    <h3 className={`text-sm font-medium mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
                         設定済みのペア ({pairExclusions.length}件)
                     </h3>
 
                     {pairExclusions.length === 0 ? (
-                        <p className="text-sm text-gray-500 text-center py-4">
+                        <p className={`text-sm text-center py-4 ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'}`}>
                             設定がありません
                         </p>
                     ) : (
@@ -187,25 +189,34 @@ export function PairExclusionSettingsModal({
                             {pairExclusions.map(exclusion => (
                                 <li
                                     key={exclusion.id}
-                                    className="flex items-center justify-between p-3 bg-gray-50 rounded-lg"
+                                    className={`flex items-center justify-between p-3 rounded-lg ${
+                                        isChristmasMode ? 'bg-white/5' : 'bg-gray-50'
+                                    }`}
                                 >
                                     <div className="flex items-center gap-2 text-sm">
-                                        <span className="font-medium text-gray-800">
+                                        <span className={`font-medium ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
                                             {memberNameMap.get(exclusion.memberId1) || '(削除済み)'}
                                         </span>
-                                        <span className="text-gray-400">×</span>
-                                        <span className="font-medium text-gray-800">
+                                        <span className={isChristmasMode ? 'text-[#d4af37]/60' : 'text-gray-400'}>×</span>
+                                        <span className={`font-medium ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
                                             {memberNameMap.get(exclusion.memberId2) || '(削除済み)'}
                                         </span>
                                     </div>
-                                    <button
+                                    <Button
+                                        variant="ghost"
+                                        size="sm"
                                         onClick={() => handleDelete(exclusion.id)}
                                         disabled={isLoading}
-                                        className="p-1.5 text-red-500 hover:text-red-700 hover:bg-red-50 rounded transition-colors disabled:opacity-50"
+                                        isChristmasMode={isChristmasMode}
+                                        className={`!p-1.5 !min-h-0 ${
+                                            isChristmasMode
+                                                ? '!text-red-400 hover:!text-red-300 hover:!bg-red-500/10'
+                                                : '!text-red-500 hover:!text-red-700 hover:!bg-red-50'
+                                        }`}
                                         aria-label="削除"
                                     >
                                         <HiTrash className="w-4 h-4" />
-                                    </button>
+                                    </Button>
                                 </li>
                             ))}
                         </ul>

--- a/app/assignment/components/assignment-table/AssignmentTable.tsx
+++ b/app/assignment/components/assignment-table/AssignmentTable.tsx
@@ -29,6 +29,7 @@ export const AssignmentTable: React.FC<Props> = (props) => {
         onSwapAssignments,
         onShuffle,
         isShuffleDisabled,
+        isChristmasMode = false,
     } = props;
 
     const cellInteraction = useCellInteraction(members);
@@ -115,6 +116,7 @@ export const AssignmentTable: React.FC<Props> = (props) => {
                 handleCellClick={handleCellClick}
                 onShuffle={onShuffle}
                 isShuffleDisabled={isShuffleDisabled}
+                isChristmasMode={isChristmasMode}
             />
 
             <MobileListView
@@ -136,6 +138,7 @@ export const AssignmentTable: React.FC<Props> = (props) => {
                 handleCellTouchEnd={cellInteraction.handleCellTouchEnd}
                 handleCellTouchMove={cellInteraction.handleCellTouchMove}
                 handleCellClick={handleCellClick}
+                isChristmasMode={isChristmasMode}
             />
 
             <TableModals
@@ -173,6 +176,7 @@ export const AssignmentTable: React.FC<Props> = (props) => {
                 onDeleteMember={onDeleteMember}
                 onDeleteTaskLabel={onDeleteTaskLabel}
                 onUpdateTableSettings={onUpdateTableSettings}
+                isChristmasMode={isChristmasMode}
             />
         </div>
     );

--- a/app/assignment/components/assignment-table/DesktopTableView.tsx
+++ b/app/assignment/components/assignment-table/DesktopTableView.tsx
@@ -3,6 +3,7 @@ import { Team, TaskLabel, Assignment, Member, TableSettings } from '@/types';
 import { MdAdd } from 'react-icons/md';
 import { PiShuffleBold } from 'react-icons/pi';
 import { DEFAULT_TABLE_SETTINGS, WidthConfig, HeightConfig } from './types';
+import { Button, Input, InlineInput, IconButton } from '@/components/ui';
 
 type DesktopTableViewProps = {
     teams: Team[];
@@ -39,6 +40,7 @@ type DesktopTableViewProps = {
     handleCellClick: (teamId: string, taskLabelId: string) => void;
     onShuffle: () => Promise<void>;
     isShuffleDisabled: boolean;
+    isChristmasMode?: boolean;
 };
 
 export const DesktopTableView: React.FC<DesktopTableViewProps> = ({
@@ -72,6 +74,7 @@ export const DesktopTableView: React.FC<DesktopTableViewProps> = ({
     handleCellClick,
     onShuffle,
     isShuffleDisabled,
+    isChristmasMode = false,
 }) => {
     const headerLabels = tableSettings?.headerLabels ?? DEFAULT_TABLE_SETTINGS.headerLabels;
     const formatTeamTitle = (teamName?: string) => {
@@ -119,11 +122,14 @@ export const DesktopTableView: React.FC<DesktopTableViewProps> = ({
 
                 {/* チーム列 */}
                 {teams.length === 0 ? (
-                    <div className="py-2 px-2 border-r border-gray-700 text-center bg-dark flex flex-col items-center justify-center h-full min-h-[44px]">
+                    <div className={`py-2 px-2 border-r text-center flex flex-col items-center justify-center h-full min-h-[44px] ${
+                        isChristmasMode ? 'bg-[#1a1a1a] border-[#d4af37]/30' : 'bg-dark border-gray-700'
+                    }`}>
                         {isAddingTeam ? (
-                            <div className="relative z-20 flex items-center bg-white shadow-lg rounded border border-primary p-1 w-32 md:w-40">
-                                <input
-                                    className="w-full px-1 md:p-2 md:text-base text-sm outline-none text-gray-900"
+                            <div className={`relative z-20 flex items-center shadow-lg rounded p-1 w-32 md:w-40 ${
+                                isChristmasMode ? 'bg-[#1a1a1a] border border-[#d4af37]' : 'bg-white border border-primary'
+                            }`}>
+                                <InlineInput
                                     placeholder="班名(任意)"
                                     value={newTeamName}
                                     onChange={e => setNewTeamName(e.target.value)}
@@ -132,38 +138,57 @@ export const DesktopTableView: React.FC<DesktopTableViewProps> = ({
                                         if (e.key === 'Enter') handleAddTeam();
                                         if (e.key === 'Escape') setIsAddingTeam(false);
                                     }}
+                                    variant="dark"
+                                    isChristmasMode={isChristmasMode}
+                                    className="!border-none !px-1 md:!p-2 md:!text-base !text-sm"
                                 />
-                                <button onClick={handleAddTeam} className="text-primary hover:bg-primary/10 rounded p-1 md:p-2">
+                                <IconButton
+                                    variant="primary"
+                                    size="sm"
+                                    onClick={handleAddTeam}
+                                    isChristmasMode={isChristmasMode}
+                                >
                                     <MdAdd size={20} className="md:w-6 md:h-6" />
-                                </button>
+                                </IconButton>
                             </div>
                         ) : (
-                            <button
+                            <Button
+                                variant="outline"
+                                size="sm"
                                 onClick={() => setIsAddingTeam(true)}
-                                className="text-primary text-sm md:text-base font-bold flex items-center gap-1 hover:underline py-1 px-3 rounded hover:bg-white/10 border border-primary/20 bg-transparent shadow-sm"
+                                isChristmasMode={isChristmasMode}
+                                className="!text-sm md:!text-base !gap-1 !bg-transparent"
                             >
                                 <MdAdd className="md:w-5 md:h-5" /> 最初の班を追加
-                            </button>
+                            </Button>
                         )}
                     </div>
                 ) : (
                     teams.map(team => (
                         <div
                             key={team.id}
-                            className="py-2 px-2 border-r border-gray-700 text-center relative group bg-dark flex items-center justify-center"
+                            className={`py-2 px-2 border-r text-center relative group flex items-center justify-center ${
+                                isChristmasMode ? 'bg-[#1a1a1a] border-[#d4af37]/30' : 'bg-dark border-gray-700'
+                            }`}
                         >
                             {editingTeamId === team.id ? (
-                                <input
-                                    className="w-full px-1 py-1 text-center border rounded bg-white text-gray-900 text-sm md:text-base"
+                                <InlineInput
                                     value={editTeamName}
                                     onChange={e => setEditTeamName(e.target.value)}
                                     autoFocus
                                     onKeyDown={e => e.key === 'Enter' && handleUpdateTeam(team.id)}
                                     onBlur={() => handleUpdateTeam(team.id)}
+                                    variant="light"
+                                    isChristmasMode={isChristmasMode}
+                                    className="!text-sm md:!text-base"
                                 />
                             ) : (
                                 <div
-                                    className="cursor-pointer hover:bg-gray-800 rounded px-2 py-1 truncate w-full select-none active:bg-gray-700"
+                                    className={`cursor-pointer rounded px-2 py-1 truncate w-full select-none ${
+                                        isChristmasMode
+                                            ? 'text-[#f8f1e7] hover:bg-white/10 active:bg-white/20'
+                                            : 'hover:bg-gray-800 active:bg-gray-700'
+                                    }`}
                                     onClick={() => {
                                         setActiveTeamActionId(team.id);
                                         setActiveTeamName(team.name);
@@ -178,7 +203,11 @@ export const DesktopTableView: React.FC<DesktopTableViewProps> = ({
 
                 {/* チーム追加 & 補足ヘッダー */}
                 <div
-                    className="py-2 px-2 sm:px-3 text-center flex items-center justify-between bg-dark relative cursor-pointer hover:bg-gray-800 transition-colors"
+                    className={`py-2 px-2 sm:px-3 text-center flex items-center justify-between relative cursor-pointer transition-colors ${
+                        isChristmasMode
+                            ? 'bg-[#1a1a1a] hover:bg-white/10'
+                            : 'bg-dark hover:bg-gray-800'
+                    }`}
                     onClick={(e) => {
                         if ((e.target as HTMLElement).closest('button, input')) return;
                         setWidthConfig({
@@ -201,9 +230,10 @@ export const DesktopTableView: React.FC<DesktopTableViewProps> = ({
                                             setIsAddingTeam(false);
                                         }}
                                     />
-                                    <div className="absolute top-1/2 -translate-y-1/2 right-0 z-20 flex items-center bg-white shadow-lg rounded border border-primary p-1 w-32 md:w-40">
-                                        <input
-                                            className="w-full px-1 md:p-2 text-sm md:text-base outline-none text-gray-900"
+                                    <div className={`absolute top-1/2 -translate-y-1/2 right-0 z-20 flex items-center shadow-lg rounded p-1 w-32 md:w-40 ${
+                                        isChristmasMode ? 'bg-[#1a1a1a] border border-[#d4af37]' : 'bg-white border border-primary'
+                                    }`}>
+                                        <InlineInput
                                             placeholder="班名(任意)"
                                             value={newTeamName}
                                             onChange={e => setNewTeamName(e.target.value)}
@@ -212,24 +242,36 @@ export const DesktopTableView: React.FC<DesktopTableViewProps> = ({
                                                 if (e.key === 'Enter') handleAddTeam();
                                                 if (e.key === 'Escape') setIsAddingTeam(false);
                                             }}
+                                            variant="dark"
+                                            isChristmasMode={isChristmasMode}
+                                            className="!border-none !px-1 md:!p-2 !text-sm md:!text-base"
                                         />
-                                        <button onClick={handleAddTeam} className="text-primary hover:bg-primary/10 rounded p-1 md:p-2">
+                                        <IconButton
+                                            variant="primary"
+                                            size="sm"
+                                            onClick={handleAddTeam}
+                                            isChristmasMode={isChristmasMode}
+                                        >
                                             <MdAdd size={20} className="md:w-6 md:h-6" />
-                                        </button>
+                                        </IconButton>
                                     </div>
                                 </>
                             ) : (
-                                <button
+                                <IconButton
+                                    variant={isChristmasMode ? 'primary' : 'ghost'}
+                                    size="sm"
+                                    rounded
                                     onClick={() => setIsAddingTeam(true)}
-                                    className="p-1 rounded-full bg-gray-700 text-gray-300 hover:bg-primary hover:text-white transition-colors shadow-sm"
+                                    isChristmasMode={isChristmasMode}
+                                    className={isChristmasMode ? '!bg-[#d4af37]/20' : '!bg-gray-700 !text-gray-300 hover:!bg-primary hover:!text-white'}
                                     title="班を追加"
                                 >
                                     <MdAdd size={16} className="md:w-5 md:h-5" />
-                                </button>
+                                </IconButton>
                             )
                         )}
                     </div>
-                    <span>{headerLabels.right}</span>
+                    <span className={isChristmasMode ? 'text-[#f8f1e7]' : ''}>{headerLabels.right}</span>
                     <span className="w-4"></span>
                 </div>
             </div>
@@ -331,46 +373,52 @@ export const DesktopTableView: React.FC<DesktopTableViewProps> = ({
                     style={{ gridTemplateColumns }}
                 >
                     <div className="pr-2">
-                        <input
-                            className="w-full p-2 border border-gray-300 rounded shadow-sm focus:ring-primary focus:border-primary text-sm text-gray-800 placeholder-gray-500"
-                            placeholder=""
+                        <Input
                             value={newLeftLabel}
                             onChange={e => setNewLeftLabel(e.target.value)}
                             onKeyDown={e => {
                                 if (e.key === 'Enter') handleAddTaskLabel();
                             }}
+                            isChristmasMode={isChristmasMode}
+                            className="!p-2 !text-sm !min-h-0"
                         />
                     </div>
 
                     {/* シャッフルボタン（中央配置） */}
                     <div className="col-span-full px-2 flex items-center justify-center" style={{ gridColumn: `2 / span ${Math.max(1, teams.length)}` }}>
-                        <button
+                        <Button
+                            variant="primary"
+                            size="sm"
                             onClick={onShuffle}
                             disabled={isShuffleDisabled}
-                            className="bg-primary text-white px-4 py-2 rounded-full hover:bg-primary-dark shadow-md disabled:opacity-50 disabled:cursor-not-allowed transition-all active:scale-95 flex items-center gap-2"
+                            isChristmasMode={isChristmasMode}
+                            className="!rounded-full !px-4 shadow-md active:scale-95"
                         >
                             <PiShuffleBold className="w-5 h-5" />
                             <span className="font-medium text-sm">シャッフル</span>
-                        </button>
+                        </Button>
                     </div>
 
                     <div className="pl-2 flex gap-2 w-full h-full" style={{ gridColumn: '-2 / -1' }}>
-                        <input
-                            className="w-full min-w-0 p-2 border border-gray-300 rounded shadow-sm focus:ring-primary focus:border-primary text-right text-sm text-gray-800 placeholder-gray-500"
-                            placeholder=""
+                        <Input
                             value={newRightLabel}
                             onChange={e => setNewRightLabel(e.target.value)}
                             onKeyDown={e => {
                                 if (e.key === 'Enter') handleAddTaskLabel();
                             }}
+                            isChristmasMode={isChristmasMode}
+                            className="!min-w-0 !p-2 !text-right !text-sm !min-h-0"
                         />
-                        <button
+                        <Button
+                            variant="primary"
+                            size="sm"
                             onClick={handleAddTaskLabel}
                             disabled={!newLeftLabel.trim()}
-                            className="bg-primary text-white px-2 py-1 rounded hover:bg-primary-dark shadow-sm disabled:opacity-50 disabled:shadow-none transition-all flex-shrink-0 flex items-center justify-center h-full max-h-[38px]"
+                            isChristmasMode={isChristmasMode}
+                            className="!px-2 !py-1 !min-h-0 !h-full max-h-[38px] flex-shrink-0"
                         >
                             <MdAdd size={20} />
-                        </button>
+                        </Button>
                     </div>
                 </div>
             </div>

--- a/app/assignment/components/assignment-table/MobileListView.tsx
+++ b/app/assignment/components/assignment-table/MobileListView.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Team, TaskLabel, Assignment, Member, TableSettings } from '@/types';
 import { MdDelete, MdCheck } from 'react-icons/md';
 import { DEFAULT_TABLE_SETTINGS } from './types';
+import { Button, Input } from '@/components/ui';
 
 type MobileListViewProps = {
     teams: Team[];
@@ -22,6 +23,7 @@ type MobileListViewProps = {
     handleCellTouchEnd: () => void;
     handleCellTouchMove: (e: React.TouchEvent | React.MouseEvent) => void;
     handleCellClick: (teamId: string, taskLabelId: string) => void;
+    isChristmasMode?: boolean;
 };
 
 export const MobileListView: React.FC<MobileListViewProps> = ({
@@ -43,6 +45,7 @@ export const MobileListView: React.FC<MobileListViewProps> = ({
     handleCellTouchEnd,
     handleCellTouchMove,
     handleCellClick,
+    isChristmasMode = false,
 }) => {
     const headerLabels = tableSettings?.headerLabels ?? DEFAULT_TABLE_SETTINGS.headerLabels;
     const formatTeamTitle = (teamName?: string) => {
@@ -55,49 +58,71 @@ export const MobileListView: React.FC<MobileListViewProps> = ({
                 const isEditing = editingLabelId === label.id;
 
                 return (
-                    <div key={label.id} className="bg-white rounded-xl shadow-sm border border-gray-100 p-4 flex flex-col gap-3">
+                    <div key={label.id} className={`rounded-xl shadow-sm p-4 flex flex-col gap-3 ${
+                        isChristmasMode
+                            ? 'bg-[#1a1a1a] border border-[#d4af37]/30'
+                            : 'bg-white border border-gray-100'
+                    }`}>
                         {/* Header: Label Names */}
-                        <div className="flex justify-between items-start border-b border-gray-50 pb-2 min-h-[40px]">
+                        <div className={`flex justify-between items-start pb-2 min-h-[40px] ${
+                            isChristmasMode ? 'border-b border-[#d4af37]/20' : 'border-b border-gray-50'
+                        }`}>
                             {isEditing ? (
                                 <div className="flex flex-col gap-2 w-full">
-                                    <input
-                                        className="w-full p-2 border rounded bg-white text-lg font-bold text-gray-800"
+                                    <Input
                                         value={editLeftLabel}
                                         onChange={e => setEditLeftLabel(e.target.value)}
                                         placeholder={headerLabels.left}
+                                        isChristmasMode={isChristmasMode}
+                                        className="!p-2 !text-lg !font-bold !min-h-0"
                                     />
                                     <div className="flex gap-2">
-                                        <input
-                                            className="flex-1 p-2 border rounded bg-white text-sm text-gray-600"
+                                        <Input
                                             value={editRightLabel}
                                             onChange={e => setEditRightLabel(e.target.value)}
                                             placeholder={headerLabels.right}
+                                            isChristmasMode={isChristmasMode}
+                                            className="flex-1 !p-2 !text-sm !min-h-0"
                                         />
-                                        <button
+                                        <Button
+                                            variant="success"
+                                            size="sm"
                                             onClick={() => saveLabel(label.id)}
-                                            className="bg-green-500 text-white p-2 rounded hover:bg-green-600 shrink-0"
+                                            isChristmasMode={isChristmasMode}
+                                            className="!p-2 !min-h-0 shrink-0"
                                         >
                                             <MdCheck size={20} />
-                                        </button>
-                                        <button
+                                        </Button>
+                                        <Button
+                                            variant="danger"
+                                            size="sm"
                                             onClick={() => handleDeleteTaskLabel(label.id)}
-                                            className="bg-red-50 text-red-500 p-2 rounded hover:bg-red-100 border border-red-200 shrink-0"
+                                            isChristmasMode={isChristmasMode}
+                                            className="!p-2 !min-h-0 shrink-0"
                                         >
                                             <MdDelete size={20} />
-                                        </button>
+                                        </Button>
                                     </div>
                                 </div>
                             ) : (
                                 <div className="flex items-center gap-2 w-full flex-wrap">
                                     <div
-                                        className="text-sm text-gray-700 bg-gray-50 px-2 py-1 rounded border border-gray-100 cursor-pointer font-bold"
+                                        className={`text-sm px-2 py-1 rounded cursor-pointer font-bold ${
+                                            isChristmasMode
+                                                ? 'text-[#f8f1e7] bg-white/10 border border-[#d4af37]/20'
+                                                : 'text-gray-700 bg-gray-50 border border-gray-100'
+                                        }`}
                                         onClick={() => startEditLabel(label)}
                                     >
                                         {label.leftLabel}
                                     </div>
                                     {label.rightLabel && (
                                         <div
-                                            className="text-sm text-gray-700 bg-gray-50 px-2 py-1 rounded border border-gray-100 cursor-pointer font-bold"
+                                            className={`text-sm px-2 py-1 rounded cursor-pointer font-bold ${
+                                                isChristmasMode
+                                                    ? 'text-[#f8f1e7] bg-white/10 border border-[#d4af37]/20'
+                                                    : 'text-gray-700 bg-gray-50 border border-gray-100'
+                                            }`}
                                             onClick={() => startEditLabel(label)}
                                         >
                                             {label.rightLabel}

--- a/app/assignment/components/assignment-table/TableModals.tsx
+++ b/app/assignment/components/assignment-table/TableModals.tsx
@@ -3,6 +3,7 @@ import { Team, TaskLabel, Assignment, Member, TableSettings } from '@/types';
 import { motion, AnimatePresence } from 'framer-motion';
 import { MdAdd, MdDelete, MdPersonOff, MdBlock, MdPerson, MdClose, MdCheck, MdKeyboardArrowRight, MdKeyboardArrowDown } from 'react-icons/md';
 import { DEFAULT_TABLE_SETTINGS, WidthConfig, HeightConfig } from './types';
+import { Button, Input, IconButton, NumberInput } from '@/components/ui';
 
 type TableModalsProps = {
     teams: Team[];
@@ -45,6 +46,7 @@ type TableModalsProps = {
     onDeleteMember: (memberId: string) => Promise<void>;
     onDeleteTaskLabel: (taskLabelId: string) => Promise<void>;
     onUpdateTableSettings: (settings: TableSettings) => Promise<void>;
+    isChristmasMode?: boolean;
 };
 
 export const TableModals: React.FC<TableModalsProps> = ({
@@ -82,6 +84,7 @@ export const TableModals: React.FC<TableModalsProps> = ({
     onDeleteMember,
     onDeleteTaskLabel,
     onUpdateTableSettings,
+    isChristmasMode = false,
 }) => {
     const headerLabels = tableSettings?.headerLabels ?? DEFAULT_TABLE_SETTINGS.headerLabels;
     const formatTeamTitle = (teamName?: string) => {
@@ -105,10 +108,14 @@ export const TableModals: React.FC<TableModalsProps> = ({
                             initial={{ opacity: 0, scale: 0.95, y: 20 }}
                             animate={{ opacity: 1, scale: 1, y: 0 }}
                             exit={{ opacity: 0, scale: 0.95, y: 20 }}
-                            className="bg-white rounded-xl shadow-xl w-full max-w-sm relative z-10 overflow-hidden"
+                            className={`rounded-xl shadow-xl w-full max-w-sm relative z-10 overflow-hidden ${
+                                isChristmasMode ? 'bg-[#1a1a1a] border border-[#d4af37]/30' : 'bg-white'
+                            }`}
                         >
-                            <div className="bg-gray-50 px-4 py-3 border-b border-gray-100 flex items-center justify-between">
-                                <h3 className="font-bold text-gray-800">
+                            <div className={`px-4 py-3 flex items-center justify-between ${
+                                isChristmasMode ? 'bg-white/5 border-b border-[#d4af37]/20' : 'bg-gray-50 border-b border-gray-100'
+                            }`}>
+                                <h3 className={`font-bold ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
                                     {(() => {
                                         const team = teams.find(t => t.id === contextMenu.teamId);
                                         const title = formatTeamTitle(team?.name);
@@ -116,78 +123,108 @@ export const TableModals: React.FC<TableModalsProps> = ({
                                         return title ? `${title} - ${label}` : label;
                                     })()}
                                 </h3>
-                                <button onClick={() => setContextMenu(null)} className="text-gray-400 hover:text-gray-600">
+                                <IconButton
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={() => setContextMenu(null)}
+                                    isChristmasMode={isChristmasMode}
+                                >
                                     <MdClose size={20} />
-                                </button>
+                                </IconButton>
                             </div>
 
                             <div className="p-4 space-y-4">
                                 {contextMenu.memberId ? (
                                     <div className="space-y-2">
-                                        <label className="text-xs font-bold text-gray-500">メンバー名</label>
+                                        <label className={`text-xs font-bold ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500'}`}>
+                                            メンバー名
+                                        </label>
                                         <div className="flex gap-2">
-                                            <input
-                                                className="flex-1 border border-gray-300 rounded px-3 py-2 focus:border-primary focus:ring-1 focus:ring-primary outline-none text-gray-900"
+                                            <Input
                                                 value={editingMemberName}
                                                 onChange={(e) => setEditingMemberName(e.target.value)}
+                                                isChristmasMode={isChristmasMode}
+                                                className="flex-1 !py-2"
                                             />
-                                            <button
+                                            <Button
+                                                variant="primary"
+                                                size="sm"
                                                 onClick={async () => {
                                                     if (contextMenu.memberId && editingMemberName.trim()) {
                                                         await onUpdateMemberName(contextMenu.memberId, editingMemberName);
                                                         setContextMenu(null);
                                                     }
                                                 }}
-                                                className="bg-primary text-white px-3 py-2 rounded hover:bg-primary-dark flex items-center justify-center"
                                                 disabled={!editingMemberName.trim()}
+                                                isChristmasMode={isChristmasMode}
+                                                className="!px-3"
                                             >
                                                 <MdCheck size={20} />
-                                            </button>
+                                            </Button>
                                         </div>
                                     </div>
                                 ) : (
-                                    <div className="text-center py-2 text-gray-500">
+                                    <div className={`text-center py-2 ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'}`}>
                                         メンバーが割り当てられていません
                                     </div>
                                 )}
 
-                                <div className="border-t border-gray-100 pt-4 grid gap-2">
-                                    <button
+                                <div className={`pt-4 grid gap-2 ${isChristmasMode ? 'border-t border-[#d4af37]/20' : 'border-t border-gray-100'}`}>
+                                    <Button
+                                        variant="ghost"
+                                        size="md"
                                         onClick={() => {
                                             setShowMemberMenu({ taskLabelId: contextMenu.taskLabelId, teamId: contextMenu.teamId });
                                             setContextMenu(null);
                                         }}
-                                        className="flex items-center gap-3 p-3 rounded-lg bg-gray-50 text-gray-700 hover:bg-gray-100 transition-colors text-left"
+                                        isChristmasMode={isChristmasMode}
+                                        className={`!justify-start !gap-3 !p-3 ${
+                                            isChristmasMode ? '!bg-white/5 hover:!bg-white/10' : '!bg-gray-50 hover:!bg-gray-100'
+                                        }`}
                                     >
                                         <MdPerson size={20} />
-                                        <div className="text-sm font-bold">メンバーを変更・追加</div>
-                                    </button>
+                                        <span className="text-sm font-bold">メンバーを変更・追加</span>
+                                    </Button>
 
                                     {contextMenu.memberId && (
-                                        <button
+                                        <Button
+                                            variant="ghost"
+                                            size="md"
                                             onClick={async () => {
                                                 await onUpdateMember({ teamId: contextMenu.teamId, taskLabelId: contextMenu.taskLabelId, memberId: null, assignedDate: '' }, null);
                                                 setContextMenu(null);
                                             }}
-                                            className="flex items-center gap-3 p-3 rounded-lg bg-gray-50 text-red-600 hover:bg-red-50 transition-colors text-left"
+                                            isChristmasMode={isChristmasMode}
+                                            className={`!justify-start !gap-3 !p-3 ${
+                                                isChristmasMode
+                                                    ? '!bg-white/5 hover:!bg-red-500/10 !text-red-400'
+                                                    : '!bg-gray-50 hover:!bg-red-50 !text-red-600'
+                                            }`}
                                         >
                                             <MdPersonOff size={20} />
-                                            <div className="text-sm font-bold">未割り当てにする</div>
-                                        </button>
+                                            <span className="text-sm font-bold">未割り当てにする</span>
+                                        </Button>
                                     )}
 
                                     {contextMenu.memberId && (
-                                        <div className="border border-gray-200 rounded-lg overflow-hidden mt-2">
-                                            <button
+                                        <div className={`rounded-lg overflow-hidden mt-2 ${
+                                            isChristmasMode ? 'border border-[#d4af37]/20' : 'border border-gray-200'
+                                        }`}>
+                                            <Button
+                                                variant="ghost"
+                                                size="md"
                                                 onClick={() => setIsExclusionSettingsOpen(!isExclusionSettingsOpen)}
-                                                className="w-full flex items-center justify-between gap-3 p-3 bg-gray-50 text-gray-700 hover:bg-gray-100 transition-colors text-left"
+                                                isChristmasMode={isChristmasMode}
+                                                className={`!w-full !justify-between !gap-3 !p-3 !rounded-none ${
+                                                    isChristmasMode ? '!bg-white/5 hover:!bg-white/10' : '!bg-gray-50 hover:!bg-gray-100'
+                                                }`}
                                             >
                                                 <div className="flex items-center gap-3">
-                                                    <MdBlock size={20} className="text-gray-500" />
-                                                    <div className="text-sm font-bold">除外ラベル設定</div>
+                                                    <MdBlock size={20} className={isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'} />
+                                                    <span className="text-sm font-bold">除外ラベル設定</span>
                                                 </div>
                                                 {isExclusionSettingsOpen ? <MdKeyboardArrowDown size={20} /> : <MdKeyboardArrowRight size={20} />}
-                                            </button>
+                                            </Button>
 
                                             <AnimatePresence>
                                                 {isExclusionSettingsOpen && (
@@ -195,10 +232,10 @@ export const TableModals: React.FC<TableModalsProps> = ({
                                                         initial={{ height: 0, opacity: 0 }}
                                                         animate={{ height: 'auto', opacity: 1 }}
                                                         exit={{ height: 0, opacity: 0 }}
-                                                        className="overflow-hidden bg-white"
+                                                        className={`overflow-hidden ${isChristmasMode ? 'bg-[#1a1a1a]' : 'bg-white'}`}
                                                     >
-                                                        <div className="p-2 border-t border-gray-200">
-                                                            <div className="text-xs text-gray-500 mb-2 px-1">
+                                                        <div className={`p-2 ${isChristmasMode ? 'border-t border-[#d4af37]/20' : 'border-t border-gray-200'}`}>
+                                                            <div className={`text-xs mb-2 px-1 ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'}`}>
                                                                 チェックした作業には割り当てられません
                                                             </div>
                                                             <div className="max-h-40 overflow-y-auto space-y-1">
@@ -211,7 +248,10 @@ export const TableModals: React.FC<TableModalsProps> = ({
                                                                             key={label.id}
                                                                             className={`
                                                                                 flex items-center gap-3 p-2 rounded cursor-pointer transition-colors
-                                                                                ${isExcluded ? 'bg-red-50' : 'hover:bg-gray-50'}
+                                                                                ${isExcluded
+                                                                                    ? isChristmasMode ? 'bg-red-500/10' : 'bg-red-50'
+                                                                                    : isChristmasMode ? 'hover:bg-white/5' : 'hover:bg-gray-50'
+                                                                                }
                                                                             `}
                                                                         >
                                                                             <div className="relative flex items-center justify-center w-5 h-5">
@@ -223,18 +263,30 @@ export const TableModals: React.FC<TableModalsProps> = ({
                                                                                             await onUpdateMemberExclusion(contextMenu.memberId, label.id, e.target.checked);
                                                                                         }
                                                                                     }}
-                                                                                    className="appearance-none w-5 h-5 border border-gray-300 rounded checked:bg-red-500 checked:border-red-500 focus:ring-2 focus:ring-red-200 transition-colors cursor-pointer"
+                                                                                    className={`appearance-none w-5 h-5 border rounded checked:bg-red-500 checked:border-red-500 transition-colors cursor-pointer ${
+                                                                                        isChristmasMode
+                                                                                            ? 'border-[#d4af37]/40 focus:ring-2 focus:ring-red-400/20'
+                                                                                            : 'border-gray-300 focus:ring-2 focus:ring-red-200'
+                                                                                    }`}
                                                                                 />
                                                                                 {isExcluded && (
                                                                                     <MdClose className="absolute text-white pointer-events-none" size={14} />
                                                                                 )}
                                                                             </div>
                                                                             <div className="text-sm flex-1 truncate">
-                                                                                <span className={isExcluded ? 'text-red-700 font-medium' : 'text-gray-700'}>
+                                                                                <span className={
+                                                                                    isExcluded
+                                                                                        ? isChristmasMode ? 'text-red-400 font-medium' : 'text-red-700 font-medium'
+                                                                                        : isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'
+                                                                                }>
                                                                                     {label.leftLabel}
                                                                                 </span>
                                                                                 {label.rightLabel && (
-                                                                                    <span className={`ml-1 text-xs ${isExcluded ? 'text-red-500' : 'text-gray-400'}`}>
+                                                                                    <span className={`ml-1 text-xs ${
+                                                                                        isExcluded
+                                                                                            ? isChristmasMode ? 'text-red-400/70' : 'text-red-500'
+                                                                                            : isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-400'
+                                                                                    }`}>
                                                                                         ({label.rightLabel})
                                                                                     </span>
                                                                                 )}
@@ -271,10 +323,12 @@ export const TableModals: React.FC<TableModalsProps> = ({
                             initial={{ opacity: 0, scale: 0.95 }}
                             animate={{ opacity: 1, scale: 1 }}
                             exit={{ opacity: 0, scale: 0.95 }}
-                            className="bg-white rounded-lg shadow-xl p-4 w-full max-w-sm relative z-10"
+                            className={`rounded-lg shadow-xl p-4 w-full max-w-sm relative z-10 ${
+                                isChristmasMode ? 'bg-[#1a1a1a] border border-[#d4af37]/30' : 'bg-white'
+                            }`}
                         >
                             <div className="flex justify-between items-center mb-4">
-                                <div className="text-sm text-gray-500 font-bold">
+                                <div className={`text-sm font-bold ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500'}`}>
                                     {(() => {
                                         const team = teams.find(t => t.id === showMemberMenu.teamId);
                                         const title = formatTeamTitle(team?.name);
@@ -282,24 +336,35 @@ export const TableModals: React.FC<TableModalsProps> = ({
                                         return title ? `${title} - ${label}` : label;
                                     })()}
                                 </div>
-                                <button onClick={() => setShowMemberMenu(null)}><MdClose /></button>
+                                <IconButton
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={() => setShowMemberMenu(null)}
+                                    isChristmasMode={isChristmasMode}
+                                >
+                                    <MdClose />
+                                </IconButton>
                             </div>
 
                             {/* 新規追加 */}
-                            <div className="flex gap-2 mb-4 pb-4 border-b border-gray-100">
-                                <input
-                                    className="flex-1 border rounded px-3 py-2 text-sm text-gray-900"
+                            <div className={`flex gap-2 mb-4 pb-4 ${isChristmasMode ? 'border-b border-[#d4af37]/20' : 'border-b border-gray-100'}`}>
+                                <Input
                                     placeholder="新規メンバー名"
                                     value={newMemberName}
                                     onChange={e => setNewMemberName(e.target.value)}
+                                    isChristmasMode={isChristmasMode}
+                                    className="flex-1 !py-2 !text-sm"
                                 />
-                                <button
+                                <Button
+                                    variant="primary"
+                                    size="sm"
                                     onClick={() => handleAddMember(showMemberMenu.taskLabelId, showMemberMenu.teamId)}
                                     disabled={!newMemberName.trim()}
-                                    className="bg-primary text-white px-3 py-2 rounded hover:bg-primary-dark disabled:opacity-50"
+                                    isChristmasMode={isChristmasMode}
+                                    className="!px-3"
                                 >
                                     <MdAdd size={20} />
-                                </button>
+                                </Button>
                             </div>
 
                             <div className="max-h-60 overflow-y-auto space-y-2">
@@ -309,27 +374,34 @@ export const TableModals: React.FC<TableModalsProps> = ({
 
                                     return (
                                         <div key={m.id} className="flex items-center gap-2">
-                                            <button
+                                            <Button
+                                                variant="ghost"
+                                                size="sm"
                                                 onClick={() => {
                                                     onUpdateMember({ teamId: showMemberMenu.teamId, taskLabelId: showMemberMenu.taskLabelId, memberId: null, assignedDate: '' }, m.id);
                                                     setShowMemberMenu(null);
                                                 }}
-                                                className="flex-1 text-left px-3 py-2 hover:bg-gray-100 rounded text-gray-700"
+                                                isChristmasMode={isChristmasMode}
+                                                className={`flex-1 !justify-start !text-left ${
+                                                    isChristmasMode ? 'hover:!bg-white/10' : 'hover:!bg-gray-100'
+                                                }`}
                                             >
                                                 {m.name}
-                                            </button>
-                                            <button
+                                            </Button>
+                                            <IconButton
+                                                variant="danger"
+                                                size="sm"
                                                 onClick={async (e) => {
                                                     e.stopPropagation();
                                                     if (confirm(`${m.name}を削除しますか？\n割り当てからも解除されます。`)) {
                                                         await onDeleteMember(m.id);
                                                     }
                                                 }}
-                                                className="p-2 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded"
+                                                isChristmasMode={isChristmasMode}
                                                 title="メンバーを削除"
                                             >
                                                 <MdDelete size={20} />
-                                            </button>
+                                            </IconButton>
                                         </div>
                                     );
                                 })}
@@ -354,24 +426,27 @@ export const TableModals: React.FC<TableModalsProps> = ({
                             initial={{ opacity: 0, scale: 0.95 }}
                             animate={{ opacity: 1, scale: 1 }}
                             exit={{ opacity: 0, scale: 0.95 }}
-                            className="bg-white rounded-xl shadow-xl p-6 w-full max-w-sm relative z-10"
+                            className={`rounded-xl shadow-xl p-6 w-full max-w-sm relative z-10 ${
+                                isChristmasMode ? 'bg-[#1a1a1a] border border-[#d4af37]/30' : 'bg-white'
+                            }`}
                         >
-                            <h3 className="text-lg font-bold text-gray-800 mb-4">班の編集</h3>
+                            <h3 className={`text-lg font-bold mb-4 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
+                                班の編集
+                            </h3>
 
                             <div className="mb-6">
-                                <label className="block text-sm text-gray-500 mb-1">班名</label>
-                                <input
-                                    className="w-full p-2 border border-gray-300 rounded text-lg text-gray-800"
+                                <Input
+                                    label="班名"
                                     value={activeTeamName}
                                     onChange={e => setActiveTeamName(e.target.value)}
+                                    isChristmasMode={isChristmasMode}
                                 />
                             </div>
 
                             <div className="mb-6">
-                                <label className="block text-sm text-gray-500 mb-1">幅(px)</label>
-                                <input
-                                    type="number"
-                                    className="w-full p-2 border border-gray-300 rounded text-lg text-gray-800"
+                                <NumberInput
+                                    label="幅"
+                                    suffix="px"
                                     value={tableSettings?.colWidths?.teams?.[activeTeamActionId] ?? 100}
                                     onChange={async (e) => {
                                         if (!activeTeamActionId || !tableSettings) return;
@@ -381,29 +456,42 @@ export const TableModals: React.FC<TableModalsProps> = ({
                                         newSettings.colWidths.teams[activeTeamActionId] = val;
                                         await onUpdateTableSettings(newSettings);
                                     }}
+                                    isChristmasMode={isChristmasMode}
                                 />
                             </div>
 
                             <div className="space-y-3">
-                                <button
+                                <Button
+                                    variant="primary"
+                                    size="md"
+                                    fullWidth
                                     onClick={handleUpdateTeamFromModal}
-                                    className="w-full py-3 bg-primary text-white rounded-lg font-bold hover:bg-primary-dark"
+                                    isChristmasMode={isChristmasMode}
                                 >
                                     更新する
-                                </button>
-                                <button
+                                </Button>
+                                <Button
+                                    variant="danger"
+                                    size="md"
+                                    fullWidth
                                     onClick={handleDeleteTeamFromModal}
-                                    className="w-full py-3 bg-gray-100 text-red-500 rounded-lg font-bold hover:bg-red-50 flex items-center justify-center gap-2"
+                                    isChristmasMode={isChristmasMode}
+                                    className={`!flex !items-center !justify-center !gap-2 ${
+                                        isChristmasMode ? '!bg-red-500/10 !text-red-400 hover:!bg-red-500/20' : '!bg-gray-100 hover:!bg-red-50'
+                                    }`}
                                 >
                                     <MdDelete size={20} />
                                     この班を削除
-                                </button>
-                                <button
+                                </Button>
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    fullWidth
                                     onClick={() => setActiveTeamActionId(null)}
-                                    className="w-full py-2 text-gray-500 hover:bg-gray-50 rounded-lg"
+                                    isChristmasMode={isChristmasMode}
                                 >
                                     キャンセル
-                                </button>
+                                </Button>
                             </div>
                         </motion.div>
                     </div>
@@ -421,37 +509,54 @@ export const TableModals: React.FC<TableModalsProps> = ({
                         />
                         <motion.div
                             initial={{ opacity: 0, scale: 0.95 }} animate={{ opacity: 1, scale: 1 }} exit={{ opacity: 0, scale: 0.95 }}
-                            className="bg-white rounded-xl shadow-xl p-6 w-full max-w-xs relative z-10"
+                            className={`rounded-xl shadow-xl p-6 w-full max-w-xs relative z-10 ${
+                                isChristmasMode ? 'bg-[#1a1a1a] border border-[#d4af37]/30' : 'bg-white'
+                            }`}
                         >
-                            <h3 className="text-lg font-bold text-gray-800 mb-4">{widthConfig.label}</h3>
+                            <h3 className={`text-lg font-bold mb-4 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
+                                {widthConfig.label}
+                            </h3>
                             {(widthConfig.type === 'taskLabel' || widthConfig.type === 'note') && (
                                 <div className="mb-4">
-                                    <label className="block text-sm text-gray-600 mb-1">
-                                        列の表示名
-                                    </label>
-                                    <input
-                                        className="w-full p-2 border border-gray-300 rounded text-base text-gray-900"
+                                    <Input
+                                        label="列の表示名"
                                         value={widthConfig.currentTitle ?? ''}
                                         onChange={e => setWidthConfig({ ...widthConfig, currentTitle: e.target.value })}
                                         placeholder={`${widthConfig.type === 'taskLabel' ? '左' : '右'}ラベル名`}
                                         onKeyDown={e => e.key === 'Enter' && handleSaveWidth(widthConfig.currentWidth, widthConfig.currentTitle)}
+                                        isChristmasMode={isChristmasMode}
                                     />
                                 </div>
                             )}
-                            <div className="flex items-center gap-2 mb-6">
-                                <input
-                                    type="number"
-                                    className="flex-1 p-2 border border-gray-300 rounded text-lg text-center text-gray-800"
+                            <div className="mb-6">
+                                <NumberInput
+                                    suffix="px"
                                     value={widthConfig.currentWidth}
                                     onChange={e => setWidthConfig({ ...widthConfig, currentWidth: parseInt(e.target.value) || 0 })}
                                     autoFocus
                                     onKeyDown={e => e.key === 'Enter' && handleSaveWidth(widthConfig.currentWidth, widthConfig.currentTitle)}
+                                    isChristmasMode={isChristmasMode}
                                 />
-                                <span className="text-gray-500 font-bold">px</span>
                             </div>
                             <div className="flex gap-2">
-                                <button onClick={() => setWidthConfig(null)} className="flex-1 py-2 text-gray-500 hover:bg-gray-100 rounded-lg">キャンセル</button>
-                                <button onClick={() => handleSaveWidth(widthConfig.currentWidth, widthConfig.currentTitle)} className="flex-1 py-2 bg-primary text-white rounded-lg font-bold hover:bg-primary-dark">保存</button>
+                                <Button
+                                    variant="ghost"
+                                    size="md"
+                                    onClick={() => setWidthConfig(null)}
+                                    isChristmasMode={isChristmasMode}
+                                    className="flex-1"
+                                >
+                                    キャンセル
+                                </Button>
+                                <Button
+                                    variant="primary"
+                                    size="md"
+                                    onClick={() => handleSaveWidth(widthConfig.currentWidth, widthConfig.currentTitle)}
+                                    isChristmasMode={isChristmasMode}
+                                    className="flex-1"
+                                >
+                                    保存
+                                </Button>
                             </div>
                         </motion.div>
                     </div>
@@ -469,51 +574,76 @@ export const TableModals: React.FC<TableModalsProps> = ({
                         />
                         <motion.div
                             initial={{ opacity: 0, scale: 0.95 }} animate={{ opacity: 1, scale: 1 }} exit={{ opacity: 0, scale: 0.95 }}
-                            className="bg-white rounded-xl shadow-xl p-6 w-full max-w-xs relative z-10"
+                            className={`rounded-xl shadow-xl p-6 w-full max-w-xs relative z-10 ${
+                                isChristmasMode ? 'bg-[#1a1a1a] border border-[#d4af37]/30' : 'bg-white'
+                            }`}
                         >
-                            <h3 className="text-lg font-bold text-gray-800 mb-4">{heightConfig.label}</h3>
+                            <h3 className={`text-lg font-bold mb-4 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
+                                {heightConfig.label}
+                            </h3>
 
                             <div className="mb-4">
-                                <label className="block text-sm text-gray-500 mb-1">
-                                    {heightConfig.editMode === 'left' ? `${headerLabels.left}の名前` : `${headerLabels.right}の名前`}
-                                </label>
-                                <input
-                                    className="w-full p-2 border border-gray-300 rounded text-lg text-gray-900"
+                                <Input
+                                    label={heightConfig.editMode === 'left' ? `${headerLabels.left}の名前` : `${headerLabels.right}の名前`}
                                     value={heightConfig.currentName}
                                     onChange={e => setHeightConfig({ ...heightConfig, currentName: e.target.value })}
                                     placeholder={heightConfig.editMode === 'left' ? `${headerLabels.left}を入力` : `${headerLabels.right}を入力（任意）`}
+                                    isChristmasMode={isChristmasMode}
                                 />
                                 {heightConfig.editMode === 'right' && (
-                                    <p className="text-xs text-gray-500 mt-1">{headerLabels.right}は任意です。空欄にすると削除されます。</p>
+                                    <p className={`text-xs mt-1 ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'}`}>
+                                        {headerLabels.right}は任意です。空欄にすると削除されます。
+                                    </p>
                                 )}
                             </div>
 
                             <div className="mb-6">
-                                <label className="block text-sm text-gray-500 mb-1">高さ(px)</label>
-                                <div className="flex items-center gap-2">
-                                    <input
-                                        type="number"
-                                        className="flex-1 p-2 border border-gray-300 rounded text-lg text-center text-gray-900"
-                                        value={heightConfig.currentHeight}
-                                        onChange={e => setHeightConfig({ ...heightConfig, currentHeight: parseInt(e.target.value) || 0 })}
-                                        onKeyDown={e => e.key === 'Enter' && handleSaveRowConfig(heightConfig.currentHeight, heightConfig.currentName)}
-                                    />
-                                    <span className="text-gray-500 font-bold">px</span>
-                                </div>
+                                <NumberInput
+                                    label="高さ"
+                                    suffix="px"
+                                    value={heightConfig.currentHeight}
+                                    onChange={e => setHeightConfig({ ...heightConfig, currentHeight: parseInt(e.target.value) || 0 })}
+                                    onKeyDown={e => e.key === 'Enter' && handleSaveRowConfig(heightConfig.currentHeight, heightConfig.currentName)}
+                                    isChristmasMode={isChristmasMode}
+                                />
                             </div>
 
                             <div className="flex gap-2">
-                                <button onClick={() => {
-                                    if (confirm('この作業ラベルを削除しますか？\n（全てのチームから削除されます）')) {
-                                        onDeleteTaskLabel(heightConfig.taskLabelId);
-                                        setHeightConfig(null);
-                                    }
-                                }} className="flex-1 py-2 bg-gray-100 text-red-500 rounded-lg font-bold hover:bg-red-50 flex items-center justify-center gap-2">
-                                    <MdDelete size={20} />
+                                <Button
+                                    variant="danger"
+                                    size="sm"
+                                    onClick={() => {
+                                        if (confirm('この作業ラベルを削除しますか？\n（全てのチームから削除されます）')) {
+                                            onDeleteTaskLabel(heightConfig.taskLabelId);
+                                            setHeightConfig(null);
+                                        }
+                                    }}
+                                    isChristmasMode={isChristmasMode}
+                                    className={`flex-1 !flex !items-center !justify-center !gap-1 ${
+                                        isChristmasMode ? '!bg-red-500/10 hover:!bg-red-500/20' : '!bg-gray-100 hover:!bg-red-50'
+                                    }`}
+                                >
+                                    <MdDelete size={18} />
                                     削除
-                                </button>
-                                <button onClick={() => setHeightConfig(null)} className="flex-1 py-2 text-gray-500 hover:bg-gray-100 rounded-lg">キャンセル</button>
-                                <button onClick={() => handleSaveRowConfig(heightConfig.currentHeight, heightConfig.currentName)} className="flex-1 py-2 bg-primary text-white rounded-lg font-bold hover:bg-primary-dark">保存</button>
+                                </Button>
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={() => setHeightConfig(null)}
+                                    isChristmasMode={isChristmasMode}
+                                    className="flex-1"
+                                >
+                                    キャンセル
+                                </Button>
+                                <Button
+                                    variant="primary"
+                                    size="sm"
+                                    onClick={() => handleSaveRowConfig(heightConfig.currentHeight, heightConfig.currentName)}
+                                    isChristmasMode={isChristmasMode}
+                                    className="flex-1"
+                                >
+                                    保存
+                                </Button>
                             </div>
                         </motion.div>
                     </div>

--- a/app/assignment/components/assignment-table/types.ts
+++ b/app/assignment/components/assignment-table/types.ts
@@ -21,6 +21,7 @@ export type Props = {
     onSwapAssignments: (asg1: { teamId: string, taskLabelId: string }, asg2: { teamId: string, taskLabelId: string }) => Promise<void>;
     onShuffle: () => Promise<void>;
     isShuffleDisabled: boolean;
+    isChristmasMode?: boolean;
 };
 
 export const DEFAULT_TABLE_SETTINGS: TableSettings = {

--- a/app/assignment/page.tsx
+++ b/app/assignment/page.tsx
@@ -15,12 +15,14 @@ import { IoArrowBack } from "react-icons/io5";
 import { FaUsers, FaUserTie } from "react-icons/fa";
 import { HiPlus, HiCog } from "react-icons/hi";
 import { Button } from '@/components/ui';
+import { useChristmasMode } from '@/hooks/useChristmasMode';
 
 export default function AssignmentPage() {
     const router = useRouter();
     const { user, loading: authLoading } = useAuth();
     const userId = user?.uid ?? null;
     const { isEnabled: isDeveloperMode } = useDeveloperMode();
+    const { isChristmasMode } = useChristmasMode();
 
     // 管理者ダイアログ
     const [isManagerDialogOpen, setIsManagerDialogOpen] = useState(false);
@@ -123,6 +125,7 @@ export default function AssignmentPage() {
                     onAddTeam={handlers.handleAddTeam}
                     onDeleteTeam={handlers.handleDeleteTeam}
                     onUpdateTeam={handlers.handleUpdateTeam}
+                    isChristmasMode={isChristmasMode}
                 />
             </main>
 
@@ -133,19 +136,21 @@ export default function AssignmentPage() {
 
             {/* 管理者バッジ（右下固定） */}
             <div className="fixed bottom-6 right-6 z-20">
-                <button
+                <Button
+                    variant={data.manager ? 'outline' : 'primary'}
+                    size="md"
                     onClick={() => setIsManagerDialogOpen(true)}
-                    className={`flex items-center gap-2 px-4 py-3 rounded-lg shadow-lg transition-all ${data.manager
-                        ? 'bg-white hover:bg-gray-50 border border-gray-200'
-                        : 'bg-primary text-white hover:bg-primary-dark'
-                        }`}
+                    isChristmasMode={isChristmasMode}
+                    className={`!flex !items-center !gap-2 !px-4 !py-3 !rounded-lg shadow-lg ${
+                        data.manager && !isChristmasMode ? '!bg-white hover:!bg-gray-50 !border-gray-200' : ''
+                    }`}
                 >
                     {data.manager ? (
                         <>
-                            <FaUserTie className="w-5 h-5 text-primary" />
+                            <FaUserTie className={`w-5 h-5 ${isChristmasMode ? 'text-[#d4af37]' : 'text-primary'}`} />
                             <div className="text-left">
-                                <div className="text-sm font-semibold text-gray-800">{data.manager.name}</div>
-                                <div className="text-xs text-gray-500">管理者</div>
+                                <div className={`text-sm font-semibold ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>{data.manager.name}</div>
+                                <div className={`text-xs ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500'}`}>管理者</div>
                             </div>
                         </>
                     ) : (
@@ -154,7 +159,7 @@ export default function AssignmentPage() {
                             <span className="font-medium">管理者</span>
                         </>
                     )}
-                </button>
+                </Button>
             </div>
 
             {/* 管理者編集ダイアログ */}
@@ -172,6 +177,7 @@ export default function AssignmentPage() {
                     await deleteManager(userId);
                     data.setManagerState(null);
                 }}
+                isChristmasMode={isChristmasMode}
             />
 
             {/* ペア除外設定モーダル */}
@@ -188,6 +194,7 @@ export default function AssignmentPage() {
                     if (!userId) return;
                     await deletePairExclusion(userId, exclusionId);
                 }}
+                isChristmasMode={isChristmasMode}
             />
         </div>
     );

--- a/components/ui/IconButton.tsx
+++ b/components/ui/IconButton.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { forwardRef } from 'react';
+
+/**
+ * アイコンボタンコンポーネント
+ *
+ * @example
+ * // 基本的な使用方法
+ * <IconButton onClick={handleClose} aria-label="閉じる">
+ *   <HiX className="w-5 h-5" />
+ * </IconButton>
+ *
+ * @example
+ * // サイズバリエーション
+ * <IconButton size="sm"><MdAdd /></IconButton>
+ * <IconButton size="md"><MdAdd /></IconButton>
+ * <IconButton size="lg"><MdAdd /></IconButton>
+ *
+ * @example
+ * // バリアントとクリスマスモード
+ * <IconButton variant="danger" isChristmasMode={isChristmasMode}>
+ *   <MdDelete />
+ * </IconButton>
+ */
+
+export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** ボタンのスタイルバリエーション */
+  variant?: 'default' | 'primary' | 'danger' | 'success' | 'ghost';
+  /** ボタンのサイズ */
+  size?: 'sm' | 'md' | 'lg';
+  /** 丸いボタン（完全な円形） */
+  rounded?: boolean;
+  /** クリスマスモードの有効/無効 */
+  isChristmasMode?: boolean;
+}
+
+export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
+  (
+    {
+      variant = 'default',
+      size = 'md',
+      rounded = false,
+      isChristmasMode = false,
+      className = '',
+      disabled,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    // サイズスタイル
+    const sizeStyles = {
+      sm: 'p-1.5',
+      md: 'p-2',
+      lg: 'p-3',
+    };
+
+    // 通常モードのバリアントスタイル
+    const normalVariantStyles = {
+      default: 'text-gray-500 hover:text-gray-700 hover:bg-gray-100',
+      primary: 'text-primary hover:text-primary-dark hover:bg-primary/10',
+      danger: 'text-red-500 hover:text-red-700 hover:bg-red-50',
+      success: 'text-green-500 hover:text-green-700 hover:bg-green-50',
+      ghost: 'text-gray-400 hover:text-gray-600 hover:bg-gray-50',
+    };
+
+    // クリスマスモードのバリアントスタイル
+    const christmasVariantStyles = {
+      default: 'text-[#f8f1e7]/70 hover:text-[#f8f1e7] hover:bg-white/10',
+      primary: 'text-[#d4af37] hover:text-[#e8c65f] hover:bg-[#d4af37]/10',
+      danger: 'text-red-400 hover:text-red-300 hover:bg-red-500/10',
+      success: 'text-green-400 hover:text-green-300 hover:bg-green-500/10',
+      ghost: 'text-[#f8f1e7]/50 hover:text-[#f8f1e7]/70 hover:bg-white/5',
+    };
+
+    const variantStyles = isChristmasMode ? christmasVariantStyles : normalVariantStyles;
+
+    const baseStyles = 'inline-flex items-center justify-center transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2';
+    const focusRingStyles = isChristmasMode ? 'focus:ring-[#d4af37]/50' : 'focus:ring-amber-500/50';
+    const borderRadiusStyles = rounded ? 'rounded-full' : 'rounded-lg';
+    const disabledStyles = 'opacity-50 cursor-not-allowed';
+
+    const buttonStyles = [
+      baseStyles,
+      sizeStyles[size],
+      variantStyles[variant],
+      borderRadiusStyles,
+      focusRingStyles,
+      disabled ? disabledStyles : '',
+      className,
+    ].filter(Boolean).join(' ');
+
+    return (
+      <button
+        ref={ref}
+        className={buttonStyles}
+        disabled={disabled}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  }
+);
+
+IconButton.displayName = 'IconButton';

--- a/components/ui/InlineInput.tsx
+++ b/components/ui/InlineInput.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { forwardRef } from 'react';
+
+/**
+ * インライン編集用の軽量入力コンポーネント
+ * テーブルセルやヘッダー内での編集に最適化
+ *
+ * @example
+ * // テーブルヘッダー内での使用
+ * <InlineInput
+ *   value={teamName}
+ *   onChange={(e) => setTeamName(e.target.value)}
+ *   onKeyDown={(e) => e.key === 'Enter' && save()}
+ *   autoFocus
+ * />
+ *
+ * @example
+ * // クリスマスモード
+ * <InlineInput
+ *   value={value}
+ *   onChange={handleChange}
+ *   isChristmasMode={isChristmasMode}
+ *   variant="dark"
+ * />
+ */
+
+export interface InlineInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  /** 背景のバリエーション */
+  variant?: 'light' | 'dark';
+  /** テキストの配置 */
+  textAlign?: 'left' | 'center' | 'right';
+  /** クリスマスモードの有効/無効 */
+  isChristmasMode?: boolean;
+}
+
+export const InlineInput = forwardRef<HTMLInputElement, InlineInputProps>(
+  (
+    {
+      variant = 'light',
+      textAlign = 'center',
+      isChristmasMode = false,
+      className = '',
+      ...props
+    },
+    ref
+  ) => {
+    const baseStyles = 'w-full px-2 py-1 border rounded outline-none transition-all duration-200';
+
+    const textAlignStyles = {
+      left: 'text-left',
+      center: 'text-center',
+      right: 'text-right',
+    };
+
+    // 通常モード - ライト背景用
+    const normalLightStyles = 'bg-white border-gray-300 text-gray-900 focus:border-primary focus:ring-1 focus:ring-primary';
+
+    // 通常モード - ダーク背景用
+    const normalDarkStyles = 'bg-white border-primary text-gray-900 focus:ring-2 focus:ring-primary/20';
+
+    // クリスマスモード - ライト背景用
+    const christmasLightStyles = 'bg-white/10 border-[#d4af37]/40 text-[#f8f1e7] focus:border-[#d4af37] focus:ring-1 focus:ring-[#d4af37]/30';
+
+    // クリスマスモード - ダーク背景用
+    const christmasDarkStyles = 'bg-[#1a1a1a] border-[#d4af37] text-[#f8f1e7] focus:ring-2 focus:ring-[#d4af37]/30';
+
+    const getVariantStyles = () => {
+      if (isChristmasMode) {
+        return variant === 'dark' ? christmasDarkStyles : christmasLightStyles;
+      }
+      return variant === 'dark' ? normalDarkStyles : normalLightStyles;
+    };
+
+    const inputStyles = [
+      baseStyles,
+      textAlignStyles[textAlign],
+      getVariantStyles(),
+      className,
+    ].filter(Boolean).join(' ');
+
+    return (
+      <input
+        ref={ref}
+        className={inputStyles}
+        {...props}
+      />
+    );
+  }
+);
+
+InlineInput.displayName = 'InlineInput';

--- a/components/ui/NumberInput.tsx
+++ b/components/ui/NumberInput.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { forwardRef, useId } from 'react';
+
+/**
+ * 数値入力専用コンポーネント
+ *
+ * @example
+ * // 基本的な使用方法
+ * <NumberInput
+ *   label="幅"
+ *   value={width}
+ *   onChange={(e) => setWidth(parseInt(e.target.value))}
+ *   suffix="px"
+ * />
+ *
+ * @example
+ * // 最小値・最大値の設定
+ * <NumberInput
+ *   label="高さ"
+ *   value={height}
+ *   onChange={(e) => setHeight(parseInt(e.target.value))}
+ *   min={40}
+ *   max={200}
+ *   suffix="px"
+ * />
+ *
+ * @example
+ * // クリスマスモード
+ * <NumberInput
+ *   label="設定値"
+ *   isChristmasMode={isChristmasMode}
+ *   value={value}
+ *   onChange={handleChange}
+ * />
+ */
+
+export interface NumberInputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'> {
+  /** 入力フィールドのラベル */
+  label?: string;
+  /** 単位などの接尾辞 */
+  suffix?: string;
+  /** エラーメッセージ */
+  error?: string;
+  /** クリスマスモードの有効/無効 */
+  isChristmasMode?: boolean;
+}
+
+export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
+  ({ label, suffix, error, isChristmasMode = false, className = '', id, ...props }, ref) => {
+    const generatedId = useId();
+    const inputId = id || generatedId;
+
+    const baseStyles = 'rounded-lg border-2 px-4 py-2 text-lg transition-all duration-200 min-h-[44px] text-center';
+
+    const normalStyles = 'border-gray-200 text-gray-900 bg-white placeholder:text-gray-400 hover:border-gray-300 focus:border-amber-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-amber-100';
+
+    const christmasStyles = 'bg-white/10 border-[#d4af37]/40 text-[#f8f1e7] placeholder:text-[#f8f1e7]/50 focus:border-[#d4af37] focus:outline-none focus:ring-2 focus:ring-[#d4af37]/20';
+
+    const errorStyles = isChristmasMode
+      ? 'border-red-400 focus:border-red-400 focus:ring-red-400/20'
+      : 'border-red-500 focus:border-red-500 focus:ring-red-100';
+
+    const disabledStyles = 'opacity-50 cursor-not-allowed';
+
+    const inputStyles = [
+      baseStyles,
+      isChristmasMode ? christmasStyles : normalStyles,
+      error ? errorStyles : '',
+      props.disabled ? disabledStyles : '',
+      suffix ? '' : 'w-full',
+      className,
+    ].filter(Boolean).join(' ');
+
+    const labelStyles = isChristmasMode
+      ? 'block text-sm font-medium text-[#f8f1e7] mb-2'
+      : 'block text-sm font-medium text-gray-700 mb-2';
+
+    const suffixStyles = isChristmasMode
+      ? 'text-[#f8f1e7]/70 font-bold ml-2'
+      : 'text-gray-500 font-bold ml-2';
+
+    const errorTextStyles = isChristmasMode
+      ? 'text-red-400 text-sm mt-1'
+      : 'text-red-500 text-sm mt-1';
+
+    return (
+      <div>
+        {label && (
+          <label htmlFor={inputId} className={labelStyles}>
+            {label}
+          </label>
+        )}
+        <div className="flex items-center">
+          <input
+            ref={ref}
+            id={inputId}
+            type="number"
+            className={inputStyles}
+            aria-invalid={error ? 'true' : 'false'}
+            aria-describedby={error ? `${inputId}-error` : undefined}
+            {...props}
+          />
+          {suffix && (
+            <span className={suffixStyles}>{suffix}</span>
+          )}
+        </div>
+        {error && (
+          <p id={`${inputId}-error`} className={errorTextStyles} role="alert">
+            {error}
+          </p>
+        )}
+      </div>
+    );
+  }
+);
+
+NumberInput.displayName = 'NumberInput';

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -61,3 +61,12 @@ export type { ModalProps } from './Modal';
 
 export { Dialog } from './Dialog';
 export type { DialogProps } from './Dialog';
+
+export { IconButton } from './IconButton';
+export type { IconButtonProps } from './IconButton';
+
+export { NumberInput } from './NumberInput';
+export type { NumberInputProps } from './NumberInput';
+
+export { InlineInput } from './InlineInput';
+export type { InlineInputProps } from './InlineInput';


### PR DESCRIPTION
## 概要
Issue #132 を解決。担当表ページの内部UI要素を共通UIコンポーネントに置換し、クリスマスモード（テーマ対応）を可能にしました。

## 変更内容

### 新規共通コンポーネント
- **IconButton**: アイコンのみのボタン（閉じる、削除等）- variant, size, rounded, isChristmasMode対応
- **NumberInput**: 数値入力専用（幅・高さ設定）- suffix, label, isChristmasMode対応
- **InlineInput**: テーブルヘッダー内のインライン編集用 - variant(light/dark), textAlign, isChristmasMode対応

### ページ・コンポーネント変更
| ファイル | 変更内容 |
|---------|---------|
| page.tsx | useChristmasMode導入、管理者バッジをButtonに置換 |
| ManagerDialog | Input/Buttonコンポーネント適用、モーダル背景のテーマ対応 |
| MemberSettingsDialog | Buttonコンポーネント適用、チェックボックスのテーマ対応 |
| PairExclusionSettingsModal | Select/Buttonコンポーネント適用、リストのテーマ対応 |
| AssignmentTable | isChristmasModeプロップの子コンポーネントへの伝播 |
| DesktopTableView | Button/Input/InlineInput/IconButton適用、ヘッダーのテーマ対応 |
| MobileListView | Button/Input適用、カードのテーマ対応 |
| TableModals | 全5種類のモーダルに共通コンポーネント適用 |

## 対応内容チェックリスト
- [x] 独自実装のbutton要素を`<Button>`コンポーネントに置換
- [x] 独自実装のinput要素を`<Input>`コンポーネントに置換
- [x] `useChristmasMode`フックを導入
- [x] 共通UIコンポーネントに`isChristmasMode`を渡す
- [ ] 動作確認（通常モード・クリスマスモード両方）

## テスト
- [x] TypeScriptビルド: エラーなし
- [x] ESLint: 新規エラーなし（既存の警告は維持）
- [ ] 実機動作確認

Closes #132
