### PR TITLE
refactor(schedule): スケジュールページの共通UI化とクリスマスモード対応

### DIFF
--- a/app/schedule/page.tsx
+++ b/app/schedule/page.tsx
@@ -13,7 +13,8 @@ import { HiArrowLeft, HiCalendar, HiClock, HiChevronLeft, HiChevronRight, HiCame
 import { DatePickerModal } from '@/components/DatePickerModal';
 import { ScheduleOCRModal } from '@/components/ScheduleOCRModal';
 import LoginPage from '@/app/login/page';
-import { Button } from '@/components/ui';
+import { Button, IconButton } from '@/components/ui';
+import { useChristmasMode } from '@/hooks/useChristmasMode';
 
 type TabType = 'today' | 'roast';
 
@@ -39,6 +40,7 @@ export default function SchedulePage() {
   } = useScheduleDateNavigation();
 
   const { handleOCRSuccess } = useScheduleOCR({ data, selectedDate, updateData });
+  const { isChristmasMode } = useChristmasMode();
 
   if (authLoading) {
     return <Loading />;
@@ -53,14 +55,18 @@ export default function SchedulePage() {
   }
 
   return (
-    <div className="h-screen md:h-[100dvh] lg:h-screen pt-2 pb-4 px-4 sm:py-4 sm:px-4 lg:py-6 lg:px-6 flex flex-col overflow-hidden" style={{ backgroundColor: '#F7F7F5' }}>
+    <div className="h-screen md:h-[100dvh] lg:h-screen pt-2 pb-4 px-4 sm:py-4 sm:px-4 lg:py-6 lg:px-6 flex flex-col overflow-hidden" style={{ backgroundColor: isChristmasMode ? '#051a0e' : '#F7F7F5' }}>
       <div className="w-full flex-1 flex flex-col min-h-0 lg:max-w-7xl lg:mx-auto">
         {/* ヘッダー */}
         <header className="mb-4 flex-shrink-0 flex items-center">
           <div className="flex-1 flex justify-start items-center">
             <Link
               href="/"
-              className="px-3 py-2 text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded transition-colors flex items-center justify-center min-h-[44px] min-w-[44px]"
+              className={`px-3 py-2 rounded transition-colors flex items-center justify-center min-h-[44px] min-w-[44px] ${
+                isChristmasMode
+                  ? 'text-[#f8f1e7]/70 hover:text-[#f8f1e7] hover:bg-white/10'
+                  : 'text-gray-600 hover:text-gray-800 hover:bg-gray-100'
+              }`}
               title="戻る"
               aria-label="戻る"
             >
@@ -70,82 +76,106 @@ export default function SchedulePage() {
           <div className="flex-1 flex justify-center items-center">
             {/* スマホレイアウト：1つのカード */}
             <div className="sm:hidden w-full max-w-xs">
-              <div className="bg-white border-2 border-gray-300 rounded-2xl shadow-xl px-3 py-2.5">
+              <div className={`rounded-2xl shadow-xl px-3 py-2.5 ${
+                isChristmasMode
+                  ? 'bg-[#0a2f1a] border-2 border-[#d4af37]/30'
+                  : 'bg-white border-2 border-gray-300'
+              }`}>
                 {/* 日付ナビゲーション */}
                 <div className="flex items-center justify-center gap-1.5">
-                  <button
+                  <IconButton
+                    variant="ghost"
+                    size="sm"
                     onClick={moveToPreviousDay}
-                    className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-gray-100 transition-colors text-gray-700 hover:text-gray-900"
                     aria-label="前日"
+                    isChristmasMode={isChristmasMode}
                   >
                     <HiChevronLeft className="h-5 w-5" />
-                  </button>
-                  <button
+                  </IconButton>
+                  <Button
+                    variant="ghost"
+                    size="sm"
                     onClick={() => setIsDatePickerOpen(true)}
-                    className="flex items-center cursor-pointer hover:bg-gray-50 rounded-md px-2 py-1 transition-colors flex-1 justify-center"
                     aria-label="日付を選択"
+                    isChristmasMode={isChristmasMode}
+                    className="flex-1 justify-center"
                   >
-                    <span className="text-base text-gray-900 font-semibold font-sans whitespace-nowrap leading-tight">
+                    <span className={`text-base font-semibold font-sans whitespace-nowrap leading-tight ${
+                      isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-900'
+                    }`}>
                       {formatDateString(selectedDate)}
                     </span>
-                  </button>
-                  <button
+                  </Button>
+                  <IconButton
+                    variant="ghost"
+                    size="sm"
                     onClick={moveToNextDay}
                     disabled={isMaxDate}
-                    className={`flex items-center justify-center w-8 h-8 rounded-md transition-colors ${
-                      isMaxDate
-                        ? 'text-gray-300 cursor-not-allowed'
-                        : 'text-gray-700 hover:text-gray-900 hover:bg-gray-100'
-                    }`}
                     aria-label="翌日"
+                    isChristmasMode={isChristmasMode}
                   >
                     <HiChevronRight className="h-5 w-5" />
-                  </button>
+                  </IconButton>
                 </div>
               </div>
             </div>
             {/* タブレット・デスクトップレイアウト：横並び */}
-            <div className="hidden sm:flex flex-row items-center gap-3 md:gap-4 px-5 py-2 md:px-6 md:py-2.5 bg-white border-2 border-gray-300 rounded-2xl shadow-xl">
+            <div className={`hidden sm:flex flex-row items-center gap-3 md:gap-4 px-5 py-2 md:px-6 md:py-2.5 rounded-2xl shadow-xl ${
+              isChristmasMode
+                ? 'bg-[#0a2f1a] border-2 border-[#d4af37]/30'
+                : 'bg-white border-2 border-gray-300'
+            }`}>
               {/* 日付ナビゲーション */}
               <div className="flex items-center gap-2 md:gap-2.5">
-                <button
+                <IconButton
+                  variant="ghost"
+                  size="md"
                   onClick={moveToPreviousDay}
-                  className="flex items-center justify-center w-9 h-9 md:w-10 md:h-10 rounded-md hover:bg-gray-100 transition-colors text-gray-700 hover:text-gray-900"
                   aria-label="前日"
+                  isChristmasMode={isChristmasMode}
                 >
                   <HiChevronLeft className="h-5 w-5 md:h-6 md:w-6" />
-                </button>
-                <button
+                </IconButton>
+                <Button
+                  variant="ghost"
+                  size="md"
                   onClick={() => setIsDatePickerOpen(true)}
-                  className="flex items-center gap-2 md:gap-2.5 cursor-pointer hover:bg-gray-50 rounded-md px-2 py-1.5 transition-colors"
                   aria-label="日付を選択"
+                  isChristmasMode={isChristmasMode}
+                  className="gap-2 md:gap-2.5"
                 >
-                  <HiCalendar className="h-5 w-5 md:h-6 md:w-6 text-amber-600 flex-shrink-0" />
-                  <span className="text-base md:text-lg text-gray-900 font-semibold font-sans whitespace-nowrap leading-tight">
+                  <HiCalendar className={`h-5 w-5 md:h-6 md:w-6 flex-shrink-0 ${
+                    isChristmasMode ? 'text-[#d4af37]' : 'text-amber-600'
+                  }`} />
+                  <span className={`text-base md:text-lg font-semibold font-sans whitespace-nowrap leading-tight ${
+                    isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-900'
+                  }`}>
                     {formatDateString(selectedDate)}
                   </span>
-                </button>
-                <button
+                </Button>
+                <IconButton
+                  variant="ghost"
+                  size="md"
                   onClick={moveToNextDay}
                   disabled={isMaxDate}
-                  className={`flex items-center justify-center w-9 h-9 md:w-10 md:h-10 rounded-md transition-colors ${
-                    isMaxDate
-                      ? 'text-gray-300 cursor-not-allowed'
-                      : 'text-gray-700 hover:text-gray-900 hover:bg-gray-100'
-                  }`}
                   aria-label="翌日"
+                  isChristmasMode={isChristmasMode}
                 >
                   <HiChevronRight className="h-5 w-5 md:h-6 md:w-6" />
-                </button>
+                </IconButton>
               </div>
               {/* 区切り線 */}
               <div className="flex-shrink-0 h-7 md:h-8 flex items-center">
-                <div className="w-px h-full bg-gray-200"></div>
+                <div className={`w-px h-full ${isChristmasMode ? 'bg-[#d4af37]/30' : 'bg-gray-200'}`}></div>
               </div>
               {/* 時刻 */}
               <div className="flex items-center gap-2 md:gap-2.5">
-                <HiClock className="h-5 w-5 md:h-6 md:w-6 text-amber-600 flex-shrink-0" />
-                <span className="text-base md:text-lg text-gray-900 font-semibold font-sans whitespace-nowrap leading-tight">
+                <HiClock className={`h-5 w-5 md:h-6 md:w-6 flex-shrink-0 ${
+                  isChristmasMode ? 'text-[#d4af37]' : 'text-amber-600'
+                }`} />
+                <span className={`text-base md:text-lg font-semibold font-sans whitespace-nowrap leading-tight ${
+                  isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-900'
+                }`}>
                   {formatTime(currentTime)}
                 </span>
               </div>
@@ -160,6 +190,7 @@ export default function SchedulePage() {
                 className="shadow-md"
                 title="画像から読み取り"
                 aria-label="画像から読み取り"
+                isChristmasMode={isChristmasMode}
               >
                 <HiCamera className="h-5 w-5 flex-shrink-0 mr-2" />
                 <span className="font-medium">AIで読み取る</span>
@@ -170,17 +201,20 @@ export default function SchedulePage() {
 
         {/* タブナビゲーション（スマホ版：画面下部に固定） */}
         <div className="lg:hidden fixed bottom-0 left-0 right-0 z-20 px-4 pb-4">
-          <nav className="flex gap-1.5 sm:gap-2 bg-white border-2 border-gray-300 rounded-t-xl shadow-lg p-1.5 sm:p-2">
-            <button
+          <nav className={`flex gap-1.5 sm:gap-2 rounded-t-xl shadow-lg p-1.5 sm:p-2 ${
+            isChristmasMode
+              ? 'bg-[#0a2f1a] border-2 border-[#d4af37]/30'
+              : 'bg-white border-2 border-gray-300'
+          }`}>
+            <Button
+              variant={activeTab === 'today' ? 'primary' : 'ghost'}
+              size="sm"
               onClick={() => setActiveTab('today')}
-              className={`flex-1 px-3 py-2 sm:px-4 sm:py-2.5 rounded transition-colors text-xs sm:text-sm min-h-[44px] ${
-                activeTab === 'today'
-                  ? 'bg-amber-600 text-white'
-                  : 'text-gray-700 hover:bg-gray-100'
-              }`}
+              isChristmasMode={isChristmasMode}
+              className="flex-1 text-xs sm:text-sm"
             >
               本日のスケジュール
-            </button>
+            </Button>
             <Button
               variant="primary"
               size="sm"
@@ -188,19 +222,19 @@ export default function SchedulePage() {
               className="!px-3 !py-2 sm:!px-4 sm:!py-2.5 shadow-md"
               title="画像から読み取り"
               aria-label="画像から読み取り"
+              isChristmasMode={isChristmasMode}
             >
               <HiCamera className="h-5 w-5 sm:h-6 sm:w-6" />
             </Button>
-            <button
+            <Button
+              variant={activeTab === 'roast' ? 'primary' : 'ghost'}
+              size="sm"
               onClick={() => setActiveTab('roast')}
-              className={`flex-1 px-3 py-2 sm:px-4 sm:py-2.5 rounded transition-colors text-xs sm:text-sm min-h-[44px] ${
-                activeTab === 'roast'
-                  ? 'bg-amber-600 text-white'
-                  : 'text-gray-700 hover:bg-gray-100'
-              }`}
+              isChristmasMode={isChristmasMode}
+              className="flex-1 text-xs sm:text-sm"
             >
               ローストスケジュール
-            </button>
+            </Button>
           </nav>
         </div>
 
@@ -210,12 +244,12 @@ export default function SchedulePage() {
           <div className="block lg:hidden flex-1 flex flex-col min-h-0">
             {activeTab === 'today' && (
               <div className="flex-1 flex flex-col min-h-0">
-                <TodaySchedule key={selectedDate} data={data} onUpdate={updateData} selectedDate={selectedDate} isToday={isToday} />
+                <TodaySchedule key={selectedDate} data={data} onUpdate={updateData} selectedDate={selectedDate} isToday={isToday} isChristmasMode={isChristmasMode} />
               </div>
             )}
             {activeTab === 'roast' && (
               <div className="flex-1 flex flex-col min-h-0">
-                <RoastSchedulerTab data={data} onUpdate={updateData} selectedDate={selectedDate} isToday={isToday} />
+                <RoastSchedulerTab data={data} onUpdate={updateData} selectedDate={selectedDate} isToday={isToday} isChristmasMode={isChristmasMode} />
               </div>
             )}
           </div>
@@ -223,10 +257,10 @@ export default function SchedulePage() {
           {/* デスクトップ版：横並び */}
           <div className="hidden lg:grid lg:grid-cols-2 lg:gap-6 lg:flex-1 lg:min-h-0">
             <div className="flex flex-col min-h-0">
-              <TodaySchedule key={selectedDate} data={data} onUpdate={updateData} selectedDate={selectedDate} isToday={isToday} />
+              <TodaySchedule key={selectedDate} data={data} onUpdate={updateData} selectedDate={selectedDate} isToday={isToday} isChristmasMode={isChristmasMode} />
             </div>
             <div className="flex flex-col min-h-0">
-              <RoastSchedulerTab data={data} onUpdate={updateData} selectedDate={selectedDate} isToday={isToday} />
+              <RoastSchedulerTab data={data} onUpdate={updateData} selectedDate={selectedDate} isToday={isToday} isChristmasMode={isChristmasMode} />
             </div>
           </div>
         </main>

--- a/components/OCRRoastScheduleEditor.tsx
+++ b/components/OCRRoastScheduleEditor.tsx
@@ -6,12 +6,14 @@ import { HiPlus, HiTrash, HiPencil, HiFire } from 'react-icons/hi';
 import { FaSnowflake, FaBroom } from 'react-icons/fa';
 import { PiCoffeeBeanFill } from 'react-icons/pi';
 import { RoastScheduleMemoDialog } from './RoastScheduleMemoDialog';
+import { Button, IconButton } from '@/components/ui';
 
 interface OCRRoastScheduleEditorProps {
   roastSchedules: RoastSchedule[];
   selectedDate: string;
   onUpdate: (roastSchedules: RoastSchedule[]) => void;
   onDelete: (id: string) => void;
+  isChristmasMode?: boolean;
 }
 
 export function OCRRoastScheduleEditor({
@@ -19,6 +21,7 @@ export function OCRRoastScheduleEditor({
   selectedDate,
   onUpdate,
   onDelete,
+  isChristmasMode = false,
 }: OCRRoastScheduleEditorProps) {
   const [editingSchedule, setEditingSchedule] = useState<RoastSchedule | null>(null);
   const [isAdding, setIsAdding] = useState(false);
@@ -100,10 +103,11 @@ export function OCRRoastScheduleEditor({
   };
 
   const getScheduleTypeIcon = (schedule: RoastSchedule) => {
-    if (schedule.isRoasterOn) return <HiFire className="h-5 w-5 text-orange-600" />;
-    if (schedule.isRoast) return <PiCoffeeBeanFill className="h-5 w-5 text-amber-600" />;
-    if (schedule.isAfterPurge) return <FaSnowflake className="h-5 w-5 text-blue-600" />;
-    if (schedule.isChaffCleaning) return <FaBroom className="h-5 w-5 text-gray-600" />;
+    const iconColor = isChristmasMode ? 'text-[#d4af37]' : '';
+    if (schedule.isRoasterOn) return <HiFire className={`h-5 w-5 ${iconColor || 'text-orange-600'}`} />;
+    if (schedule.isRoast) return <PiCoffeeBeanFill className={`h-5 w-5 ${iconColor || 'text-amber-600'}`} />;
+    if (schedule.isAfterPurge) return <FaSnowflake className={`h-5 w-5 ${iconColor || 'text-blue-600'}`} />;
+    if (schedule.isChaffCleaning) return <FaBroom className={`h-5 w-5 ${iconColor || 'text-gray-600'}`} />;
     return null;
   };
 
@@ -111,24 +115,34 @@ export function OCRRoastScheduleEditor({
     <>
       <div className="space-y-3">
         {sortedSchedules.length === 0 ? (
-          <div className="text-center text-gray-500 py-8">
+          <div className={`text-center py-8 ${
+            isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'
+          }`}>
             <p>ローストスケジュールがありません</p>
           </div>
         ) : (
           sortedSchedules.map((schedule) => (
             <div
               key={schedule.id}
-              className="border border-gray-200 rounded-lg p-4 bg-white hover:bg-gray-50 transition-colors"
+              className={`border rounded-lg p-4 transition-colors ${
+                isChristmasMode
+                  ? 'border-[#d4af37]/30 bg-[#0a2f1a] hover:bg-[#0a2f1a]/80'
+                  : 'border-gray-200 bg-white hover:bg-gray-50'
+              }`}
             >
               <div className="flex items-start justify-between gap-4">
                 <div className="flex-1">
                   <div className="flex items-center gap-3 mb-2">
                     {getScheduleTypeIcon(schedule)}
-                    <span className="text-sm font-medium text-gray-600">
+                    <span className={`text-sm font-medium ${
+                      isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'
+                    }`}>
                       {getScheduleTypeLabel(schedule)}
                     </span>
                     {schedule.time && (
-                      <span className="text-lg font-semibold text-gray-900">
+                      <span className={`text-lg font-semibold ${
+                        isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-900'
+                      }`}>
                         {schedule.time}
                       </span>
                     )}
@@ -136,7 +150,9 @@ export function OCRRoastScheduleEditor({
 
                   {/* 豆の情報 */}
                   {schedule.beanName && (
-                    <div className="text-sm text-gray-700 mb-1">
+                    <div className={`text-sm mb-1 ${
+                      isChristmasMode ? 'text-[#f8f1e7]/80' : 'text-gray-700'
+                    }`}>
                       <span className="font-medium">豆:</span> {schedule.beanName}
                       {schedule.beanName2 && schedule.blendRatio && (
                         <span> + {schedule.beanName2} ({schedule.blendRatio})</span>
@@ -146,7 +162,9 @@ export function OCRRoastScheduleEditor({
 
                   {/* 重さと焙煎度合い */}
                   {(schedule.weight || schedule.roastLevel) && (
-                    <div className="text-sm text-gray-700 mb-1">
+                    <div className={`text-sm mb-1 ${
+                      isChristmasMode ? 'text-[#f8f1e7]/80' : 'text-gray-700'
+                    }`}>
                       {schedule.weight && <span>{schedule.weight}g</span>}
                       {schedule.weight && schedule.roastLevel && <span> / </span>}
                       {schedule.roastLevel && <span>{schedule.roastLevel}</span>}
@@ -155,7 +173,9 @@ export function OCRRoastScheduleEditor({
 
                   {/* ロースト回数と袋数 */}
                   {schedule.isRoast && (schedule.roastCount || schedule.bagCount) && (
-                    <div className="text-sm text-gray-700">
+                    <div className={`text-sm ${
+                      isChristmasMode ? 'text-[#f8f1e7]/80' : 'text-gray-700'
+                    }`}>
                       {schedule.roastCount && <span>{schedule.roastCount}回目</span>}
                       {schedule.roastCount && schedule.bagCount && <span> / </span>}
                       {schedule.bagCount && <span>{schedule.bagCount}袋</span>}
@@ -164,20 +184,25 @@ export function OCRRoastScheduleEditor({
                 </div>
 
                 <div className="flex gap-2">
-                  <button
+                  <IconButton
+                    variant="ghost"
+                    size="md"
                     onClick={() => handleEdit(schedule)}
-                    className="p-2 text-gray-600 hover:bg-gray-100 rounded-md transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
+                    isChristmasMode={isChristmasMode}
                     aria-label="編集"
                   >
                     <HiPencil className="h-5 w-5" />
-                  </button>
-                  <button
+                  </IconButton>
+                  <IconButton
+                    variant="ghost"
+                    size="md"
                     onClick={() => handleDelete(schedule.id)}
-                    className="p-2 text-red-600 hover:bg-red-50 rounded-md transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
+                    isChristmasMode={isChristmasMode}
+                    className="text-red-500"
                     aria-label="削除"
                   >
                     <HiTrash className="h-5 w-5" />
-                  </button>
+                  </IconButton>
                 </div>
               </div>
             </div>
@@ -185,13 +210,16 @@ export function OCRRoastScheduleEditor({
         )}
 
         {/* 追加ボタン */}
-        <button
+        <Button
           onClick={handleAdd}
-          className="w-full px-4 py-3 bg-primary text-white rounded-lg hover:bg-primary-dark transition-colors flex items-center justify-center gap-2 min-h-[44px] shadow-md"
+          variant="primary"
+          size="lg"
+          className="w-full"
+          isChristmasMode={isChristmasMode}
         >
           <HiPlus className="h-5 w-5" />
           <span>ローストスケジュールを追加</span>
-        </button>
+        </Button>
       </div>
 
       {/* 編集ダイアログ */}

--- a/components/RoastScheduleMemoDialog.tsx
+++ b/components/RoastScheduleMemoDialog.tsx
@@ -9,7 +9,7 @@ import { RoasterFields } from './roast-scheduler/RoasterFields';
 import { RoastFields } from './roast-scheduler/RoastFields';
 import { SchedulePreview } from './roast-scheduler/SchedulePreview';
 import { useChristmasMode } from '@/hooks/useChristmasMode';
-import { Button, IconButton } from '@/components/ui';
+import { Button, IconButton, NumberInput } from '@/components/ui';
 
 interface RoastScheduleMemoDialogProps {
   schedule: RoastSchedule | null;
@@ -221,8 +221,7 @@ function RoastScheduleMemoDialogInner({
                   時間 <span className="text-red-500">*</span>
                 </label>
                 <div className="flex items-center justify-center gap-2 md:gap-3">
-                  <input
-                    type="number"
+                  <NumberInput
                     value={hour}
                     onChange={(e) => {
                       const value = e.target.value;
@@ -230,19 +229,15 @@ function RoastScheduleMemoDialogInner({
                         setHour(value);
                       }
                     }}
-                    min="0"
-                    max="23"
+                    min={0}
+                    max={23}
                     required={!isAfterPurge}
-                    className={`w-20 md:w-24 rounded-md border px-3 md:px-4 py-2 md:py-2.5 text-base md:text-lg text-center focus:outline-none focus:ring-2 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${
-                      isChristmasMode
-                        ? 'border-[#d4af37]/40 bg-white/10 text-[#f8f1e7] placeholder:text-[#f8f1e7]/40 focus:border-[#d4af37] focus:ring-[#d4af37]/50'
-                        : 'border-gray-300 text-gray-900 focus:border-amber-500 focus:ring-amber-500'
-                    }`}
                     placeholder="時"
+                    isChristmasMode={isChristmasMode}
+                    className="w-20 md:w-24 text-center"
                   />
                   <span className={`text-lg md:text-xl ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>:</span>
-                  <input
-                    type="number"
+                  <NumberInput
                     value={minute}
                     onChange={(e) => {
                       const value = e.target.value;
@@ -250,15 +245,12 @@ function RoastScheduleMemoDialogInner({
                         setMinute(value);
                       }
                     }}
-                    min="0"
-                    max="59"
+                    min={0}
+                    max={59}
                     required={!isAfterPurge}
-                    className={`w-20 md:w-24 rounded-md border px-3 md:px-4 py-2 md:py-2.5 text-base md:text-lg text-center focus:outline-none focus:ring-2 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${
-                      isChristmasMode
-                        ? 'border-[#d4af37]/40 bg-white/10 text-[#f8f1e7] placeholder:text-[#f8f1e7]/40 focus:border-[#d4af37] focus:ring-[#d4af37]/50'
-                        : 'border-gray-300 text-gray-900 focus:border-amber-500 focus:ring-amber-500'
-                    }`}
                     placeholder="分"
+                    isChristmasMode={isChristmasMode}
+                    className="w-20 md:w-24 text-center"
                   />
                 </div>
               </div>

--- a/components/RoastScheduleMemoDialog.tsx
+++ b/components/RoastScheduleMemoDialog.tsx
@@ -8,6 +8,8 @@ import { ScheduleTypeSelector } from './roast-scheduler/ScheduleTypeSelector';
 import { RoasterFields } from './roast-scheduler/RoasterFields';
 import { RoastFields } from './roast-scheduler/RoastFields';
 import { SchedulePreview } from './roast-scheduler/SchedulePreview';
+import { useChristmasMode } from '@/hooks/useChristmasMode';
+import { Button, IconButton } from '@/components/ui';
 
 interface RoastScheduleMemoDialogProps {
   schedule: RoastSchedule | null;
@@ -37,6 +39,8 @@ function RoastScheduleMemoDialogInner({
   onDelete,
   onCancel,
 }: RoastScheduleMemoDialogProps) {
+  const { isChristmasMode } = useChristmasMode();
+
   // 時間を時・分に分割
   const parseTime = (timeStr: string) => {
     if (!timeStr) return { hour: '', minute: '' };
@@ -170,26 +174,39 @@ function RoastScheduleMemoDialogInner({
   };
 
   return (
-    <div 
+    <div
       className="fixed inset-0 bg-black/20 flex items-center justify-center z-[100] p-4"
       onClick={onCancel}
     >
-      <div 
-        className="bg-white rounded-lg shadow-xl max-w-md w-full max-h-[90vh] overflow-y-auto border-2 border-gray-300"
+      <div
+        className={`rounded-lg shadow-xl max-w-md w-full max-h-[90vh] overflow-y-auto border-2 ${
+          isChristmasMode
+            ? 'bg-[#0a2f1a] border-[#d4af37]/30'
+            : 'bg-white border-gray-300'
+        }`}
         onClick={(e) => e.stopPropagation()}
       >
         {/* ヘッダー */}
-        <div className="sticky top-0 bg-white border-b border-gray-200 px-6 md:px-8 py-4 md:py-5 flex items-center justify-between">
-          <h3 className="text-2xl md:text-2xl font-semibold text-gray-800">
+        <div className={`sticky top-0 border-b px-6 md:px-8 py-4 md:py-5 flex items-center justify-between ${
+          isChristmasMode
+            ? 'bg-[#0a2f1a] border-[#d4af37]/20'
+            : 'bg-white border-gray-200'
+        }`}>
+          <h3 className={`text-2xl md:text-2xl font-semibold ${
+            isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'
+          }`}>
             {schedule ? 'スケジュールを編集' : 'スケジュールを追加'}
           </h3>
-          <button
+          <IconButton
+            variant="ghost"
+            size="md"
             onClick={onCancel}
-            className="rounded-md bg-gray-200 p-2 md:p-2.5 text-gray-700 transition-colors hover:bg-gray-300 min-w-[44px] min-h-[44px] flex items-center justify-center"
+            isChristmasMode={isChristmasMode}
+            rounded
             aria-label="閉じる"
           >
             <HiX className="h-6 w-6 md:h-7 md:w-7" />
-          </button>
+          </IconButton>
         </div>
 
         {/* フォーム */}
@@ -198,7 +215,9 @@ function RoastScheduleMemoDialogInner({
             {/* 時間選択 */}
             {!isAfterPurge && (
               <div>
-                <label className="mb-1 md:mb-2 block text-base md:text-lg font-medium text-gray-700 text-center">
+                <label className={`mb-1 md:mb-2 block text-base md:text-lg font-medium text-center ${
+                  isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'
+                }`}>
                   時間 <span className="text-red-500">*</span>
                 </label>
                 <div className="flex items-center justify-center gap-2 md:gap-3">
@@ -214,10 +233,14 @@ function RoastScheduleMemoDialogInner({
                     min="0"
                     max="23"
                     required={!isAfterPurge}
-                    className="w-20 md:w-24 rounded-md border border-gray-300 px-3 md:px-4 py-2 md:py-2.5 text-base md:text-lg text-gray-900 text-center focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                    className={`w-20 md:w-24 rounded-md border px-3 md:px-4 py-2 md:py-2.5 text-base md:text-lg text-center focus:outline-none focus:ring-2 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${
+                      isChristmasMode
+                        ? 'border-[#d4af37]/40 bg-white/10 text-[#f8f1e7] placeholder:text-[#f8f1e7]/40 focus:border-[#d4af37] focus:ring-[#d4af37]/50'
+                        : 'border-gray-300 text-gray-900 focus:border-amber-500 focus:ring-amber-500'
+                    }`}
                     placeholder="時"
                   />
-                  <span className="text-gray-600 text-lg md:text-xl">:</span>
+                  <span className={`text-lg md:text-xl ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>:</span>
                   <input
                     type="number"
                     value={minute}
@@ -230,7 +253,11 @@ function RoastScheduleMemoDialogInner({
                     min="0"
                     max="59"
                     required={!isAfterPurge}
-                    className="w-20 md:w-24 rounded-md border border-gray-300 px-3 md:px-4 py-2 md:py-2.5 text-base md:text-lg text-gray-900 text-center focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                    className={`w-20 md:w-24 rounded-md border px-3 md:px-4 py-2 md:py-2.5 text-base md:text-lg text-center focus:outline-none focus:ring-2 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${
+                      isChristmasMode
+                        ? 'border-[#d4af37]/40 bg-white/10 text-[#f8f1e7] placeholder:text-[#f8f1e7]/40 focus:border-[#d4af37] focus:ring-[#d4af37]/50'
+                        : 'border-gray-300 text-gray-900 focus:border-amber-500 focus:ring-amber-500'
+                    }`}
                     placeholder="分"
                   />
                 </div>
@@ -244,6 +271,7 @@ function RoastScheduleMemoDialogInner({
               isAfterPurge={isAfterPurge}
               isChaffCleaning={isChaffCleaning}
               onTypeChange={handleMemoTypeChange}
+              isChristmasMode={isChristmasMode}
             />
 
             {/* 焙煎機予熱用フィールド */}
@@ -261,6 +289,7 @@ function RoastScheduleMemoDialogInner({
                 onBlendRatio2Change={setBlendRatio2}
                 onWeightChange={setWeight}
                 onRoastLevelChange={setRoastLevel}
+                isChristmasMode={isChristmasMode}
               />
             )}
 
@@ -271,6 +300,7 @@ function RoastScheduleMemoDialogInner({
                 bagCount={bagCount}
                 onRoastCountChange={setRoastCount}
                 onBagCountChange={setBagCount}
+                isChristmasMode={isChristmasMode}
               />
             )}
 
@@ -288,25 +318,32 @@ function RoastScheduleMemoDialogInner({
               roastLevel={roastLevel}
               roastCount={roastCount}
               bagCount={bagCount}
+              isChristmasMode={isChristmasMode}
             />
 
             {/* フッター */}
-            <div className="flex gap-3 md:gap-4 pt-4 md:pt-5 border-t border-gray-200 justify-center">
+            <div className={`flex gap-3 md:gap-4 pt-4 md:pt-5 border-t justify-center ${
+              isChristmasMode ? 'border-[#d4af37]/20' : 'border-gray-200'
+            }`}>
               {schedule && onDelete && (
-                <button
+                <Button
                   type="button"
+                  variant="danger"
+                  size="lg"
                   onClick={handleDelete}
-                  className="px-4 md:px-6 py-2 md:py-2.5 bg-red-500 text-white rounded-md hover:bg-red-600 transition-colors min-h-[44px] text-base md:text-lg"
+                  isChristmasMode={isChristmasMode}
                 >
                   削除
-                </button>
+                </Button>
               )}
-              <button
+              <Button
                 type="submit"
-                className="px-6 md:px-8 py-2 md:py-2.5 bg-amber-600 text-white rounded-md hover:bg-amber-700 transition-colors font-medium min-h-[44px] text-base md:text-lg"
+                variant="primary"
+                size="lg"
+                isChristmasMode={isChristmasMode}
               >
                 保存
-              </button>
+              </Button>
             </div>
           </div>
         </form>

--- a/components/RoastSchedulerTab.tsx
+++ b/components/RoastSchedulerTab.tsx
@@ -6,15 +6,17 @@ import type { AppData, RoastSchedule } from '@/types';
 import { HiPlus, HiCalendar } from 'react-icons/hi';
 import { RoastScheduleMemoDialog } from './RoastScheduleMemoDialog';
 import { ScheduleCard } from './roast-scheduler/ScheduleCard';
+import { Button } from '@/components/ui';
 
 interface RoastSchedulerTabProps {
   data: AppData | null;
   onUpdate: (data: AppData) => void;
   selectedDate: string; // YYYY-MM-DD形式
   isToday: boolean; // 選択日が今日かどうか
+  isChristmasMode?: boolean;
 }
 
-export function RoastSchedulerTab({ data, onUpdate, selectedDate, isToday: _isToday }: RoastSchedulerTabProps) {
+export function RoastSchedulerTab({ data, onUpdate, selectedDate, isToday: _isToday, isChristmasMode = false }: RoastSchedulerTabProps) {
   const [editingSchedule, setEditingSchedule] = useState<RoastSchedule | null>(null);
   const [isAdding, setIsAdding] = useState(false);
   const [draggedId, setDraggedId] = useState<string | null>(null);
@@ -260,40 +262,58 @@ export function RoastSchedulerTab({ data, onUpdate, selectedDate, isToday: _isTo
 
   if (!data) {
     return (
-      <div className="rounded-2xl bg-white p-6 shadow-xl border-2 border-gray-300">
-        <p className="text-center text-gray-500">データがありません</p>
+      <div className={`rounded-2xl p-6 shadow-xl ${
+        isChristmasMode
+          ? 'bg-[#0a2f1a] border-2 border-[#d4af37]/30'
+          : 'bg-white border-2 border-gray-300'
+      }`}>
+        <p className={`text-center ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500'}`}>データがありません</p>
       </div>
     );
   }
 
   return (
     <div
-      className="relative rounded-2xl bg-white p-4 md:p-6 shadow-xl border-2 border-gray-300 h-full flex flex-col backdrop-blur-sm"
+      className={`relative rounded-2xl p-4 md:p-6 shadow-xl h-full flex flex-col backdrop-blur-sm ${
+        isChristmasMode
+          ? 'bg-[#0a2f1a] border-2 border-[#d4af37]/30'
+          : 'bg-white border-2 border-gray-300'
+      }`}
       data-is-today={_isToday}
     >
       {/* デスクトップ版：タイトルと追加ボタンを横並び */}
       <div className="mb-3 md:mb-4 hidden lg:flex items-center justify-between">
-        <h2 className="text-base md:text-lg font-semibold text-gray-800">
+        <h2 className={`text-base md:text-lg font-semibold ${
+          isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'
+        }`}>
           ローストスケジュール
         </h2>
-        <button
+        <Button
+          variant="primary"
+          size="sm"
           onClick={handleAdd}
-          className="flex items-center gap-1 md:gap-1.5 rounded-md bg-primary px-2.5 md:px-3 py-1.5 md:py-2 text-xs md:text-sm font-medium text-white transition-colors hover:bg-primary-dark shadow-md"
+          isChristmasMode={isChristmasMode}
           aria-label="スケジュールを追加"
         >
-          <HiPlus className="h-3.5 w-3.5 md:h-4 md:w-4" />
+          <HiPlus className="h-4 w-4" />
           <span>追加</span>
-        </button>
+        </Button>
       </div>
 
       {sortedSchedules.length === 0 ? (
-        <div className="flex-1 flex items-center justify-center text-center text-gray-500">
+        <div className={`flex-1 flex items-center justify-center text-center ${
+          isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500'
+        }`}>
           <div>
             <div className="mb-3 md:mb-5 flex justify-center">
-              <HiCalendar className="h-12 w-12 md:h-20 md:w-20 text-gray-300" />
+              <HiCalendar className={`h-12 w-12 md:h-20 md:w-20 ${
+                isChristmasMode ? 'text-[#d4af37]/30' : 'text-gray-300'
+              }`} />
             </div>
             <p className="text-sm md:text-lg font-medium">スケジュールがありません</p>
-            <p className="mt-1.5 md:mt-3 text-xs md:text-base text-gray-400">ボタンから新しいスケジュールを作成してください</p>
+            <p className={`mt-1.5 md:mt-3 text-xs md:text-base ${
+              isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-400'
+            }`}>ボタンから新しいスケジュールを作成してください</p>
           </div>
         </div>
       ) : (
@@ -311,18 +331,21 @@ export function RoastSchedulerTab({ data, onUpdate, selectedDate, isToday: _isTo
                 onDragLeave={handleDragLeave}
                 onDrop={(e) => handleDrop(e, schedule.id)}
                 onDragEnd={handleDragEnd}
+                isChristmasMode={isChristmasMode}
               />
             ))}
             {/* モバイル版：追加ボタンを一番下に表示 */}
             <div className="mt-4 flex lg:hidden items-center justify-center pb-2">
-              <button
+              <Button
+                variant="primary"
+                size="md"
                 onClick={handleAdd}
-                className="flex items-center justify-center gap-1 md:gap-1.5 rounded-md bg-primary px-3 md:px-4 py-2 md:py-2 text-sm md:text-base font-medium text-white transition-colors hover:bg-primary-dark shadow-md min-w-[44px] min-h-[44px]"
+                isChristmasMode={isChristmasMode}
                 aria-label="スケジュールを追加"
               >
-                <HiPlus className="h-4 w-4 md:h-4 md:w-4" />
+                <HiPlus className="h-4 w-4" />
                 <span className="hidden sm:inline">追加</span>
-              </button>
+              </Button>
             </div>
           </div>
         </div>
@@ -331,14 +354,16 @@ export function RoastSchedulerTab({ data, onUpdate, selectedDate, isToday: _isTo
       {/* モバイル版：追加ボタンを一番下に表示（空の場合） */}
       {sortedSchedules.length === 0 && (
         <div className="mt-4 flex lg:hidden items-center justify-center">
-          <button
+          <Button
+            variant="primary"
+            size="md"
             onClick={handleAdd}
-            className="flex items-center justify-center gap-1 md:gap-1.5 rounded-md bg-primary px-3 md:px-4 py-2 md:py-2 text-sm md:text-base font-medium text-white transition-colors hover:bg-primary-dark shadow-md min-w-[44px] min-h-[44px]"
+            isChristmasMode={isChristmasMode}
             aria-label="スケジュールを追加"
           >
-            <HiPlus className="h-4 w-4 md:h-4 md:w-4" />
+            <HiPlus className="h-4 w-4" />
             <span className="hidden sm:inline">追加</span>
-          </button>
+          </Button>
         </div>
       )}
 

--- a/components/ScheduleOCRModal.tsx
+++ b/components/ScheduleOCRModal.tsx
@@ -9,6 +9,8 @@ import { HiX, HiPhotograph, HiCamera } from 'react-icons/hi';
 import { useToastContext } from './Toast';
 import { useAppData } from '@/hooks/useAppData';
 import { useScheduleImageProcessing } from '@/hooks/useScheduleImageProcessing';
+import { useChristmasMode } from '@/hooks/useChristmasMode';
+import { Button, IconButton } from '@/components/ui';
 
 interface ScheduleOCRModalProps {
   selectedDate: string;
@@ -17,6 +19,7 @@ interface ScheduleOCRModalProps {
 }
 
 export function ScheduleOCRModal({ selectedDate, onSuccess, onCancel }: ScheduleOCRModalProps) {
+  const { isChristmasMode } = useChristmasMode();
   const { showToast } = useToastContext();
   const { data } = useAppData();
   const [showCamera, setShowCamera] = useState(false);
@@ -90,34 +93,49 @@ export function ScheduleOCRModal({ selectedDate, onSuccess, onCancel }: Schedule
   if (!showCamera && !isProcessing && !error && !showConfirm) {
     return (
       <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center">
-        <div className="bg-white rounded-lg p-6 max-w-sm w-full mx-4">
+        <div className={`rounded-lg p-6 max-w-sm w-full mx-4 ${
+          isChristmasMode
+            ? 'bg-[#0a2f1a] border border-[#d4af37]/30'
+            : 'bg-white'
+        }`}>
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold text-gray-800">画像を選択</h2>
-            <button
+            <h2 className={`text-lg font-semibold ${
+              isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'
+            }`}>画像を選択</h2>
+            <IconButton
+              variant="ghost"
+              size="md"
               onClick={() => {
                 handleReset();
                 onCancel();
               }}
-              className="p-2 hover:bg-gray-100 rounded-full transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
+              isChristmasMode={isChristmasMode}
+              rounded
             >
-              <HiX className="h-5 w-5 text-gray-600" />
-            </button>
+              <HiX className="h-5 w-5" />
+            </IconButton>
           </div>
           <div className="space-y-3">
-            <button
+            <Button
+              variant="primary"
+              size="lg"
               onClick={() => setShowCamera(true)}
-              className="w-full px-4 py-3 bg-amber-600 text-white rounded-md hover:bg-amber-700 transition-colors min-h-[44px] flex items-center justify-center gap-2"
+              isChristmasMode={isChristmasMode}
+              className="w-full"
             >
-              <HiCamera className="h-5 w-5" />
+              <HiCamera className="h-5 w-5 mr-2" />
               <span>カメラで撮影</span>
-            </button>
-            <button
+            </Button>
+            <Button
+              variant="secondary"
+              size="lg"
               onClick={() => fileInputRef.current?.click()}
-              className="w-full px-4 py-3 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300 transition-colors min-h-[44px] flex items-center justify-center gap-2"
+              isChristmasMode={isChristmasMode}
+              className="w-full"
             >
-              <HiPhotograph className="h-5 w-5" />
+              <HiPhotograph className="h-5 w-5 mr-2" />
               <span>ファイルから選択</span>
-            </button>
+            </Button>
           </div>
           <input
             ref={fileInputRef}
@@ -145,11 +163,17 @@ export function ScheduleOCRModal({ selectedDate, onSuccess, onCancel }: Schedule
   if (isProcessing) {
     return (
       <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4">
-        <div className="bg-white rounded-xl p-6 max-w-md w-full mx-4 shadow-2xl">
+        <div className={`rounded-xl p-6 max-w-md w-full mx-4 shadow-2xl ${
+          isChristmasMode
+            ? 'bg-[#0a2f1a] border border-[#d4af37]/30'
+            : 'bg-white'
+        }`}>
           <div className="text-center">
             {/* 画像プレビュー */}
             {imagePreview && (
-              <div className="mb-6 rounded-lg overflow-hidden border-2 border-amber-200 bg-gray-50">
+              <div className={`mb-6 rounded-lg overflow-hidden border-2 ${
+                isChristmasMode ? 'border-[#d4af37]/30 bg-white/5' : 'border-amber-200 bg-gray-50'
+              }`}>
                 <Image
                   src={imagePreview}
                   alt="解析中の画像"
@@ -160,19 +184,27 @@ export function ScheduleOCRModal({ selectedDate, onSuccess, onCancel }: Schedule
                 />
               </div>
             )}
-            
+
             {/* スピナー */}
             <div className="flex justify-center mb-4">
               <div className="relative">
-                <div className="w-12 h-12 border-4 border-amber-200 border-t-amber-600 rounded-full animate-spin"></div>
+                <div className={`w-12 h-12 border-4 rounded-full animate-spin ${
+                  isChristmasMode
+                    ? 'border-[#d4af37]/20 border-t-[#d4af37]'
+                    : 'border-amber-200 border-t-amber-600'
+                }`}></div>
               </div>
             </div>
-            
+
             {/* メッセージ */}
-            <p className="text-lg font-medium text-gray-800 mb-1">
+            <p className={`text-lg font-medium mb-1 ${
+              isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'
+            }`}>
               画像を解析中...
             </p>
-            <p className="text-sm text-gray-500">
+            <p className={`text-sm ${
+              isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500'
+            }`}>
               しばらくお待ちください
             </p>
           </div>
@@ -184,39 +216,56 @@ export function ScheduleOCRModal({ selectedDate, onSuccess, onCancel }: Schedule
   if (error) {
     return (
       <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center">
-        <div className="bg-white rounded-lg p-6 max-w-sm w-full mx-4">
+        <div className={`rounded-lg p-6 max-w-sm w-full mx-4 ${
+          isChristmasMode
+            ? 'bg-[#0a2f1a] border border-[#d4af37]/30'
+            : 'bg-white'
+        }`}>
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold text-gray-800">エラー</h2>
-            <button
+            <h2 className={`text-lg font-semibold ${
+              isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'
+            }`}>エラー</h2>
+            <IconButton
+              variant="ghost"
+              size="md"
               onClick={() => {
                 handleReset();
                 onCancel();
               }}
-              className="p-2 hover:bg-gray-100 rounded-full transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
+              isChristmasMode={isChristmasMode}
+              rounded
             >
-              <HiX className="h-5 w-5 text-gray-600" />
-            </button>
+              <HiX className="h-5 w-5" />
+            </IconButton>
           </div>
-          <div className="text-gray-700 mb-4 whitespace-pre-wrap break-words">{error}</div>
+          <div className={`mb-4 whitespace-pre-wrap break-words ${
+            isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-700'
+          }`}>{error}</div>
           <div className="flex gap-2">
-            <button
+            <Button
+              variant="primary"
+              size="md"
               onClick={() => {
                 resetState();
                 setShowCamera(false);
               }}
-              className="flex-1 px-4 py-2 bg-amber-600 text-white rounded-md hover:bg-amber-700 transition-colors min-h-[44px]"
+              isChristmasMode={isChristmasMode}
+              className="flex-1"
             >
               再試行
-            </button>
-            <button
+            </Button>
+            <Button
+              variant="secondary"
+              size="md"
               onClick={() => {
                 resetState();
                 onCancel();
               }}
-              className="flex-1 px-4 py-2 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300 transition-colors min-h-[44px]"
+              isChristmasMode={isChristmasMode}
+              className="flex-1"
             >
               キャンセル
-            </button>
+            </Button>
           </div>
         </div>
       </div>

--- a/components/TodaySchedule.tsx
+++ b/components/TodaySchedule.tsx
@@ -13,14 +13,16 @@ interface TodayScheduleProps {
   onUpdate: (data: AppData) => void;
   selectedDate: string;
   isToday: boolean;
+  isChristmasMode?: boolean;
 }
 
 interface TodayScheduleInnerProps extends TodayScheduleProps {
   currentSchedule: TodayScheduleType;
+  isChristmasMode: boolean;
 }
 
 export function TodaySchedule(props: TodayScheduleProps) {
-  const { data, selectedDate } = props;
+  const { data, selectedDate, isChristmasMode = false } = props;
   const todaySchedules = data?.todaySchedules ?? [];
   const currentSchedule =
     todaySchedules.find((s) => s.date === selectedDate) || {
@@ -32,10 +34,10 @@ export function TodaySchedule(props: TodayScheduleProps) {
     .map((s) => `${s.id}:${s.timeLabels?.length ?? 0}`)
     .join('|')}`;
 
-  return <TodayScheduleInner key={scheduleKey} {...props} currentSchedule={currentSchedule} />;
+  return <TodayScheduleInner key={scheduleKey} {...props} currentSchedule={currentSchedule} isChristmasMode={isChristmasMode} />;
 }
 
-function TodayScheduleInner({ data, onUpdate, selectedDate, currentSchedule }: TodayScheduleInnerProps) {
+function TodayScheduleInner({ data, onUpdate, selectedDate, currentSchedule, isChristmasMode }: TodayScheduleInnerProps) {
   const [editingLabelId, setEditingLabelId] = useState<string | null>(null);
 
   const {
@@ -104,17 +106,25 @@ function TodayScheduleInner({ data, onUpdate, selectedDate, currentSchedule }: T
 
   if (!data) {
     return (
-      <div className="rounded-lg bg-white p-6 shadow-md">
-        <p className="text-center text-gray-500">データがありません</p>
+      <div className={`rounded-lg p-6 shadow-md ${
+        isChristmasMode ? 'bg-[#0a2f1a] border border-[#d4af37]/30' : 'bg-white'
+      }`}>
+        <p className={`text-center ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500'}`}>データがありません</p>
       </div>
     );
   }
 
   return (
-    <div className="rounded-2xl bg-white p-4 md:p-6 shadow-xl border-2 border-gray-300 h-full flex flex-col backdrop-blur-sm">
+    <div className={`rounded-2xl p-4 md:p-6 shadow-xl h-full flex flex-col backdrop-blur-sm ${
+      isChristmasMode
+        ? 'bg-[#0a2f1a] border-2 border-[#d4af37]/30'
+        : 'bg-white border-2 border-gray-300'
+    }`}>
       {/* デスクトップ版：タイトルと時間入力欄を横並び */}
       <div className="mb-3 md:mb-4 hidden lg:flex flex-row items-center justify-between gap-2">
-        <h2 className="hidden lg:block text-base md:text-lg font-semibold text-gray-800 whitespace-nowrap">本日のスケジュール</h2>
+        <h2 className={`hidden lg:block text-base md:text-lg font-semibold whitespace-nowrap ${
+          isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'
+        }`}>本日のスケジュール</h2>
         <TimeInputRow
           newHour={newHour}
           newMinute={newMinute}
@@ -123,18 +133,24 @@ function TodayScheduleInner({ data, onUpdate, selectedDate, currentSchedule }: T
           onMinuteChange={handleMinuteInputChange}
           onAdd={addTimeLabel}
           wrapperClassName="flex items-center gap-1.5 md:gap-2 flex-shrink-0"
-          buttonClassName="flex items-center gap-1 md:gap-1.5 rounded-md bg-primary px-2 md:px-3 py-1 md:py-1.5 text-base md:text-base font-medium text-white transition-colors hover:bg-primary-dark shadow-md"
+          isChristmasMode={isChristmasMode}
         />
       </div>
 
       {localTimeLabels.length === 0 ? (
-        <div className="flex-1 flex items-center justify-center text-center text-gray-500">
+        <div className={`flex-1 flex items-center justify-center text-center ${
+          isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500'
+        }`}>
           <div>
             <div className="mb-3 md:mb-5 flex justify-center">
-              <HiClock className="h-12 w-12 md:h-20 md:w-20 text-gray-300" />
+              <HiClock className={`h-12 w-12 md:h-20 md:w-20 ${
+                isChristmasMode ? 'text-[#d4af37]/30' : 'text-gray-300'
+              }`} />
             </div>
             <p className="text-base md:text-lg font-medium">時間ラベルがありません</p>
-            <p className="mt-1.5 md:mt-3 text-base md:text-base text-gray-400">時間を入力して「追加」ボタンから時間ラベルを追加してください</p>
+            <p className={`mt-1.5 md:mt-3 text-base md:text-base ${
+              isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-400'
+            }`}>時間を入力して「追加」ボタンから時間ラベルを追加してください</p>
           </div>
         </div>
       ) : (
@@ -143,12 +159,20 @@ function TodayScheduleInner({ data, onUpdate, selectedDate, currentSchedule }: T
             {groupedTimeLabels.map((group) => (
               <div
                 key={group.time}
-                className="group flex items-baseline gap-3 md:gap-4 py-2.5 md:py-2 px-3 md:px-2.5 rounded-lg bg-gray-50 hover:bg-amber-50 border border-gray-200 hover:border-amber-300 transition-all duration-200"
+                className={`group flex items-baseline gap-3 md:gap-4 py-2.5 md:py-2 px-3 md:px-2.5 rounded-lg border transition-all duration-200 ${
+                  isChristmasMode
+                    ? 'bg-white/5 hover:bg-[#d4af37]/10 border-[#d4af37]/20 hover:border-[#d4af37]/40'
+                    : 'bg-gray-50 hover:bg-amber-50 border-gray-200 hover:border-amber-300'
+                }`}
               >
                 {/* 時間表示 */}
                 <div
                   onClick={() => handleEditGroup(group.time)}
-                  className="flex-shrink-0 w-16 md:w-18 text-center px-2 py-1 bg-white rounded-md text-sm md:text-base font-semibold text-gray-800 group-hover:text-amber-700 group-hover:bg-amber-100 cursor-pointer transition-colors tabular-nums shadow-sm"
+                  className={`flex-shrink-0 w-16 md:w-18 text-center px-2 py-1 rounded-md text-sm md:text-base font-semibold cursor-pointer transition-colors tabular-nums shadow-sm ${
+                    isChristmasMode
+                      ? 'bg-[#d4af37]/20 text-[#d4af37] group-hover:bg-[#d4af37]/30'
+                      : 'bg-white text-gray-800 group-hover:text-amber-700 group-hover:bg-amber-100'
+                  }`}
                 >
                   {group.time || '--:--'}
                 </div>
@@ -164,11 +188,19 @@ function TodayScheduleInner({ data, onUpdate, selectedDate, currentSchedule }: T
                           onChange={(e) => updateTimeLabel(label.id, { content: e.target.value })}
                           onCompositionStart={handleCompositionStart}
                           onCompositionEnd={handleCompositionEnd}
-                          className="flex-1 min-w-0 bg-transparent border-0 border-b border-transparent focus:border-amber-400 text-base md:text-base text-gray-900 focus:outline-none placeholder:text-gray-400 transition-colors py-1"
+                          className={`flex-1 min-w-0 bg-transparent border-0 border-b border-transparent focus:outline-none transition-colors py-1 text-base md:text-base ${
+                            isChristmasMode
+                              ? 'text-[#f8f1e7] focus:border-[#d4af37] placeholder:text-[#f8f1e7]/40'
+                              : 'text-gray-900 focus:border-amber-400 placeholder:text-gray-400'
+                          }`}
                           placeholder="内容を入力"
                         />
                         {label.continuesUntil && (
-                          <span className="text-xs text-amber-600 bg-amber-50 px-2 py-0.5 rounded-full whitespace-nowrap">
+                          <span className={`text-xs px-2 py-0.5 rounded-full whitespace-nowrap ${
+                            isChristmasMode
+                              ? 'text-[#d4af37] bg-[#d4af37]/20'
+                              : 'text-amber-600 bg-amber-50'
+                          }`}>
                             〜{label.continuesUntil}まで
                           </span>
                         )}
@@ -176,8 +208,14 @@ function TodayScheduleInner({ data, onUpdate, selectedDate, currentSchedule }: T
 
                       {label.assignee && (
                         <div className="flex items-center gap-1.5 mt-1 ml-1">
-                          <HiUser className="h-3.5 w-3.5 text-gray-400 flex-shrink-0" />
-                          <span className="text-sm text-gray-500 bg-gray-100 px-2 py-0.5 rounded-full">
+                          <HiUser className={`h-3.5 w-3.5 flex-shrink-0 ${
+                            isChristmasMode ? 'text-[#f8f1e7]/40' : 'text-gray-400'
+                          }`} />
+                          <span className={`text-sm px-2 py-0.5 rounded-full ${
+                            isChristmasMode
+                              ? 'text-[#f8f1e7]/70 bg-white/10'
+                              : 'text-gray-500 bg-gray-100'
+                          }`}>
                             {label.assignee}
                           </span>
                         </div>
@@ -189,11 +227,19 @@ function TodayScheduleInner({ data, onUpdate, selectedDate, currentSchedule }: T
                             .sort((a, b) => a.order - b.order)
                             .map((subTask) => (
                               <div key={subTask.id} className="flex items-start gap-2">
-                                <HiArrowDown className="h-4 w-4 text-gray-400 flex-shrink-0 mt-0.5" />
+                                <HiArrowDown className={`h-4 w-4 flex-shrink-0 mt-0.5 ${
+                                  isChristmasMode ? 'text-[#f8f1e7]/40' : 'text-gray-400'
+                                }`} />
                                 <div className="flex-1">
-                                  <span className="text-sm text-gray-700">{subTask.content}</span>
+                                  <span className={`text-sm ${
+                                    isChristmasMode ? 'text-[#f8f1e7]/80' : 'text-gray-700'
+                                  }`}>{subTask.content}</span>
                                   {subTask.assignee && (
-                                    <span className="ml-2 text-xs text-gray-500 bg-gray-100 px-1.5 py-0.5 rounded-full">
+                                    <span className={`ml-2 text-xs px-1.5 py-0.5 rounded-full ${
+                                      isChristmasMode
+                                        ? 'text-[#f8f1e7]/60 bg-white/10'
+                                        : 'text-gray-500 bg-gray-100'
+                                    }`}>
                                       {subTask.assignee}
                                     </span>
                                   )}
@@ -216,8 +262,7 @@ function TodayScheduleInner({ data, onUpdate, selectedDate, currentSchedule }: T
               onMinuteChange={handleMinuteInputChange}
               onAdd={addTimeLabel}
               wrapperClassName="mt-3 md:mt-4 flex lg:hidden items-center justify-center gap-1.5 md:gap-2 pb-2"
-              buttonClassName="flex items-center justify-center gap-1 md:gap-1.5 rounded-md bg-primary px-2 md:px-3 py-1 md:py-1.5 text-base md:text-base font-medium text-white transition-colors hover:bg-primary-dark shadow-md min-w-[44px] min-h-[44px]"
-              labelClassName="hidden sm:inline"
+              isChristmasMode={isChristmasMode}
             />
           </div>
         </div>
@@ -233,8 +278,7 @@ function TodayScheduleInner({ data, onUpdate, selectedDate, currentSchedule }: T
           onMinuteChange={handleMinuteInputChange}
           onAdd={addTimeLabel}
           wrapperClassName="mt-3 md:mt-4 flex lg:hidden items-center justify-center gap-1.5 md:gap-2"
-          buttonClassName="flex items-center justify-center gap-1 md:gap-1.5 rounded-md bg-primary px-2 md:px-3 py-1 md:py-1.5 text-sm md:text-base font-medium text-white transition-colors hover:bg-primary-dark shadow-md min-w-[44px] min-h-[44px]"
-          labelClassName="hidden sm:inline"
+          isChristmasMode={isChristmasMode}
         />
       )}
 

--- a/components/ocr-confirm/OCRConfirmModal.tsx
+++ b/components/ocr-confirm/OCRConfirmModal.tsx
@@ -8,6 +8,8 @@ import { OCRRoastScheduleEditor } from '../OCRRoastScheduleEditor';
 import { useToastContext } from '../Toast';
 import { sortTimeLabels, sortRoastSchedules } from './OCRConfirmHelpers';
 import type { TabType } from './OCRConfirmHelpers';
+import { useChristmasMode } from '@/hooks/useChristmasMode';
+import { Button, IconButton } from '@/components/ui';
 
 interface OCRConfirmModalProps {
   timeLabels: TimeLabel[];
@@ -31,6 +33,7 @@ export function OCRConfirmModal({
   onRetry,
 }: OCRConfirmModalProps) {
   const { showToast } = useToastContext();
+  const { isChristmasMode } = useChristmasMode();
   const [activeTab, setActiveTab] = useState<TabType>('timeLabels');
   const [mode, setMode] = useState<'replace' | 'add'>('replace');
   const [timeLabels, setTimeLabels] = useState<TimeLabel[]>(() =>
@@ -131,65 +134,84 @@ export function OCRConfirmModal({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <div className="bg-white rounded-lg shadow-xl max-w-4xl w-full mx-4 flex flex-col max-h-[90vh]">
+      <div className={`rounded-lg shadow-xl max-w-4xl w-full mx-4 flex flex-col max-h-[90vh] ${
+        isChristmasMode
+          ? 'bg-[#0a2f1a] border border-[#d4af37]/30'
+          : 'bg-white'
+      }`}>
         {/* ヘッダー */}
-        <div className="flex items-center justify-between p-4 sm:p-6 border-b border-gray-200 flex-shrink-0">
-          <h2 className="text-lg sm:text-xl font-bold text-gray-800">
+        <div className={`flex items-center justify-between p-4 sm:p-6 border-b flex-shrink-0 ${
+          isChristmasMode ? 'border-[#d4af37]/20' : 'border-gray-200'
+        }`}>
+          <h2 className={`text-lg sm:text-xl font-bold ${
+            isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'
+          }`}>
             読み取り結果の確認
           </h2>
-          <button
+          <IconButton
+            variant="ghost"
+            size="md"
             onClick={onCancel}
-            className="p-2 hover:bg-gray-100 rounded-full transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
+            isChristmasMode={isChristmasMode}
+            rounded
             aria-label="閉じる"
           >
-            <HiX className="h-5 w-5 sm:h-6 sm:w-6 text-gray-600" />
-          </button>
+            <HiX className="h-5 w-5 sm:h-6 sm:w-6" />
+          </IconButton>
         </div>
 
         {/* モード選択 */}
         {hasExistingData && (
-          <div className="px-4 sm:px-6 py-3 border-b border-gray-200 flex-shrink-0">
+          <div className={`px-4 sm:px-6 py-3 border-b flex-shrink-0 ${
+            isChristmasMode ? 'border-[#d4af37]/20' : 'border-gray-200'
+          }`}>
             <div className="flex items-center gap-4">
-              <span className="text-sm font-medium text-gray-700">適用方法:</span>
+              <span className={`text-sm font-medium ${
+                isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'
+              }`}>適用方法:</span>
               <div className="flex gap-2">
-                <button
+                <Button
+                  variant={mode === 'replace' ? 'primary' : 'ghost'}
+                  size="sm"
                   onClick={() => setMode('replace')}
-                  className={`px-4 py-2 rounded-md text-sm font-medium transition-colors min-h-[44px] ${
-                    mode === 'replace'
-                      ? 'bg-amber-600 text-white'
-                      : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                  }`}
+                  isChristmasMode={isChristmasMode}
                 >
                   置き換え
-                </button>
-                <button
+                </Button>
+                <Button
+                  variant={mode === 'add' ? 'primary' : 'ghost'}
+                  size="sm"
                   onClick={() => setMode('add')}
-                  className={`px-4 py-2 rounded-md text-sm font-medium transition-colors min-h-[44px] ${
-                    mode === 'add'
-                      ? 'bg-amber-600 text-white'
-                      : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                  }`}
+                  isChristmasMode={isChristmasMode}
                 >
                   追加
-                </button>
+                </Button>
               </div>
             </div>
           </div>
         )}
 
         {/* タブ */}
-        <div className="flex border-b border-gray-200 flex-shrink-0">
+        <div className={`flex border-b flex-shrink-0 ${
+          isChristmasMode ? 'border-[#d4af37]/20' : 'border-gray-200'
+        }`}>
           <button
             onClick={() => setActiveTab('timeLabels')}
             className={`flex-1 px-4 py-3 text-sm font-medium transition-colors min-h-[44px] flex items-center justify-center gap-2 ${
               activeTab === 'timeLabels'
-                ? 'bg-amber-50 text-amber-700 border-b-2 border-amber-600'
-                : 'bg-white text-gray-600 hover:bg-gray-50'
+                ? isChristmasMode
+                  ? 'bg-[#d4af37]/20 text-[#d4af37] border-b-2 border-[#d4af37]'
+                  : 'bg-amber-50 text-amber-700 border-b-2 border-amber-600'
+                : isChristmasMode
+                  ? 'bg-transparent text-[#f8f1e7]/70 hover:bg-white/5'
+                  : 'bg-white text-gray-600 hover:bg-gray-50'
             }`}
           >
             <HiClock className="h-5 w-5" />
             <span>本日のスケジュール</span>
-            <span className="bg-gray-200 text-gray-700 rounded-full px-2 py-0.5 text-xs">
+            <span className={`rounded-full px-2 py-0.5 text-xs ${
+              isChristmasMode ? 'bg-[#d4af37]/30 text-[#f8f1e7]' : 'bg-gray-200 text-gray-700'
+            }`}>
               {timeLabels.length}
             </span>
           </button>
@@ -197,13 +219,19 @@ export function OCRConfirmModal({
             onClick={() => setActiveTab('roastSchedules')}
             className={`flex-1 px-4 py-3 text-sm font-medium transition-colors min-h-[44px] flex items-center justify-center gap-2 ${
               activeTab === 'roastSchedules'
-                ? 'bg-amber-50 text-amber-700 border-b-2 border-amber-600'
-                : 'bg-white text-gray-600 hover:bg-gray-50'
+                ? isChristmasMode
+                  ? 'bg-[#d4af37]/20 text-[#d4af37] border-b-2 border-[#d4af37]'
+                  : 'bg-amber-50 text-amber-700 border-b-2 border-amber-600'
+                : isChristmasMode
+                  ? 'bg-transparent text-[#f8f1e7]/70 hover:bg-white/5'
+                  : 'bg-white text-gray-600 hover:bg-gray-50'
             }`}
           >
             <HiFire className="h-5 w-5" />
             <span>ローストスケジュール</span>
-            <span className="bg-gray-200 text-gray-700 rounded-full px-2 py-0.5 text-xs">
+            <span className={`rounded-full px-2 py-0.5 text-xs ${
+              isChristmasMode ? 'bg-[#d4af37]/30 text-[#f8f1e7]' : 'bg-gray-200 text-gray-700'
+            }`}>
               {roastSchedules.length}
             </span>
           </button>
@@ -218,6 +246,7 @@ export function OCRConfirmModal({
               onDelete={(id) => {
                 setTimeLabels(timeLabels.filter((label) => label.id !== id));
               }}
+              isChristmasMode={isChristmasMode}
             />
           ) : (
             <OCRRoastScheduleEditor
@@ -227,32 +256,41 @@ export function OCRConfirmModal({
               onDelete={(id) => {
                 setRoastSchedules(roastSchedules.filter((schedule) => schedule.id !== id));
               }}
+              isChristmasMode={isChristmasMode}
             />
           )}
         </div>
 
         {/* フッター */}
-        <div className="flex items-center justify-between p-4 sm:p-6 border-t border-gray-200 gap-3 flex-shrink-0">
-          <button
+        <div className={`flex items-center justify-between p-4 sm:p-6 border-t gap-3 flex-shrink-0 ${
+          isChristmasMode ? 'border-[#d4af37]/20' : 'border-gray-200'
+        }`}>
+          <Button
+            variant="ghost"
+            size="md"
             onClick={onRetry}
-            className="px-4 py-2 text-gray-600 hover:text-gray-800 font-medium transition-colors min-h-[44px]"
+            isChristmasMode={isChristmasMode}
             aria-label="再解析"
           >
             再解析
-          </button>
+          </Button>
           <div className="flex gap-2">
-            <button
+            <Button
+              variant="secondary"
+              size="md"
               onClick={onCancel}
-              className="px-4 py-2 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300 transition-colors font-medium min-h-[44px]"
+              isChristmasMode={isChristmasMode}
             >
               キャンセル
-            </button>
-            <button
+            </Button>
+            <Button
+              variant="primary"
+              size="md"
               onClick={handleSave}
-              className="px-4 sm:px-6 py-2 bg-amber-600 text-white rounded-md hover:bg-amber-700 transition-colors font-medium min-h-[44px]"
+              isChristmasMode={isChristmasMode}
             >
               保存
-            </button>
+            </Button>
           </div>
         </div>
       </div>

--- a/components/ocr-time-label-editor/OCRTimeLabelEditor.tsx
+++ b/components/ocr-time-label-editor/OCRTimeLabelEditor.tsx
@@ -4,24 +4,29 @@ import type { TimeLabel } from '@/types';
 import { HiPlus } from 'react-icons/hi';
 import { useOCRTimeLabelEditor } from './useOCRTimeLabelEditor';
 import { TimeLabelRow } from './TimeLabelRow';
+import { Button } from '@/components/ui';
 
 interface OCRTimeLabelEditorProps {
   timeLabels: TimeLabel[];
   onUpdate: (timeLabels: TimeLabel[]) => void;
   onDelete: (id: string) => void;
+  isChristmasMode?: boolean;
 }
 
 export function OCRTimeLabelEditor({
   timeLabels,
   onUpdate,
   onDelete,
+  isChristmasMode = false,
 }: OCRTimeLabelEditorProps) {
   const editor = useOCRTimeLabelEditor({ timeLabels, onUpdate });
 
   return (
     <div className="space-y-3">
       {editor.sortedLabels.length === 0 ? (
-        <div className="text-center text-gray-500 py-8">
+        <div className={`text-center py-8 ${
+          isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'
+        }`}>
           <p>スケジュールがありません</p>
         </div>
       ) : (
@@ -32,18 +37,22 @@ export function OCRTimeLabelEditor({
             isEditing={editor.editingId === label.id}
             editor={editor}
             onDelete={onDelete}
+            isChristmasMode={isChristmasMode}
           />
         ))
       )}
 
       {/* 追加ボタン */}
-      <button
+      <Button
         onClick={editor.handleAdd}
-        className="w-full px-4 py-3 bg-primary text-white rounded-lg hover:bg-primary-dark transition-colors flex items-center justify-center gap-2 min-h-[44px] shadow-md"
+        variant="primary"
+        size="lg"
+        className="w-full"
+        isChristmasMode={isChristmasMode}
       >
         <HiPlus className="h-5 w-5" />
         <span>スケジュールを追加</span>
-      </button>
+      </Button>
     </div>
   );
 }

--- a/components/ocr-time-label-editor/TimeLabelRow.tsx
+++ b/components/ocr-time-label-editor/TimeLabelRow.tsx
@@ -3,15 +3,17 @@
 import type { TimeLabel } from '@/types';
 import { HiPlus, HiTrash, HiPencil, HiUser, HiArrowDown } from 'react-icons/hi';
 import type { useOCRTimeLabelEditor } from './useOCRTimeLabelEditor';
+import { Button, IconButton } from '@/components/ui';
 
 interface TimeLabelRowProps {
   label: TimeLabel;
   isEditing: boolean;
   editor: ReturnType<typeof useOCRTimeLabelEditor>;
   onDelete: (id: string) => void;
+  isChristmasMode?: boolean;
 }
 
-export function TimeLabelRow({ label, isEditing, editor, onDelete }: TimeLabelRowProps) {
+export function TimeLabelRow({ label, isEditing, editor, onDelete, isChristmasMode = false }: TimeLabelRowProps) {
   const {
     editingTime,
     setEditingTime,
@@ -32,15 +34,34 @@ export function TimeLabelRow({ label, isEditing, editor, onDelete }: TimeLabelRo
     handleUpdateSubTask,
   } = editor;
 
+  // クリスマスモード用のスタイル定義
+  const labelClass = `block text-sm font-medium mb-1 ${
+    isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'
+  }`;
+  const inputClass = `w-full rounded-md border px-3 py-2 text-base focus:outline-none focus:ring-2 ${
+    isChristmasMode
+      ? 'border-[#d4af37]/40 bg-white/10 text-[#f8f1e7] placeholder:text-[#f8f1e7]/40 focus:border-[#d4af37] focus:ring-[#d4af37]/50'
+      : 'border-gray-300 text-gray-900 focus:border-amber-500 focus:ring-amber-500'
+  }`;
+  const timeInputClass = `w-20 rounded-md border px-3 py-2 text-base text-center focus:outline-none focus:ring-2 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${
+    isChristmasMode
+      ? 'border-[#d4af37]/40 bg-white/10 text-[#f8f1e7] placeholder:text-[#f8f1e7]/40 focus:border-[#d4af37] focus:ring-[#d4af37]/50'
+      : 'border-gray-300 text-gray-900 focus:border-amber-500 focus:ring-amber-500'
+  }`;
+
   return (
     <div
-      className="border border-gray-200 rounded-lg p-4 bg-white hover:bg-gray-50 transition-colors"
+      className={`border rounded-lg p-4 transition-colors ${
+        isChristmasMode
+          ? 'border-[#d4af37]/30 bg-[#0a2f1a] hover:bg-[#0a2f1a]/80'
+          : 'border-gray-200 bg-white hover:bg-gray-50'
+      }`}
     >
       {isEditing ? (
         <div className="space-y-3">
           {/* 時間編集 */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label className={labelClass}>
               時間 <span className="text-red-500">*</span>
             </label>
             <div className="flex items-center gap-2">
@@ -56,10 +77,10 @@ export function TimeLabelRow({ label, isEditing, editor, onDelete }: TimeLabelRo
                 min="0"
                 max="23"
                 required
-                className="w-20 rounded-md border border-gray-300 px-3 py-2 text-base text-gray-900 text-center focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                className={timeInputClass}
                 placeholder="時"
               />
-              <span className="text-gray-600">:</span>
+              <span className={isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}>:</span>
               <input
                 type="number"
                 value={editingTime.minute}
@@ -71,7 +92,7 @@ export function TimeLabelRow({ label, isEditing, editor, onDelete }: TimeLabelRo
                 }}
                 min="0"
                 max="59"
-                className="w-20 rounded-md border border-gray-300 px-3 py-2 text-base text-gray-900 text-center focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                className={timeInputClass}
                 placeholder="分"
               />
             </div>
@@ -79,35 +100,31 @@ export function TimeLabelRow({ label, isEditing, editor, onDelete }: TimeLabelRo
 
           {/* 内容編集 */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              内容
-            </label>
+            <label className={labelClass}>内容</label>
             <input
               type="text"
               value={editingContent}
               onChange={(e) => setEditingContent(e.target.value)}
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-base text-gray-900 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500"
+              className={inputClass}
               placeholder="内容を入力"
             />
           </div>
 
           {/* メモ編集 */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              メモ
-            </label>
+            <label className={labelClass}>メモ</label>
             <textarea
               value={editingMemo}
               onChange={(e) => setEditingMemo(e.target.value)}
               rows={2}
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-base text-gray-900 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500 resize-none"
+              className={`${inputClass} resize-none`}
               placeholder="メモを入力"
             />
           </div>
 
           {/* 担当者編集 */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label className={labelClass}>
               <span className="flex items-center gap-1.5">
                 <HiUser className="h-4 w-4" />
                 担当者
@@ -117,18 +134,18 @@ export function TimeLabelRow({ label, isEditing, editor, onDelete }: TimeLabelRo
               type="text"
               value={editingAssignee}
               onChange={(e) => setEditingAssignee(e.target.value)}
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-base text-gray-900 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500"
+              className={inputClass}
               placeholder="例：浅田さん、小山さん"
             />
           </div>
 
           {/* 継続終了時間編集 */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label className={labelClass}>
               継続終了時間（時間経過タスクの場合）
             </label>
             <div className="flex items-center gap-2">
-              <span className="text-gray-500 text-sm">〜</span>
+              <span className={`text-sm ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'}`}>〜</span>
               <input
                 type="number"
                 value={editingContinuesUntil.hour}
@@ -140,10 +157,10 @@ export function TimeLabelRow({ label, isEditing, editor, onDelete }: TimeLabelRo
                 }}
                 min="0"
                 max="23"
-                className="w-20 rounded-md border border-gray-300 px-3 py-2 text-base text-gray-900 text-center focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                className={timeInputClass}
                 placeholder="時"
               />
-              <span className="text-gray-600">:</span>
+              <span className={isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}>:</span>
               <input
                 type="number"
                 value={editingContinuesUntil.minute}
@@ -155,26 +172,27 @@ export function TimeLabelRow({ label, isEditing, editor, onDelete }: TimeLabelRo
                 }}
                 min="0"
                 max="59"
-                className="w-20 rounded-md border border-gray-300 px-3 py-2 text-base text-gray-900 text-center focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                className={timeInputClass}
                 placeholder="分"
               />
-              <span className="text-gray-500 text-sm">まで</span>
+              <span className={`text-sm ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'}`}>まで</span>
               {editingContinuesUntil.hour && (
-                <button
-                  type="button"
+                <IconButton
+                  variant="ghost"
+                  size="sm"
                   onClick={() => setEditingContinuesUntil({ hour: '', minute: '' })}
-                  className="p-1 text-gray-400 hover:text-red-500 transition-colors"
+                  isChristmasMode={isChristmasMode}
                   aria-label="継続終了時間をクリア"
                 >
                   <HiTrash className="h-4 w-4" />
-                </button>
+                </IconButton>
               )}
             </div>
           </div>
 
           {/* サブタスク編集 */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
+            <label className={`${labelClass} mb-2`}>
               <span className="flex items-center gap-1.5">
                 <HiArrowDown className="h-4 w-4" />
                 連続タスク（サブタスク）
@@ -182,75 +200,100 @@ export function TimeLabelRow({ label, isEditing, editor, onDelete }: TimeLabelRo
             </label>
             <div className="space-y-2 ml-4">
               {editingSubTasks.map((subTask) => (
-                <div key={subTask.id} className="flex items-start gap-2 p-2 bg-gray-50 rounded-md">
-                  <span className="text-gray-400 text-sm mt-2">↓</span>
+                <div key={subTask.id} className={`flex items-start gap-2 p-2 rounded-md ${
+                  isChristmasMode ? 'bg-white/5' : 'bg-gray-50'
+                }`}>
+                  <span className={`text-sm mt-2 ${isChristmasMode ? 'text-[#f8f1e7]/40' : 'text-gray-400'}`}>↓</span>
                   <div className="flex-1 space-y-2">
                     <input
                       type="text"
                       value={subTask.content}
                       onChange={(e) => handleUpdateSubTask(subTask.id, { content: e.target.value })}
-                      className="w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-900 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500"
+                      className={`w-full rounded-md border px-3 py-1.5 text-sm focus:outline-none focus:ring-2 ${
+                        isChristmasMode
+                          ? 'border-[#d4af37]/40 bg-white/10 text-[#f8f1e7] placeholder:text-[#f8f1e7]/40 focus:border-[#d4af37] focus:ring-[#d4af37]/50'
+                          : 'border-gray-300 text-gray-900 focus:border-amber-500 focus:ring-amber-500'
+                      }`}
                       placeholder="タスク内容"
                     />
                     <input
                       type="text"
                       value={subTask.assignee || ''}
                       onChange={(e) => handleUpdateSubTask(subTask.id, { assignee: e.target.value || undefined })}
-                      className="w-full rounded-md border border-gray-200 px-3 py-1 text-xs text-gray-700 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500"
+                      className={`w-full rounded-md border px-3 py-1 text-xs focus:outline-none focus:ring-2 ${
+                        isChristmasMode
+                          ? 'border-[#d4af37]/30 bg-white/5 text-[#f8f1e7]/70 placeholder:text-[#f8f1e7]/30 focus:border-[#d4af37] focus:ring-[#d4af37]/50'
+                          : 'border-gray-200 text-gray-700 focus:border-amber-500 focus:ring-amber-500'
+                      }`}
                       placeholder="担当者（任意）"
                     />
                   </div>
-                  <button
-                    type="button"
+                  <IconButton
+                    variant="ghost"
+                    size="sm"
                     onClick={() => handleDeleteSubTask(subTask.id)}
-                    className="p-1.5 text-red-500 hover:bg-red-50 rounded transition-colors mt-1"
+                    isChristmasMode={isChristmasMode}
+                    className="text-red-500 mt-1"
                     aria-label="サブタスクを削除"
                   >
                     <HiTrash className="h-4 w-4" />
-                  </button>
+                  </IconButton>
                 </div>
               ))}
-              <button
-                type="button"
+              <Button
+                variant="ghost"
+                size="sm"
                 onClick={handleAddSubTask}
-                className="flex items-center gap-1.5 text-sm text-amber-600 hover:text-amber-700 transition-colors py-1"
+                isChristmasMode={isChristmasMode}
               >
                 <HiPlus className="h-4 w-4" />
                 サブタスクを追加
-              </button>
+              </Button>
             </div>
           </div>
 
           {/* 編集ボタン */}
           <div className="flex gap-2 justify-end">
-            <button
+            <Button
+              variant="secondary"
+              size="sm"
               onClick={handleCancel}
-              className="px-3 py-2 text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors text-sm font-medium min-h-[44px]"
+              isChristmasMode={isChristmasMode}
             >
               キャンセル
-            </button>
-            <button
+            </Button>
+            <Button
+              variant="primary"
+              size="sm"
               onClick={() => handleSave(label.id)}
               disabled={!editingTime.hour}
-              className="px-3 py-2 bg-amber-600 text-white rounded-md hover:bg-amber-700 transition-colors text-sm font-medium min-h-[44px] disabled:bg-gray-300 disabled:cursor-not-allowed"
+              isChristmasMode={isChristmasMode}
             >
               保存
-            </button>
+            </Button>
           </div>
         </div>
       ) : (
         <div className="flex items-start justify-between gap-4">
           <div className="flex-1">
             <div className="flex items-center gap-3 mb-2">
-              <span className="text-lg font-semibold text-gray-900">
+              <span className={`text-lg font-semibold ${
+                isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-900'
+              }`}>
                 {label.time || '--:--'}
               </span>
               {label.content && (
-                <span className="text-base text-gray-700">{label.content}</span>
+                <span className={`text-base ${
+                  isChristmasMode ? 'text-[#f8f1e7]/80' : 'text-gray-700'
+                }`}>{label.content}</span>
               )}
               {/* 継続終了時間 */}
               {label.continuesUntil && (
-                <span className="text-xs text-amber-600 bg-amber-50 px-2 py-0.5 rounded-full">
+                <span className={`text-xs px-2 py-0.5 rounded-full ${
+                  isChristmasMode
+                    ? 'text-[#d4af37] bg-[#d4af37]/20'
+                    : 'text-amber-600 bg-amber-50'
+                }`}>
                   〜{label.continuesUntil}まで
                 </span>
               )}
@@ -258,26 +301,44 @@ export function TimeLabelRow({ label, isEditing, editor, onDelete }: TimeLabelRo
             {/* 担当者表示 */}
             {label.assignee && (
               <div className="flex items-center gap-1.5 mb-2">
-                <HiUser className="h-3.5 w-3.5 text-gray-400" />
-                <span className="text-sm text-gray-500 bg-gray-100 px-2 py-0.5 rounded-full">
+                <HiUser className={`h-3.5 w-3.5 ${
+                  isChristmasMode ? 'text-[#f8f1e7]/40' : 'text-gray-400'
+                }`} />
+                <span className={`text-sm px-2 py-0.5 rounded-full ${
+                  isChristmasMode
+                    ? 'text-[#f8f1e7]/70 bg-white/10'
+                    : 'text-gray-500 bg-gray-100'
+                }`}>
                   {label.assignee}
                 </span>
               </div>
             )}
             {label.memo && (
-              <p className="text-sm text-gray-600 whitespace-pre-wrap mb-2">{label.memo}</p>
+              <p className={`text-sm whitespace-pre-wrap mb-2 ${
+                isChristmasMode ? 'text-[#f8f1e7]/60' : 'text-gray-600'
+              }`}>{label.memo}</p>
             )}
             {/* サブタスク表示 */}
             {label.subTasks && label.subTasks.length > 0 && (
-              <div className="ml-4 space-y-1 border-l-2 border-gray-200 pl-3">
+              <div className={`ml-4 space-y-1 border-l-2 pl-3 ${
+                isChristmasMode ? 'border-[#d4af37]/30' : 'border-gray-200'
+              }`}>
                 {label.subTasks
                   .sort((a, b) => a.order - b.order)
                   .map((subTask) => (
                     <div key={subTask.id} className="flex items-center gap-2">
-                      <HiArrowDown className="h-3.5 w-3.5 text-gray-400 flex-shrink-0" />
-                      <span className="text-sm text-gray-700">{subTask.content}</span>
+                      <HiArrowDown className={`h-3.5 w-3.5 flex-shrink-0 ${
+                        isChristmasMode ? 'text-[#f8f1e7]/40' : 'text-gray-400'
+                      }`} />
+                      <span className={`text-sm ${
+                        isChristmasMode ? 'text-[#f8f1e7]/80' : 'text-gray-700'
+                      }`}>{subTask.content}</span>
                       {subTask.assignee && (
-                        <span className="text-xs text-gray-500 bg-gray-100 px-1.5 py-0.5 rounded-full">
+                        <span className={`text-xs px-1.5 py-0.5 rounded-full ${
+                          isChristmasMode
+                            ? 'text-[#f8f1e7]/60 bg-white/10'
+                            : 'text-gray-500 bg-gray-100'
+                        }`}>
                           {subTask.assignee}
                         </span>
                       )}
@@ -287,20 +348,25 @@ export function TimeLabelRow({ label, isEditing, editor, onDelete }: TimeLabelRo
             )}
           </div>
           <div className="flex gap-2">
-            <button
+            <IconButton
+              variant="ghost"
+              size="md"
               onClick={() => handleEdit(label)}
-              className="p-2 text-gray-600 hover:bg-gray-100 rounded-md transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
+              isChristmasMode={isChristmasMode}
               aria-label="編集"
             >
               <HiPencil className="h-5 w-5" />
-            </button>
-            <button
+            </IconButton>
+            <IconButton
+              variant="ghost"
+              size="md"
               onClick={() => onDelete(label.id)}
-              className="p-2 text-red-600 hover:bg-red-50 rounded-md transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
+              isChristmasMode={isChristmasMode}
+              className="text-red-500"
               aria-label="削除"
             >
               <HiTrash className="h-5 w-5" />
-            </button>
+            </IconButton>
           </div>
         </div>
       )}

--- a/components/ocr-time-label-editor/TimeLabelRow.tsx
+++ b/components/ocr-time-label-editor/TimeLabelRow.tsx
@@ -3,7 +3,7 @@
 import type { TimeLabel } from '@/types';
 import { HiPlus, HiTrash, HiPencil, HiUser, HiArrowDown } from 'react-icons/hi';
 import type { useOCRTimeLabelEditor } from './useOCRTimeLabelEditor';
-import { Button, IconButton } from '@/components/ui';
+import { Button, IconButton, Input, NumberInput, Textarea } from '@/components/ui';
 
 interface TimeLabelRowProps {
   label: TimeLabel;
@@ -38,16 +38,6 @@ export function TimeLabelRow({ label, isEditing, editor, onDelete, isChristmasMo
   const labelClass = `block text-sm font-medium mb-1 ${
     isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'
   }`;
-  const inputClass = `w-full rounded-md border px-3 py-2 text-base focus:outline-none focus:ring-2 ${
-    isChristmasMode
-      ? 'border-[#d4af37]/40 bg-white/10 text-[#f8f1e7] placeholder:text-[#f8f1e7]/40 focus:border-[#d4af37] focus:ring-[#d4af37]/50'
-      : 'border-gray-300 text-gray-900 focus:border-amber-500 focus:ring-amber-500'
-  }`;
-  const timeInputClass = `w-20 rounded-md border px-3 py-2 text-base text-center focus:outline-none focus:ring-2 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${
-    isChristmasMode
-      ? 'border-[#d4af37]/40 bg-white/10 text-[#f8f1e7] placeholder:text-[#f8f1e7]/40 focus:border-[#d4af37] focus:ring-[#d4af37]/50'
-      : 'border-gray-300 text-gray-900 focus:border-amber-500 focus:ring-amber-500'
-  }`;
 
   return (
     <div
@@ -65,8 +55,7 @@ export function TimeLabelRow({ label, isEditing, editor, onDelete, isChristmasMo
               時間 <span className="text-red-500">*</span>
             </label>
             <div className="flex items-center gap-2">
-              <input
-                type="number"
+              <NumberInput
                 value={editingTime.hour}
                 onChange={(e) => {
                   const value = e.target.value;
@@ -74,15 +63,15 @@ export function TimeLabelRow({ label, isEditing, editor, onDelete, isChristmasMo
                     setEditingTime({ ...editingTime, hour: value });
                   }
                 }}
-                min="0"
-                max="23"
+                min={0}
+                max={23}
                 required
-                className={timeInputClass}
                 placeholder="時"
+                isChristmasMode={isChristmasMode}
+                className="w-20 text-center"
               />
               <span className={isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}>:</span>
-              <input
-                type="number"
+              <NumberInput
                 value={editingTime.minute}
                 onChange={(e) => {
                   const value = e.target.value;
@@ -90,35 +79,35 @@ export function TimeLabelRow({ label, isEditing, editor, onDelete, isChristmasMo
                     setEditingTime({ ...editingTime, minute: value });
                   }
                 }}
-                min="0"
-                max="59"
-                className={timeInputClass}
+                min={0}
+                max={59}
                 placeholder="分"
+                isChristmasMode={isChristmasMode}
+                className="w-20 text-center"
               />
             </div>
           </div>
 
           {/* 内容編集 */}
           <div>
-            <label className={labelClass}>内容</label>
-            <input
-              type="text"
+            <Input
+              label="内容"
               value={editingContent}
               onChange={(e) => setEditingContent(e.target.value)}
-              className={inputClass}
               placeholder="内容を入力"
+              isChristmasMode={isChristmasMode}
             />
           </div>
 
           {/* メモ編集 */}
           <div>
-            <label className={labelClass}>メモ</label>
-            <textarea
+            <Textarea
+              label="メモ"
               value={editingMemo}
               onChange={(e) => setEditingMemo(e.target.value)}
               rows={2}
-              className={`${inputClass} resize-none`}
               placeholder="メモを入力"
+              isChristmasMode={isChristmasMode}
             />
           </div>
 
@@ -130,12 +119,11 @@ export function TimeLabelRow({ label, isEditing, editor, onDelete, isChristmasMo
                 担当者
               </span>
             </label>
-            <input
-              type="text"
+            <Input
               value={editingAssignee}
               onChange={(e) => setEditingAssignee(e.target.value)}
-              className={inputClass}
               placeholder="例：浅田さん、小山さん"
+              isChristmasMode={isChristmasMode}
             />
           </div>
 
@@ -146,8 +134,7 @@ export function TimeLabelRow({ label, isEditing, editor, onDelete, isChristmasMo
             </label>
             <div className="flex items-center gap-2">
               <span className={`text-sm ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'}`}>〜</span>
-              <input
-                type="number"
+              <NumberInput
                 value={editingContinuesUntil.hour}
                 onChange={(e) => {
                   const value = e.target.value;
@@ -155,14 +142,14 @@ export function TimeLabelRow({ label, isEditing, editor, onDelete, isChristmasMo
                     setEditingContinuesUntil({ ...editingContinuesUntil, hour: value });
                   }
                 }}
-                min="0"
-                max="23"
-                className={timeInputClass}
+                min={0}
+                max={23}
                 placeholder="時"
+                isChristmasMode={isChristmasMode}
+                className="w-20 text-center"
               />
               <span className={isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}>:</span>
-              <input
-                type="number"
+              <NumberInput
                 value={editingContinuesUntil.minute}
                 onChange={(e) => {
                   const value = e.target.value;
@@ -170,10 +157,11 @@ export function TimeLabelRow({ label, isEditing, editor, onDelete, isChristmasMo
                     setEditingContinuesUntil({ ...editingContinuesUntil, minute: value });
                   }
                 }}
-                min="0"
-                max="59"
-                className={timeInputClass}
+                min={0}
+                max={59}
                 placeholder="分"
+                isChristmasMode={isChristmasMode}
+                className="w-20 text-center"
               />
               <span className={`text-sm ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'}`}>まで</span>
               {editingContinuesUntil.hour && (
@@ -205,27 +193,19 @@ export function TimeLabelRow({ label, isEditing, editor, onDelete, isChristmasMo
                 }`}>
                   <span className={`text-sm mt-2 ${isChristmasMode ? 'text-[#f8f1e7]/40' : 'text-gray-400'}`}>↓</span>
                   <div className="flex-1 space-y-2">
-                    <input
-                      type="text"
+                    <Input
                       value={subTask.content}
                       onChange={(e) => handleUpdateSubTask(subTask.id, { content: e.target.value })}
-                      className={`w-full rounded-md border px-3 py-1.5 text-sm focus:outline-none focus:ring-2 ${
-                        isChristmasMode
-                          ? 'border-[#d4af37]/40 bg-white/10 text-[#f8f1e7] placeholder:text-[#f8f1e7]/40 focus:border-[#d4af37] focus:ring-[#d4af37]/50'
-                          : 'border-gray-300 text-gray-900 focus:border-amber-500 focus:ring-amber-500'
-                      }`}
                       placeholder="タスク内容"
+                      isChristmasMode={isChristmasMode}
+                      className="!py-1.5 !text-sm"
                     />
-                    <input
-                      type="text"
+                    <Input
                       value={subTask.assignee || ''}
                       onChange={(e) => handleUpdateSubTask(subTask.id, { assignee: e.target.value || undefined })}
-                      className={`w-full rounded-md border px-3 py-1 text-xs focus:outline-none focus:ring-2 ${
-                        isChristmasMode
-                          ? 'border-[#d4af37]/30 bg-white/5 text-[#f8f1e7]/70 placeholder:text-[#f8f1e7]/30 focus:border-[#d4af37] focus:ring-[#d4af37]/50'
-                          : 'border-gray-200 text-gray-700 focus:border-amber-500 focus:ring-amber-500'
-                      }`}
                       placeholder="担当者（任意）"
+                      isChristmasMode={isChristmasMode}
+                      className="!py-1 !text-xs"
                     />
                   </div>
                   <IconButton

--- a/components/roast-scheduler/RoastFields.tsx
+++ b/components/roast-scheduler/RoastFields.tsx
@@ -5,13 +5,36 @@ interface RoastFieldsProps {
   bagCount: 1 | 2 | '';
   onRoastCountChange: (value: string) => void;
   onBagCountChange: (value: 1 | 2 | '') => void;
+  isChristmasMode?: boolean;
 }
 
-export function RoastFields({ roastCount, bagCount, onRoastCountChange, onBagCountChange }: RoastFieldsProps) {
+export function RoastFields({
+  roastCount,
+  bagCount,
+  onRoastCountChange,
+  onBagCountChange,
+  isChristmasMode = false,
+}: RoastFieldsProps) {
+  const labelClass = `mb-1 md:mb-2 block text-base md:text-lg font-medium ${
+    isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'
+  }`;
+  const inputClass = `w-full rounded-md border px-3 md:px-4 py-2 md:py-2.5 text-base md:text-lg focus:outline-none focus:ring-2 ${
+    isChristmasMode
+      ? 'border-[#d4af37]/40 bg-white/10 text-[#f8f1e7] placeholder:text-[#f8f1e7]/40 focus:border-[#d4af37] focus:ring-[#d4af37]/50'
+      : 'border-gray-300 text-gray-900 focus:border-amber-500 focus:ring-amber-500'
+  }`;
+  const selectClass = `w-full rounded-md border px-3 md:px-4 py-2 md:py-2.5 text-base md:text-lg focus:outline-none focus:ring-2 ${
+    isChristmasMode
+      ? 'border-[#d4af37]/40 bg-[#0a2f1a] text-[#f8f1e7] focus:border-[#d4af37] focus:ring-[#d4af37]/50'
+      : 'border-gray-300 bg-white text-gray-900 focus:border-amber-500 focus:ring-amber-500'
+  }`;
+
   return (
-    <div className="space-y-3 md:space-y-4 border-t border-gray-200 pt-3 md:pt-4">
+    <div className={`space-y-3 md:space-y-4 border-t pt-3 md:pt-4 ${
+      isChristmasMode ? 'border-[#d4af37]/20' : 'border-gray-200'
+    }`}>
       <div>
-        <label className="mb-1 md:mb-2 block text-base md:text-lg font-medium text-gray-700">
+        <label className={labelClass}>
           何回目 <span className="text-red-500">*</span>
         </label>
         <input
@@ -20,17 +43,17 @@ export function RoastFields({ roastCount, bagCount, onRoastCountChange, onBagCou
           onChange={(e) => onRoastCountChange(e.target.value)}
           required
           min="1"
-          className="w-full rounded-md border border-gray-300 px-3 md:px-4 py-2 md:py-2.5 text-base md:text-lg text-gray-900 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500"
+          className={inputClass}
           placeholder="回数を入力"
         />
       </div>
 
       <div>
-        <label className="mb-1 md:mb-2 block text-base md:text-lg font-medium text-gray-700">袋数</label>
+        <label className={labelClass}>袋数</label>
         <select
           value={bagCount}
           onChange={(e) => onBagCountChange(e.target.value ? (parseInt(e.target.value, 10) as 1 | 2) : '')}
-          className="w-full rounded-md border border-gray-300 px-3 md:px-4 py-2 md:py-2.5 text-base md:text-lg text-gray-900 bg-white focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500"
+          className={selectClass}
         >
           <option value="">選択してください</option>
           <option value="1">1袋</option>

--- a/components/roast-scheduler/RoastFields.tsx
+++ b/components/roast-scheduler/RoastFields.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { NumberInput, Select } from '@/components/ui';
+
 interface RoastFieldsProps {
   roastCount: string;
   bagCount: 1 | 2 | '';
@@ -8,6 +10,11 @@ interface RoastFieldsProps {
   isChristmasMode?: boolean;
 }
 
+const BAG_COUNT_OPTIONS = [
+  { value: '1', label: '1袋' },
+  { value: '2', label: '2袋' },
+];
+
 export function RoastFields({
   roastCount,
   bagCount,
@@ -15,51 +22,27 @@ export function RoastFields({
   onBagCountChange,
   isChristmasMode = false,
 }: RoastFieldsProps) {
-  const labelClass = `mb-1 md:mb-2 block text-base md:text-lg font-medium ${
-    isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'
-  }`;
-  const inputClass = `w-full rounded-md border px-3 md:px-4 py-2 md:py-2.5 text-base md:text-lg focus:outline-none focus:ring-2 ${
-    isChristmasMode
-      ? 'border-[#d4af37]/40 bg-white/10 text-[#f8f1e7] placeholder:text-[#f8f1e7]/40 focus:border-[#d4af37] focus:ring-[#d4af37]/50'
-      : 'border-gray-300 text-gray-900 focus:border-amber-500 focus:ring-amber-500'
-  }`;
-  const selectClass = `w-full rounded-md border px-3 md:px-4 py-2 md:py-2.5 text-base md:text-lg focus:outline-none focus:ring-2 ${
-    isChristmasMode
-      ? 'border-[#d4af37]/40 bg-[#0a2f1a] text-[#f8f1e7] focus:border-[#d4af37] focus:ring-[#d4af37]/50'
-      : 'border-gray-300 bg-white text-gray-900 focus:border-amber-500 focus:ring-amber-500'
-  }`;
-
   return (
     <div className={`space-y-3 md:space-y-4 border-t pt-3 md:pt-4 ${
       isChristmasMode ? 'border-[#d4af37]/20' : 'border-gray-200'
     }`}>
-      <div>
-        <label className={labelClass}>
-          何回目 <span className="text-red-500">*</span>
-        </label>
-        <input
-          type="number"
-          value={roastCount}
-          onChange={(e) => onRoastCountChange(e.target.value)}
-          required
-          min="1"
-          className={inputClass}
-          placeholder="回数を入力"
-        />
-      </div>
+      <NumberInput
+        label="何回目 *"
+        value={roastCount}
+        onChange={(e) => onRoastCountChange(e.target.value)}
+        min={1}
+        placeholder="回数を入力"
+        isChristmasMode={isChristmasMode}
+      />
 
-      <div>
-        <label className={labelClass}>袋数</label>
-        <select
-          value={bagCount}
-          onChange={(e) => onBagCountChange(e.target.value ? (parseInt(e.target.value, 10) as 1 | 2) : '')}
-          className={selectClass}
-        >
-          <option value="">選択してください</option>
-          <option value="1">1袋</option>
-          <option value="2">2袋</option>
-        </select>
-      </div>
+      <Select
+        label="袋数"
+        value={bagCount.toString()}
+        onChange={(e) => onBagCountChange(e.target.value ? (parseInt(e.target.value, 10) as 1 | 2) : '')}
+        options={BAG_COUNT_OPTIONS}
+        placeholder="選択してください"
+        isChristmasMode={isChristmasMode}
+      />
     </div>
   );
 }

--- a/components/roast-scheduler/RoasterFields.tsx
+++ b/components/roast-scheduler/RoasterFields.tsx
@@ -15,6 +15,7 @@ interface RoasterFieldsProps {
   onBlendRatio2Change: (value: string) => void;
   onWeightChange: (value: 200 | 300 | 500 | '') => void;
   onRoastLevelChange: (value: '浅煎り' | '中煎り' | '中深煎り' | '深煎り' | '') => void;
+  isChristmasMode?: boolean;
 }
 
 export function RoasterFields({
@@ -30,11 +31,31 @@ export function RoasterFields({
   onBlendRatio2Change,
   onWeightChange,
   onRoastLevelChange,
+  isChristmasMode = false,
 }: RoasterFieldsProps) {
+  const labelClass = `mb-1 md:mb-2 block text-base md:text-lg font-medium ${
+    isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'
+  }`;
+  const subLabelClass = `mb-1 md:mb-2 block text-sm md:text-base font-medium ${
+    isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'
+  }`;
+  const selectClass = `w-full rounded-md border px-3 md:px-4 py-2 md:py-2.5 text-base md:text-lg focus:outline-none focus:ring-2 ${
+    isChristmasMode
+      ? 'border-[#d4af37]/40 bg-[#0a2f1a] text-[#f8f1e7] focus:border-[#d4af37] focus:ring-[#d4af37]/50'
+      : 'border-gray-300 bg-white text-gray-900 focus:border-amber-500 focus:ring-amber-500'
+  }`;
+  const inputClass = `w-full rounded-md border px-3 md:px-4 py-2 md:py-2.5 text-base md:text-lg text-center focus:outline-none focus:ring-2 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${
+    isChristmasMode
+      ? 'border-[#d4af37]/40 bg-white/10 text-[#f8f1e7] placeholder:text-[#f8f1e7]/40 focus:border-[#d4af37] focus:ring-[#d4af37]/50'
+      : 'border-gray-300 text-gray-900 focus:border-amber-500 focus:ring-amber-500'
+  }`;
+
   return (
-    <div className="space-y-3 md:space-y-4 border-t border-gray-200 pt-3 md:pt-4">
+    <div className={`space-y-3 md:space-y-4 border-t pt-3 md:pt-4 ${
+      isChristmasMode ? 'border-[#d4af37]/20' : 'border-gray-200'
+    }`}>
       <div>
-        <label className="mb-1 md:mb-2 block text-base md:text-lg font-medium text-gray-700">豆の名前</label>
+        <label className={labelClass}>豆の名前</label>
         <select
           value={beanName}
           onChange={(e) => {
@@ -47,7 +68,7 @@ export function RoasterFields({
               onBlendRatio2Change('');
             }
           }}
-          className="w-full rounded-md border border-gray-300 px-3 md:px-4 py-2 md:py-2.5 text-base md:text-lg text-gray-900 bg-white focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500"
+          className={selectClass}
         >
           <option value="">選択してください</option>
           {ALL_BEANS.map((bean) => (
@@ -59,7 +80,7 @@ export function RoasterFields({
       </div>
 
       <div>
-        <label className="mb-1 md:mb-2 block text-base md:text-lg font-medium text-gray-700">
+        <label className={labelClass}>
           2種類目の豆の名前
         </label>
         <select
@@ -73,7 +94,7 @@ export function RoasterFields({
               onBlendRatio2Change('');
             }
           }}
-          className="w-full rounded-md border border-gray-300 px-3 md:px-4 py-2 md:py-2.5 text-base md:text-lg text-gray-900 bg-white focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500"
+          className={selectClass}
         >
           <option value="">なし</option>
           {ALL_BEANS.filter((bean) => bean !== beanName).map((bean) => (
@@ -86,12 +107,12 @@ export function RoasterFields({
 
       {beanName2 && (
         <div>
-          <label className="mb-1 md:mb-2 block text-base md:text-lg font-medium text-gray-700">
+          <label className={labelClass}>
             ブレンド割合 <span className="text-red-500">*</span>
           </label>
           <div className="grid grid-cols-2 gap-2 md:gap-3">
             <div>
-              <label className="mb-1 md:mb-2 block text-sm md:text-base font-medium text-gray-600">
+              <label className={subLabelClass}>
                 {beanName}の割合
               </label>
               <input
@@ -106,12 +127,12 @@ export function RoasterFields({
                 min="0"
                 max="10"
                 required={!!beanName2}
-                className="w-full rounded-md border border-gray-300 px-3 md:px-4 py-2 md:py-2.5 text-base md:text-lg text-gray-900 text-center focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                className={inputClass}
                 placeholder="5"
               />
             </div>
             <div>
-              <label className="mb-1 md:mb-2 block text-sm md:text-base font-medium text-gray-600">
+              <label className={subLabelClass}>
                 {beanName2}の割合
               </label>
               <input
@@ -126,23 +147,25 @@ export function RoasterFields({
                 min="0"
                 max="10"
                 required={!!beanName2}
-                className="w-full rounded-md border border-gray-300 px-3 md:px-4 py-2 md:py-2.5 text-base md:text-lg text-gray-900 text-center focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                className={inputClass}
                 placeholder="5"
               />
             </div>
           </div>
-          <p className="mt-1 md:mt-2 text-sm md:text-base text-gray-500">
+          <p className={`mt-1 md:mt-2 text-sm md:text-base ${
+            isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'
+          }`}>
             合計が10になるように入力してください（例：5と5、8と2）
           </p>
         </div>
       )}
 
       <div>
-        <label className="mb-1 md:mb-2 block text-base md:text-lg font-medium text-gray-700">重さ</label>
+        <label className={labelClass}>重さ</label>
         <select
           value={weight}
           onChange={(e) => onWeightChange(e.target.value ? (parseInt(e.target.value, 10) as 200 | 300 | 500) : '')}
-          className="w-full rounded-md border border-gray-300 px-3 md:px-4 py-2 md:py-2.5 text-base md:text-lg text-gray-900 bg-white focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500"
+          className={selectClass}
         >
           <option value="">選択してください</option>
           <option value="200">200g</option>
@@ -152,13 +175,13 @@ export function RoasterFields({
       </div>
 
       <div>
-        <label className="mb-1 md:mb-2 block text-base md:text-lg font-medium text-gray-700">焙煎度合い</label>
+        <label className={labelClass}>焙煎度合い</label>
         <select
           value={roastLevel}
           onChange={(e) =>
             onRoastLevelChange(e.target.value as '浅煎り' | '中煎り' | '中深煎り' | '深煎り' | '')
           }
-          className="w-full rounded-md border border-gray-300 px-3 md:px-4 py-2 md:py-2.5 text-base md:text-lg text-gray-900 bg-white focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500"
+          className={selectClass}
         >
           <option value="">選択してください</option>
           <option value="浅煎り">浅煎り</option>

--- a/components/roast-scheduler/RoasterFields.tsx
+++ b/components/roast-scheduler/RoasterFields.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { useMemo } from 'react';
 import { ALL_BEANS, type BeanName } from '@/lib/beanConfig';
+import { Select, NumberInput } from '@/components/ui';
 
 interface RoasterFieldsProps {
   beanName: BeanName | '';
@@ -18,6 +20,19 @@ interface RoasterFieldsProps {
   isChristmasMode?: boolean;
 }
 
+const WEIGHT_OPTIONS = [
+  { value: '200', label: '200g' },
+  { value: '300', label: '300g' },
+  { value: '500', label: '500g' },
+];
+
+const ROAST_LEVEL_OPTIONS = [
+  { value: '浅煎り', label: '浅煎り' },
+  { value: '中煎り', label: '中煎り' },
+  { value: '中深煎り', label: '中深煎り' },
+  { value: '深煎り', label: '深煎り' },
+];
+
 export function RoasterFields({
   beanName,
   beanName2,
@@ -33,124 +48,101 @@ export function RoasterFields({
   onRoastLevelChange,
   isChristmasMode = false,
 }: RoasterFieldsProps) {
-  const labelClass = `mb-1 md:mb-2 block text-base md:text-lg font-medium ${
-    isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'
-  }`;
-  const subLabelClass = `mb-1 md:mb-2 block text-sm md:text-base font-medium ${
-    isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'
-  }`;
-  const selectClass = `w-full rounded-md border px-3 md:px-4 py-2 md:py-2.5 text-base md:text-lg focus:outline-none focus:ring-2 ${
-    isChristmasMode
-      ? 'border-[#d4af37]/40 bg-[#0a2f1a] text-[#f8f1e7] focus:border-[#d4af37] focus:ring-[#d4af37]/50'
-      : 'border-gray-300 bg-white text-gray-900 focus:border-amber-500 focus:ring-amber-500'
-  }`;
-  const inputClass = `w-full rounded-md border px-3 md:px-4 py-2 md:py-2.5 text-base md:text-lg text-center focus:outline-none focus:ring-2 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${
-    isChristmasMode
-      ? 'border-[#d4af37]/40 bg-white/10 text-[#f8f1e7] placeholder:text-[#f8f1e7]/40 focus:border-[#d4af37] focus:ring-[#d4af37]/50'
-      : 'border-gray-300 text-gray-900 focus:border-amber-500 focus:ring-amber-500'
-  }`;
+  // 豆の選択肢を生成
+  const beanOptions = useMemo(
+    () => ALL_BEANS.map((bean) => ({ value: bean, label: bean })),
+    []
+  );
+
+  // 2種類目の豆の選択肢（1種類目で選択した豆を除外）
+  const bean2Options = useMemo(
+    () => ALL_BEANS.filter((bean) => bean !== beanName).map((bean) => ({ value: bean, label: bean })),
+    [beanName]
+  );
+
+  const handleBeanNameChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value as BeanName | '';
+    onBeanNameChange(value);
+    // 1種類目が変更されたとき、2種類目が同じ豆の場合はクリア
+    if (beanName2 === value && value !== '') {
+      onBeanName2Change('');
+      onBlendRatio1Change('');
+      onBlendRatio2Change('');
+    }
+  };
+
+  const handleBeanName2Change = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value as BeanName | '';
+    onBeanName2Change(value);
+    // 2種類目を「なし」にした場合は割合もクリア
+    if (!value) {
+      onBlendRatio1Change('');
+      onBlendRatio2Change('');
+    }
+  };
+
+  const handleBlendRatio1Change = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    if (value === '' || (parseInt(value) >= 0 && parseInt(value) <= 10)) {
+      onBlendRatio1Change(value);
+    }
+  };
+
+  const handleBlendRatio2Change = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    if (value === '' || (parseInt(value) >= 0 && parseInt(value) <= 10)) {
+      onBlendRatio2Change(value);
+    }
+  };
 
   return (
     <div className={`space-y-3 md:space-y-4 border-t pt-3 md:pt-4 ${
       isChristmasMode ? 'border-[#d4af37]/20' : 'border-gray-200'
     }`}>
-      <div>
-        <label className={labelClass}>豆の名前</label>
-        <select
-          value={beanName}
-          onChange={(e) => {
-            const value = e.target.value as BeanName | '';
-            onBeanNameChange(value);
-            // 1種類目が変更されたとき、2種類目が同じ豆の場合はクリア
-            if (beanName2 === value && value !== '') {
-              onBeanName2Change('');
-              onBlendRatio1Change('');
-              onBlendRatio2Change('');
-            }
-          }}
-          className={selectClass}
-        >
-          <option value="">選択してください</option>
-          {ALL_BEANS.map((bean) => (
-            <option key={bean} value={bean}>
-              {bean}
-            </option>
-          ))}
-        </select>
-      </div>
+      <Select
+        label="豆の名前"
+        value={beanName}
+        onChange={handleBeanNameChange}
+        options={beanOptions}
+        placeholder="選択してください"
+        isChristmasMode={isChristmasMode}
+      />
 
-      <div>
-        <label className={labelClass}>
-          2種類目の豆の名前
-        </label>
-        <select
-          value={beanName2}
-          onChange={(e) => {
-            const value = e.target.value as BeanName | '';
-            onBeanName2Change(value);
-            // 2種類目を「なし」にした場合は割合もクリア
-            if (!value) {
-              onBlendRatio1Change('');
-              onBlendRatio2Change('');
-            }
-          }}
-          className={selectClass}
-        >
-          <option value="">なし</option>
-          {ALL_BEANS.filter((bean) => bean !== beanName).map((bean) => (
-            <option key={bean} value={bean}>
-              {bean}
-            </option>
-          ))}
-        </select>
-      </div>
+      <Select
+        label="2種類目の豆の名前"
+        value={beanName2}
+        onChange={handleBeanName2Change}
+        options={bean2Options}
+        placeholder="なし"
+        isChristmasMode={isChristmasMode}
+      />
 
       {beanName2 && (
         <div>
-          <label className={labelClass}>
+          <div className={`mb-1 md:mb-2 block text-base md:text-lg font-medium ${
+            isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'
+          }`}>
             ブレンド割合 <span className="text-red-500">*</span>
-          </label>
+          </div>
           <div className="grid grid-cols-2 gap-2 md:gap-3">
-            <div>
-              <label className={subLabelClass}>
-                {beanName}の割合
-              </label>
-              <input
-                type="number"
-                value={blendRatio1}
-                onChange={(e) => {
-                  const value = e.target.value;
-                  if (value === '' || (parseInt(value) >= 0 && parseInt(value) <= 10)) {
-                    onBlendRatio1Change(value);
-                  }
-                }}
-                min="0"
-                max="10"
-                required={!!beanName2}
-                className={inputClass}
-                placeholder="5"
-              />
-            </div>
-            <div>
-              <label className={subLabelClass}>
-                {beanName2}の割合
-              </label>
-              <input
-                type="number"
-                value={blendRatio2}
-                onChange={(e) => {
-                  const value = e.target.value;
-                  if (value === '' || (parseInt(value) >= 0 && parseInt(value) <= 10)) {
-                    onBlendRatio2Change(value);
-                  }
-                }}
-                min="0"
-                max="10"
-                required={!!beanName2}
-                className={inputClass}
-                placeholder="5"
-              />
-            </div>
+            <NumberInput
+              label={`${beanName}の割合`}
+              value={blendRatio1}
+              onChange={handleBlendRatio1Change}
+              min={0}
+              max={10}
+              placeholder="5"
+              isChristmasMode={isChristmasMode}
+            />
+            <NumberInput
+              label={`${beanName2}の割合`}
+              value={blendRatio2}
+              onChange={handleBlendRatio2Change}
+              min={0}
+              max={10}
+              placeholder="5"
+              isChristmasMode={isChristmasMode}
+            />
           </div>
           <p className={`mt-1 md:mt-2 text-sm md:text-base ${
             isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'
@@ -160,36 +152,23 @@ export function RoasterFields({
         </div>
       )}
 
-      <div>
-        <label className={labelClass}>重さ</label>
-        <select
-          value={weight}
-          onChange={(e) => onWeightChange(e.target.value ? (parseInt(e.target.value, 10) as 200 | 300 | 500) : '')}
-          className={selectClass}
-        >
-          <option value="">選択してください</option>
-          <option value="200">200g</option>
-          <option value="300">300g</option>
-          <option value="500">500g</option>
-        </select>
-      </div>
+      <Select
+        label="重さ"
+        value={weight.toString()}
+        onChange={(e) => onWeightChange(e.target.value ? (parseInt(e.target.value, 10) as 200 | 300 | 500) : '')}
+        options={WEIGHT_OPTIONS}
+        placeholder="選択してください"
+        isChristmasMode={isChristmasMode}
+      />
 
-      <div>
-        <label className={labelClass}>焙煎度合い</label>
-        <select
-          value={roastLevel}
-          onChange={(e) =>
-            onRoastLevelChange(e.target.value as '浅煎り' | '中煎り' | '中深煎り' | '深煎り' | '')
-          }
-          className={selectClass}
-        >
-          <option value="">選択してください</option>
-          <option value="浅煎り">浅煎り</option>
-          <option value="中煎り">中煎り</option>
-          <option value="中深煎り">中深煎り</option>
-          <option value="深煎り">深煎り</option>
-        </select>
-      </div>
+      <Select
+        label="焙煎度合い"
+        value={roastLevel}
+        onChange={(e) => onRoastLevelChange(e.target.value as '浅煎り' | '中煎り' | '中深煎り' | '深煎り' | '')}
+        options={ROAST_LEVEL_OPTIONS}
+        placeholder="選択してください"
+        isChristmasMode={isChristmasMode}
+      />
     </div>
   );
 }

--- a/components/roast-scheduler/ScheduleCard.tsx
+++ b/components/roast-scheduler/ScheduleCard.tsx
@@ -18,6 +18,7 @@ interface ScheduleCardProps {
   onDragLeave: () => void;
   onDrop: (e: React.DragEvent) => void;
   onDragEnd: () => void;
+  isChristmasMode?: boolean;
 }
 
 export function ScheduleCard({
@@ -30,6 +31,7 @@ export function ScheduleCard({
   onDragLeave,
   onDrop,
   onDragEnd,
+  isChristmasMode = false,
 }: ScheduleCardProps) {
   // メモタイプの判定
   const isRoasterOn = schedule.isRoasterOn;
@@ -39,10 +41,11 @@ export function ScheduleCard({
 
   // アイコンの取得
   const getIcon = () => {
-    if (isRoasterOn) return <HiFire className="text-xl md:text-xl text-orange-500 flex-shrink-0" />;
-    if (isRoast) return <PiCoffeeBeanFill className="text-xl md:text-xl text-amber-700 flex-shrink-0" />;
-    if (isAfterPurge) return <FaSnowflake className="text-xl md:text-xl text-blue-500 flex-shrink-0" />;
-    if (isChaffCleaning) return <FaBroom className="text-xl md:text-xl text-gray-600 flex-shrink-0" />;
+    const iconColorClass = isChristmasMode ? 'text-[#d4af37]' : '';
+    if (isRoasterOn) return <HiFire className={`text-xl md:text-xl flex-shrink-0 ${iconColorClass || 'text-orange-500'}`} />;
+    if (isRoast) return <PiCoffeeBeanFill className={`text-xl md:text-xl flex-shrink-0 ${iconColorClass || 'text-amber-700'}`} />;
+    if (isAfterPurge) return <FaSnowflake className={`text-xl md:text-xl flex-shrink-0 ${iconColorClass || 'text-blue-500'}`} />;
+    if (isChaffCleaning) return <FaBroom className={`text-xl md:text-xl flex-shrink-0 ${iconColorClass || 'text-gray-600'}`} />;
     return null;
   };
 
@@ -177,15 +180,27 @@ export function ScheduleCard({
       onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}
       onClick={handleCardClick}
-      className={`rounded-md border border-gray-200 bg-gray-50 hover:bg-amber-50 p-3 md:p-2.5 cursor-move hover:shadow-sm hover:border-amber-300 transition-all select-none touch-none ${
-        isDragging ? 'opacity-50' : ''
-      } ${isDragOver ? 'border-amber-500 border-2 bg-amber-50' : ''}`}
+      className={`rounded-md border p-3 md:p-2.5 cursor-move hover:shadow-sm transition-all select-none touch-none ${
+        isChristmasMode
+          ? `border-[#d4af37]/20 bg-white/5 hover:bg-[#d4af37]/10 hover:border-[#d4af37]/40`
+          : `border-gray-200 bg-gray-50 hover:bg-amber-50 hover:border-amber-300`
+      } ${isDragging ? 'opacity-50' : ''} ${
+        isDragOver
+          ? isChristmasMode
+            ? 'border-[#d4af37] border-2 bg-[#d4af37]/20'
+            : 'border-amber-500 border-2 bg-amber-50'
+          : ''
+      }`}
     >
       <div className="flex items-center gap-2 md:gap-2.5">
         {/* 左側：時間バッジまたはアイコン */}
         <div className="flex items-center gap-1.5 md:gap-1.5 flex-shrink-0">
           {schedule.time ? (
-            <div className="flex-shrink-0 w-16 md:w-18 text-center px-2 py-1 bg-white rounded-md text-sm md:text-base font-semibold text-gray-800 tabular-nums shadow-sm">
+            <div className={`flex-shrink-0 w-16 md:w-18 text-center px-2 py-1 rounded-md text-sm md:text-base font-semibold tabular-nums shadow-sm ${
+              isChristmasMode
+                ? 'bg-[#d4af37]/20 text-[#d4af37]'
+                : 'bg-white text-gray-800'
+            }`}>
               {schedule.time}
             </div>
           ) : (
@@ -196,16 +211,22 @@ export function ScheduleCard({
 
         {/* 中央：メモ内容 */}
         <div className="flex-1 min-w-0 flex flex-col gap-1 md:gap-0.5">
-          <div className="text-base md:text-base font-medium text-gray-800 flex items-center gap-1.5 md:gap-1.5 flex-wrap">
+          <div className={`text-base md:text-base font-medium flex items-center gap-1.5 md:gap-1.5 flex-wrap ${
+            isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'
+          }`}>
             <span className="whitespace-nowrap">{memoContent.firstLine}</span>
             {memoContent.beanName && (
-              <span className="inline-flex items-center rounded px-1.5 md:px-2 py-0.5 md:py-1 text-sm md:text-xs font-medium bg-gray-50 text-gray-700 border border-gray-200 whitespace-nowrap">
+              <span className={`inline-flex items-center rounded px-1.5 md:px-2 py-0.5 md:py-1 text-sm md:text-xs font-medium border whitespace-nowrap ${
+                isChristmasMode
+                  ? 'bg-white/10 text-[#f8f1e7]/80 border-[#d4af37]/30'
+                  : 'bg-gray-50 text-gray-700 border-gray-200'
+              }`}>
                 {memoContent.beanName2 && memoContent.blendRatio ? (
                   <>
                     <span className="whitespace-nowrap">{memoContent.beanName}</span>
                     {' '}
                     <CountryFlagEmoji countryName={memoContent.beanName} />
-                    <span className="mx-0.5 md:mx-1 text-gray-400">×</span>
+                    <span className={`mx-0.5 md:mx-1 ${isChristmasMode ? 'text-[#f8f1e7]/40' : 'text-gray-400'}`}>×</span>
                     <span className="whitespace-nowrap">{memoContent.beanName2}</span>
                     {' '}
                     <CountryFlagEmoji countryName={memoContent.beanName2} />

--- a/components/roast-scheduler/SchedulePreview.tsx
+++ b/components/roast-scheduler/SchedulePreview.tsx
@@ -18,6 +18,7 @@ interface SchedulePreviewProps {
   roastLevel: '浅煎り' | '中煎り' | '中深煎り' | '深煎り' | '';
   roastCount: string;
   bagCount: 1 | 2 | '';
+  isChristmasMode?: boolean;
 }
 
 export function SchedulePreview({
@@ -33,6 +34,7 @@ export function SchedulePreview({
   roastLevel,
   roastCount,
   bagCount,
+  isChristmasMode = false,
 }: SchedulePreviewProps) {
   // ブレンド割合を結合する関数
   const combineBlendRatio = (ratio1: string, ratio2: string): string | undefined => {
@@ -97,11 +99,23 @@ export function SchedulePreview({
 
   // プレビューの色
   const getPreviewColor = () => {
+    if (isChristmasMode) {
+      return 'bg-[#d4af37]/20 border-[#d4af37]/50 text-[#f8f1e7]';
+    }
     if (isRoasterOn) return 'bg-orange-100 border-orange-300 text-orange-800';
     if (isRoast) return 'bg-amber-100 border-amber-300 text-amber-800';
     if (isAfterPurge) return 'bg-blue-100 border-blue-300 text-blue-800';
     if (isChaffCleaning) return 'bg-gray-100 border-gray-300 text-gray-800';
     return 'bg-gray-100 border-gray-300 text-gray-800';
+  };
+
+  const getIconColor = () => {
+    if (isChristmasMode) return 'text-[#d4af37]';
+    if (isRoasterOn) return 'text-orange-500';
+    if (isRoast) return 'text-amber-700';
+    if (isAfterPurge) return 'text-blue-500';
+    if (isChaffCleaning) return 'text-gray-700';
+    return 'text-gray-500';
   };
 
   if (!isRoasterOn && !isRoast && !isAfterPurge && !isChaffCleaning) {
@@ -111,10 +125,10 @@ export function SchedulePreview({
   return (
     <div className={`rounded-md border-2 p-3 md:p-4 ${getPreviewColor()} flex justify-center`}>
       <div className="flex items-center gap-2 md:gap-3">
-        {isRoasterOn && <HiFire className="text-xl md:text-2xl text-orange-500" />}
-        {isRoast && <PiCoffeeBeanFill className="text-xl md:text-2xl text-amber-700" />}
-        {isAfterPurge && <FaSnowflake className="text-xl md:text-2xl text-blue-500" />}
-        {isChaffCleaning && <FaBroom className="text-xl md:text-2xl text-gray-700" />}
+        {isRoasterOn && <HiFire className={`text-xl md:text-2xl ${getIconColor()}`} />}
+        {isRoast && <PiCoffeeBeanFill className={`text-xl md:text-2xl ${getIconColor()}`} />}
+        {isAfterPurge && <FaSnowflake className={`text-xl md:text-2xl ${getIconColor()}`} />}
+        {isChaffCleaning && <FaBroom className={`text-xl md:text-2xl ${getIconColor()}`} />}
         <div className="text-base md:text-lg font-medium whitespace-pre-line">{getPreviewText()}</div>
       </div>
     </div>

--- a/components/roast-scheduler/ScheduleTypeSelector.tsx
+++ b/components/roast-scheduler/ScheduleTypeSelector.tsx
@@ -10,6 +10,7 @@ interface ScheduleTypeSelectorProps {
   isAfterPurge: boolean;
   isChaffCleaning: boolean;
   onTypeChange: (type: 'roasterOn' | 'roast' | 'afterPurge' | 'chaffCleaning') => void;
+  isChristmasMode?: boolean;
 }
 
 export function ScheduleTypeSelector({
@@ -18,16 +19,33 @@ export function ScheduleTypeSelector({
   isAfterPurge,
   isChaffCleaning,
   onTypeChange,
+  isChristmasMode = false,
 }: ScheduleTypeSelectorProps) {
+  // クリスマスモード用のスタイル
+  const getTypeStyle = (isSelected: boolean, selectedColor: string, selectedBg: string) => {
+    if (isChristmasMode) {
+      return isSelected
+        ? `border-[#d4af37] bg-[#d4af37]/20`
+        : `border-[#d4af37]/30 bg-white/5 hover:border-[#d4af37]/50`;
+    }
+    return isSelected
+      ? `border-${selectedColor}-500 bg-${selectedColor}-50`
+      : 'border-gray-200 bg-white hover:border-gray-300';
+  };
+
   return (
     <div>
-      <label className="mb-3 md:mb-4 block text-base md:text-lg font-medium text-gray-700 text-center">
+      <label className={`mb-3 md:mb-4 block text-base md:text-lg font-medium text-center ${
+        isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'
+      }`}>
         スケジュールタイプ <span className="text-red-500">*</span>
       </label>
       <div className="grid grid-cols-2 gap-3 md:gap-4">
         <label
           className={`flex flex-col items-center justify-center gap-2 md:gap-3 p-4 md:p-5 rounded-lg border-2 cursor-pointer transition-all ${
-            isRoasterOn ? 'border-orange-500 bg-orange-50' : 'border-gray-200 bg-white hover:border-gray-300'
+            isChristmasMode
+              ? isRoasterOn ? 'border-[#d4af37] bg-[#d4af37]/20' : 'border-[#d4af37]/30 bg-white/5 hover:border-[#d4af37]/50'
+              : isRoasterOn ? 'border-orange-500 bg-orange-50' : 'border-gray-200 bg-white hover:border-gray-300'
           }`}
         >
           <input
@@ -36,14 +54,24 @@ export function ScheduleTypeSelector({
             onChange={() => onTypeChange('roasterOn')}
             className="sr-only"
           />
-          <HiFire className={`text-3xl md:text-4xl ${isRoasterOn ? 'text-orange-500' : 'text-gray-400'}`} />
-          <span className={`text-base md:text-lg font-medium ${isRoasterOn ? 'text-orange-700' : 'text-gray-700'}`}>
+          <HiFire className={`text-3xl md:text-4xl ${
+            isChristmasMode
+              ? isRoasterOn ? 'text-[#d4af37]' : 'text-[#f8f1e7]/40'
+              : isRoasterOn ? 'text-orange-500' : 'text-gray-400'
+          }`} />
+          <span className={`text-base md:text-lg font-medium ${
+            isChristmasMode
+              ? isRoasterOn ? 'text-[#d4af37]' : 'text-[#f8f1e7]/70'
+              : isRoasterOn ? 'text-orange-700' : 'text-gray-700'
+          }`}>
             焙煎機予熱
           </span>
         </label>
         <label
           className={`flex flex-col items-center justify-center gap-2 md:gap-3 p-4 md:p-5 rounded-lg border-2 cursor-pointer transition-all ${
-            isRoast ? 'border-amber-500 bg-amber-50' : 'border-gray-200 bg-white hover:border-gray-300'
+            isChristmasMode
+              ? isRoast ? 'border-[#d4af37] bg-[#d4af37]/20' : 'border-[#d4af37]/30 bg-white/5 hover:border-[#d4af37]/50'
+              : isRoast ? 'border-amber-500 bg-amber-50' : 'border-gray-200 bg-white hover:border-gray-300'
           }`}
         >
           <input
@@ -52,14 +80,24 @@ export function ScheduleTypeSelector({
             onChange={() => onTypeChange('roast')}
             className="sr-only"
           />
-          <PiCoffeeBeanFill className={`text-3xl md:text-4xl ${isRoast ? 'text-amber-700' : 'text-gray-400'}`} />
-          <span className={`text-base md:text-lg font-medium ${isRoast ? 'text-amber-700' : 'text-gray-700'}`}>
+          <PiCoffeeBeanFill className={`text-3xl md:text-4xl ${
+            isChristmasMode
+              ? isRoast ? 'text-[#d4af37]' : 'text-[#f8f1e7]/40'
+              : isRoast ? 'text-amber-700' : 'text-gray-400'
+          }`} />
+          <span className={`text-base md:text-lg font-medium ${
+            isChristmasMode
+              ? isRoast ? 'text-[#d4af37]' : 'text-[#f8f1e7]/70'
+              : isRoast ? 'text-amber-700' : 'text-gray-700'
+          }`}>
             ロースト
           </span>
         </label>
         <label
           className={`flex flex-col items-center justify-center gap-2 md:gap-3 p-4 md:p-5 rounded-lg border-2 cursor-pointer transition-all ${
-            isAfterPurge ? 'border-blue-500 bg-blue-50' : 'border-gray-200 bg-white hover:border-gray-300'
+            isChristmasMode
+              ? isAfterPurge ? 'border-[#d4af37] bg-[#d4af37]/20' : 'border-[#d4af37]/30 bg-white/5 hover:border-[#d4af37]/50'
+              : isAfterPurge ? 'border-blue-500 bg-blue-50' : 'border-gray-200 bg-white hover:border-gray-300'
           }`}
         >
           <input
@@ -68,14 +106,24 @@ export function ScheduleTypeSelector({
             onChange={() => onTypeChange('afterPurge')}
             className="sr-only"
           />
-          <FaSnowflake className={`text-3xl md:text-4xl ${isAfterPurge ? 'text-blue-500' : 'text-gray-400'}`} />
-          <span className={`text-base md:text-lg font-medium ${isAfterPurge ? 'text-blue-700' : 'text-gray-700'}`}>
+          <FaSnowflake className={`text-3xl md:text-4xl ${
+            isChristmasMode
+              ? isAfterPurge ? 'text-[#d4af37]' : 'text-[#f8f1e7]/40'
+              : isAfterPurge ? 'text-blue-500' : 'text-gray-400'
+          }`} />
+          <span className={`text-base md:text-lg font-medium ${
+            isChristmasMode
+              ? isAfterPurge ? 'text-[#d4af37]' : 'text-[#f8f1e7]/70'
+              : isAfterPurge ? 'text-blue-700' : 'text-gray-700'
+          }`}>
             アフターパージ
           </span>
         </label>
         <label
           className={`flex flex-col items-center justify-center gap-2 md:gap-3 p-4 md:p-5 rounded-lg border-2 cursor-pointer transition-all ${
-            isChaffCleaning ? 'border-gray-500 bg-gray-50' : 'border-gray-200 bg-white hover:border-gray-300'
+            isChristmasMode
+              ? isChaffCleaning ? 'border-[#d4af37] bg-[#d4af37]/20' : 'border-[#d4af37]/30 bg-white/5 hover:border-[#d4af37]/50'
+              : isChaffCleaning ? 'border-gray-500 bg-gray-50' : 'border-gray-200 bg-white hover:border-gray-300'
           }`}
         >
           <input
@@ -84,8 +132,16 @@ export function ScheduleTypeSelector({
             onChange={() => onTypeChange('chaffCleaning')}
             className="sr-only"
           />
-          <FaBroom className={`text-3xl md:text-4xl ${isChaffCleaning ? 'text-gray-700' : 'text-gray-400'}`} />
-          <span className={`text-base md:text-lg font-medium ${isChaffCleaning ? 'text-gray-700' : 'text-gray-700'}`}>
+          <FaBroom className={`text-3xl md:text-4xl ${
+            isChristmasMode
+              ? isChaffCleaning ? 'text-[#d4af37]' : 'text-[#f8f1e7]/40'
+              : isChaffCleaning ? 'text-gray-700' : 'text-gray-400'
+          }`} />
+          <span className={`text-base md:text-lg font-medium ${
+            isChristmasMode
+              ? isChaffCleaning ? 'text-[#d4af37]' : 'text-[#f8f1e7]/70'
+              : isChaffCleaning ? 'text-gray-700' : 'text-gray-700'
+          }`}>
             チャフのお掃除
           </span>
         </label>

--- a/components/today-schedule/TimeInputRow.tsx
+++ b/components/today-schedule/TimeInputRow.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { HiPlus } from 'react-icons/hi';
+import { Button } from '@/components/ui';
 
 export interface TimeInputRowProps {
   newHour: string;
@@ -10,8 +11,7 @@ export interface TimeInputRowProps {
   onMinuteChange: (value: string) => void;
   onAdd: () => void;
   wrapperClassName: string;
-  buttonClassName: string;
-  labelClassName?: string;
+  isChristmasMode?: boolean;
 }
 
 export function TimeInputRow({
@@ -22,14 +22,20 @@ export function TimeInputRow({
   onMinuteChange,
   onAdd,
   wrapperClassName,
-  buttonClassName,
-  labelClassName,
+  isChristmasMode = false,
 }: TimeInputRowProps) {
-  const hourInputClass = `w-12 md:w-14 rounded-md border px-1.5 md:px-2 py-1 md:py-1.5 text-base md:text-base text-gray-900 text-center focus:outline-none focus:ring-2 transition-all duration-300 ease-in-out [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${
-    addError ? 'border-red-500 focus:border-red-500 focus:ring-red-500' : 'border-gray-300 focus:border-amber-500 focus:ring-amber-500'
+  const hourInputClass = `w-12 md:w-14 rounded-md border px-1.5 md:px-2 py-1 md:py-1.5 text-base md:text-base text-center focus:outline-none focus:ring-2 transition-all duration-300 ease-in-out [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${
+    addError
+      ? 'border-red-500 focus:border-red-500 focus:ring-red-500'
+      : isChristmasMode
+        ? 'border-[#d4af37]/40 bg-white/10 text-[#f8f1e7] placeholder:text-[#f8f1e7]/40 focus:border-[#d4af37] focus:ring-[#d4af37]/50'
+        : 'border-gray-300 text-gray-900 focus:border-amber-500 focus:ring-amber-500'
   }`;
-  const minuteInputClass =
-    'w-12 md:w-14 rounded-md border border-gray-300 px-1.5 md:px-2 py-1 md:py-1.5 text-base md:text-base text-gray-900 text-center focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none';
+  const minuteInputClass = `w-12 md:w-14 rounded-md border px-1.5 md:px-2 py-1 md:py-1.5 text-base md:text-base text-center focus:outline-none focus:ring-2 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${
+    isChristmasMode
+      ? 'border-[#d4af37]/40 bg-white/10 text-[#f8f1e7] placeholder:text-[#f8f1e7]/40 focus:border-[#d4af37] focus:ring-[#d4af37]/50'
+      : 'border-gray-300 text-gray-900 focus:border-amber-500 focus:ring-amber-500'
+  }`;
 
   return (
     <div className={wrapperClassName}>
@@ -43,7 +49,7 @@ export function TimeInputRow({
           className={hourInputClass}
           placeholder="時"
         />
-        <span className="text-gray-600 text-base md:text-base">:</span>
+        <span className={`text-base md:text-base ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>:</span>
         <input
           type="number"
           value={newMinute}
@@ -54,14 +60,16 @@ export function TimeInputRow({
           placeholder="分"
         />
       </div>
-      <button
+      <Button
+        variant="primary"
+        size="sm"
         onClick={onAdd}
-        className={buttonClassName}
+        isChristmasMode={isChristmasMode}
         aria-label="時間ラベルを追加"
       >
-        <HiPlus className="h-3.5 w-3.5 md:h-4 md:w-4" />
-        <span className={labelClassName}>追加</span>
-      </button>
+        <HiPlus className="h-4 w-4" />
+        <span>追加</span>
+      </Button>
     </div>
   );
 }

--- a/components/today-schedule/TimeInputRow.tsx
+++ b/components/today-schedule/TimeInputRow.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { HiPlus } from 'react-icons/hi';
-import { Button } from '@/components/ui';
+import { Button, NumberInput } from '@/components/ui';
 
 export interface TimeInputRowProps {
   newHour: string;
@@ -24,40 +24,28 @@ export function TimeInputRow({
   wrapperClassName,
   isChristmasMode = false,
 }: TimeInputRowProps) {
-  const hourInputClass = `w-12 md:w-14 rounded-md border px-1.5 md:px-2 py-1 md:py-1.5 text-base md:text-base text-center focus:outline-none focus:ring-2 transition-all duration-300 ease-in-out [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${
-    addError
-      ? 'border-red-500 focus:border-red-500 focus:ring-red-500'
-      : isChristmasMode
-        ? 'border-[#d4af37]/40 bg-white/10 text-[#f8f1e7] placeholder:text-[#f8f1e7]/40 focus:border-[#d4af37] focus:ring-[#d4af37]/50'
-        : 'border-gray-300 text-gray-900 focus:border-amber-500 focus:ring-amber-500'
-  }`;
-  const minuteInputClass = `w-12 md:w-14 rounded-md border px-1.5 md:px-2 py-1 md:py-1.5 text-base md:text-base text-center focus:outline-none focus:ring-2 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${
-    isChristmasMode
-      ? 'border-[#d4af37]/40 bg-white/10 text-[#f8f1e7] placeholder:text-[#f8f1e7]/40 focus:border-[#d4af37] focus:ring-[#d4af37]/50'
-      : 'border-gray-300 text-gray-900 focus:border-amber-500 focus:ring-amber-500'
-  }`;
-
   return (
     <div className={wrapperClassName}>
       <div className="flex items-center gap-1 md:gap-1.5">
-        <input
-          type="number"
+        <NumberInput
           value={newHour}
           onChange={(e) => onHourChange(e.target.value)}
-          min="0"
-          max="23"
-          className={hourInputClass}
+          min={0}
+          max={23}
           placeholder="時"
+          isChristmasMode={isChristmasMode}
+          error={addError ? ' ' : undefined}
+          className="w-12 md:w-14 !px-1.5 !py-1 !text-base !min-h-0"
         />
-        <span className={`text-base md:text-base ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>:</span>
-        <input
-          type="number"
+        <span className={`text-base ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>:</span>
+        <NumberInput
           value={newMinute}
           onChange={(e) => onMinuteChange(e.target.value)}
-          min="0"
-          max="59"
-          className={minuteInputClass}
+          min={0}
+          max={59}
           placeholder="分"
+          isChristmasMode={isChristmasMode}
+          className="w-12 md:w-14 !px-1.5 !py-1 !text-base !min-h-0"
         />
       </div>
       <Button


### PR DESCRIPTION
## Summary
- スケジュールページの全ボタンを共通UIコンポーネント（Button, IconButton）に置き換え
- 全コンポーネントにクリスマスモード対応を追加
- 配色を統一（深緑 #0a2f1a, 金 #d4af37, アイボリー #f8f1e7）

## 変更対象（15ファイル）
- `app/schedule/page.tsx` - メインページ
- `TodaySchedule.tsx`, `RoastSchedulerTab.tsx` - メインコンポーネント
- `ScheduleOCRModal.tsx`, `OCRConfirmModal.tsx` - OCRモーダル
- `RoastScheduleMemoDialog.tsx` - スケジュール追加ダイアログ
- `ScheduleCard.tsx` - ローストスケジュール行
- その他子コンポーネント8ファイル

## Test plan
- [x] 通常モードでスケジュールページが正常に表示される
- [x] クリスマスモードで深緑・金・アイボリーの配色が適用される
- [x] 「AIで読み取る」モーダルがテーマに対応
- [x] スケジュール追加ダイアログがテーマに対応
- [x] ドラッグ＆ドロップ機能が正常に動作

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)