### PR TITLE
refactor(tasting): 試飲記録ページの共通UI化とクリスマスモード対応

### DIFF
--- a/app/tasting/page.tsx
+++ b/app/tasting/page.tsx
@@ -11,11 +11,11 @@ import { TastingRecordForm } from '@/components/TastingRecordForm';
 import { TastingSessionForm } from '@/components/TastingSessionForm';
 import { Loading } from '@/components/Loading';
 import type { TastingSession, TastingRecord } from '@/types';
-import { CaretLeft, PencilCircle, Notebook, Coffee as CoffeeIcon, Plus } from 'phosphor-react';
+import { CaretLeft, Plus } from 'phosphor-react';
 import { useToastContext } from '@/components/Toast';
 import { motion } from 'framer-motion';
 import { useChristmasMode } from '@/hooks/useChristmasMode';
-import { Button, IconButton } from '@/components/ui';
+import { Button, IconButton, Card } from '@/components/ui';
 
 function TastingPageContent() {
   const { user, loading: authLoading } = useAuth();
@@ -25,19 +25,6 @@ function TastingPageContent() {
   const hasRedirected = useRef(false);
   const { showToast } = useToastContext();
   const { isChristmasMode } = useChristmasMode();
-
-  // クリスマスモード用のスタイル
-  const bgPageClass = isChristmasMode ? 'bg-[#0f1f15]' : 'bg-[#F7F7F5]';
-  const textPrimaryClass = isChristmasMode ? 'text-[#f8f1e7]' : 'text-stone-800';
-  const textSecondaryClass = isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-stone-400';
-  const textLinkClass = isChristmasMode ? 'text-[#d4af37]/80 hover:text-[#d4af37]' : 'text-stone-400 hover:text-amber-600';
-  const iconBgClass = isChristmasMode ? 'bg-[#1a3d2a] border-[#d4af37]/30' : 'bg-white border-stone-100';
-  const iconGlowClass = isChristmasMode ? 'bg-[#d4af37]/20' : 'bg-amber-50';
-  const iconColorClass = isChristmasMode ? 'text-[#d4af37]' : 'text-amber-600';
-  const cardBgClass = isChristmasMode ? 'bg-[#1a3d2a] border-[#d4af37]/30' : 'bg-white border-stone-100';
-  const backButtonClass = isChristmasMode
-    ? 'text-[#d4af37]/70 hover:text-[#d4af37] bg-[#1a3d2a] border-[#d4af37]/30'
-    : 'text-stone-400 hover:text-amber-600 bg-white border-stone-100';
 
   // クエリパラメータからIDを取得
   const sessionId = searchParams?.get('sessionId');
@@ -73,14 +60,14 @@ function TastingPageContent() {
     const session = tastingSessions.find((s) => s.id === sessionId);
     if (!session) {
       return (
-        <div className={`min-h-screen py-4 sm:py-6 lg:py-8 px-4 sm:px-6 lg:px-8 ${bgPageClass}`}>
+        <div className="min-h-screen py-4 sm:py-6 lg:py-8 px-4 sm:px-6 lg:px-8" style={{ backgroundColor: isChristmasMode ? '#051a0e' : '#F7F7F5' }}>
           <div className="max-w-2xl mx-auto">
-            <div className={`${cardBgClass} rounded-lg shadow-md p-6 text-center border`}>
-              <p className={`${textSecondaryClass} mb-4`}>セッションが見つかりません</p>
-              <Link href="/tasting" className={`${isChristmasMode ? 'text-[#d4af37]' : 'text-[#8B4513]'} hover:underline`}>
+            <Card isChristmasMode={isChristmasMode} className="p-6 text-center">
+              <p className={`mb-4 ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>セッションが見つかりません</p>
+              <Link href="/tasting" className={`${isChristmasMode ? 'text-[#d4af37]' : 'text-amber-600'} hover:underline`}>
                 一覧に戻る
               </Link>
-            </div>
+            </Card>
           </div>
         </div>
       );
@@ -128,7 +115,7 @@ function TastingPageContent() {
     };
 
     return (
-      <div className={`min-h-screen py-8 sm:py-12 lg:py-16 px-4 sm:px-6 lg:px-8 ${bgPageClass}`}>
+      <div className="min-h-screen py-8 sm:py-12 lg:py-16 px-4 sm:px-6 lg:px-8" style={{ backgroundColor: isChristmasMode ? '#051a0e' : '#F7F7F5' }}>
         <div className="max-w-2xl mx-auto space-y-10">
           <motion.header
             initial={{ opacity: 0, y: -10 }}
@@ -137,22 +124,20 @@ function TastingPageContent() {
           >
             <Link
               href="/tasting"
-              className={`absolute left-0 top-0 group flex items-center gap-2 ${textLinkClass} transition-colors font-bold text-sm uppercase tracking-widest`}
+              className={`absolute left-0 top-0 group flex items-center gap-2 transition-colors font-bold text-sm uppercase tracking-widest ${
+                isChristmasMode
+                  ? 'text-[#f8f1e7]/70 hover:text-[#f8f1e7]'
+                  : 'text-gray-600 hover:text-gray-800'
+              }`}
             >
               <CaretLeft size={20} weight="bold" className="group-hover:-translate-x-1 transition-transform" />
               一覧に戻る
             </Link>
 
-            <div className="flex flex-col items-center space-y-2">
-              <div className={`p-5 ${iconBgClass} rounded-[2.5rem] shadow-sm border mb-4 relative`}>
-                <div className={`absolute inset-0 ${iconGlowClass} rounded-[2.5rem] scale-110 blur-2xl opacity-30 -z-10`} />
-                <PencilCircle size={48} weight="duotone" className={iconColorClass} />
-              </div>
-              <h1 className={`text-3xl sm:text-4xl font-black ${textPrimaryClass} tracking-tight`}>
-                セッションを編集
-              </h1>
-              <p className={`${textSecondaryClass} font-medium`}>セッションの情報を更新します</p>
-            </div>
+            <h1 className={`text-3xl sm:text-4xl font-black tracking-tight ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
+              セッションを編集
+            </h1>
+            <p className={`mt-2 font-medium ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500'}`}>セッションの情報を更新します</p>
           </motion.header>
 
           <main>
@@ -173,14 +158,14 @@ function TastingPageContent() {
     const record = tastingRecords.find((r) => r.id === recordId);
     if (!record) {
       return (
-        <div className={`min-h-screen py-4 sm:py-6 lg:py-8 px-4 sm:px-6 lg:px-8 ${bgPageClass}`}>
+        <div className="min-h-screen py-4 sm:py-6 lg:py-8 px-4 sm:px-6 lg:px-8" style={{ backgroundColor: isChristmasMode ? '#051a0e' : '#F7F7F5' }}>
           <div className="max-w-2xl mx-auto">
-            <div className={`${cardBgClass} rounded-lg shadow-md p-6 text-center border`}>
-              <p className={`${textSecondaryClass} mb-4`}>記録が見つかりません</p>
-              <Link href="/tasting" className={`${isChristmasMode ? 'text-[#d4af37]' : 'text-[#8B4513]'} hover:underline`}>
+            <Card isChristmasMode={isChristmasMode} className="p-6 text-center">
+              <p className={`mb-4 ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>記録が見つかりません</p>
+              <Link href="/tasting" className={`${isChristmasMode ? 'text-[#d4af37]' : 'text-amber-600'} hover:underline`}>
                 一覧に戻る
               </Link>
-            </div>
+            </Card>
           </div>
         </div>
       );
@@ -226,7 +211,7 @@ function TastingPageContent() {
     };
 
     return (
-      <div className={`min-h-screen py-8 sm:py-12 lg:py-16 px-4 sm:px-6 lg:px-8 ${bgPageClass}`}>
+      <div className="min-h-screen py-8 sm:py-12 lg:py-16 px-4 sm:px-6 lg:px-8" style={{ backgroundColor: isChristmasMode ? '#051a0e' : '#F7F7F5' }}>
         <div className="max-w-2xl mx-auto space-y-10">
           <motion.header
             initial={{ opacity: 0, y: -10 }}
@@ -235,22 +220,20 @@ function TastingPageContent() {
           >
             <Link
               href="/tasting"
-              className={`absolute left-0 top-0 group flex items-center gap-2 ${textLinkClass} transition-colors font-bold text-sm uppercase tracking-widest`}
+              className={`absolute left-0 top-0 group flex items-center gap-2 transition-colors font-bold text-sm uppercase tracking-widest ${
+                isChristmasMode
+                  ? 'text-[#f8f1e7]/70 hover:text-[#f8f1e7]'
+                  : 'text-gray-600 hover:text-gray-800'
+              }`}
             >
               <CaretLeft size={20} weight="bold" className="group-hover:-translate-x-1 transition-transform" />
               一覧に戻る
             </Link>
 
-            <div className="flex flex-col items-center space-y-3">
-              <div className={`p-5 ${iconBgClass} rounded-[2.5rem] shadow-sm border mb-4 relative`}>
-                <div className={`absolute inset-0 ${iconGlowClass} rounded-[2.5rem] scale-110 blur-2xl opacity-30 -z-10`} />
-                <Notebook size={48} weight="duotone" className={iconColorClass} />
-              </div>
-              <h1 className={`text-3xl sm:text-4xl font-black ${textPrimaryClass} tracking-tight`}>
-                記録を編集
-              </h1>
-              <p className={`${textSecondaryClass} font-medium`}>試飲の感想を更新します</p>
-            </div>
+            <h1 className={`text-3xl sm:text-4xl font-black tracking-tight ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
+              記録を編集
+            </h1>
+            <p className={`mt-2 font-medium ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500'}`}>試飲の感想を更新します</p>
           </motion.header>
 
           <main>
@@ -272,21 +255,21 @@ function TastingPageContent() {
     const session = tastingSessions.find((s) => s.id === sessionId);
     if (!session) {
       return (
-        <div className={`min-h-screen py-4 sm:py-6 lg:py-8 px-4 sm:px-6 lg:px-8 ${bgPageClass}`}>
+        <div className="min-h-screen py-4 sm:py-6 lg:py-8 px-4 sm:px-6 lg:px-8" style={{ backgroundColor: isChristmasMode ? '#051a0e' : '#F7F7F5' }}>
           <div className="max-w-4xl mx-auto">
-            <div className={`${cardBgClass} rounded-lg shadow-md p-6 text-center border`}>
-              <p className={`${textSecondaryClass} mb-4`}>セッションが見つかりません</p>
-              <Link href="/tasting" className={`${isChristmasMode ? 'text-[#d4af37]' : 'text-[#8B4513]'} hover:underline`}>
+            <Card isChristmasMode={isChristmasMode} className="p-6 text-center">
+              <p className={`mb-4 ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>セッションが見つかりません</p>
+              <Link href="/tasting" className={`${isChristmasMode ? 'text-[#d4af37]' : 'text-amber-600'} hover:underline`}>
                 一覧に戻る
               </Link>
-            </div>
+            </Card>
           </div>
         </div>
       );
     }
 
     return (
-      <div className={`min-h-screen py-8 sm:py-12 lg:py-16 px-4 sm:px-6 lg:px-8 ${bgPageClass}`}>
+      <div className="min-h-screen py-8 sm:py-12 lg:py-16 px-4 sm:px-6 lg:px-8" style={{ backgroundColor: isChristmasMode ? '#051a0e' : '#F7F7F5' }}>
         <div className="max-w-4xl mx-auto space-y-10">
           <motion.header
             initial={{ opacity: 0, y: -10 }}
@@ -295,22 +278,20 @@ function TastingPageContent() {
           >
             <Link
               href="/tasting"
-              className={`absolute left-0 top-0 group flex items-center gap-2 ${textLinkClass} transition-colors font-bold text-sm uppercase tracking-widest`}
+              className={`absolute left-0 top-0 group flex items-center gap-2 transition-colors font-bold text-sm uppercase tracking-widest ${
+                isChristmasMode
+                  ? 'text-[#f8f1e7]/70 hover:text-[#f8f1e7]'
+                  : 'text-gray-600 hover:text-gray-800'
+              }`}
             >
               <CaretLeft size={20} weight="bold" className="group-hover:-translate-x-1 transition-transform" />
               一覧に戻る
             </Link>
 
-            <div className="flex flex-col items-center space-y-3">
-              <div className={`p-5 ${iconBgClass} rounded-[2.5rem] shadow-sm border mb-4 relative`}>
-                <div className={`absolute inset-0 ${iconGlowClass} rounded-[2.5rem] scale-110 blur-2xl opacity-30 -z-10`} />
-                <CoffeeIcon size={48} weight="duotone" className={iconColorClass} />
-              </div>
-              <h1 className={`text-3xl sm:text-4xl font-black ${textPrimaryClass} tracking-tight`}>
-                記録の追加・編集
-              </h1>
-              <p className={`${textSecondaryClass} font-medium`}>セッションの試飲記録を管理します</p>
-            </div>
+            <h1 className={`text-3xl sm:text-4xl font-black tracking-tight ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
+              記録の追加・編集
+            </h1>
+            <p className={`mt-2 font-medium ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500'}`}>セッションの試飲記録を管理します</p>
           </motion.header>
 
           <main>
@@ -325,18 +306,22 @@ function TastingPageContent() {
   const isEmpty = tastingSessions.length === 0;
 
   return (
-    <div className={`min-h-screen flex flex-col px-4 sm:px-6 lg:px-8 pt-4 sm:pt-6 lg:pt-8 pb-2 sm:pb-3 lg:pb-4 ${bgPageClass}`}>
+    <div className="min-h-screen flex flex-col px-4 sm:px-6 lg:px-8 pt-4 sm:pt-6 lg:pt-8 pb-2 sm:pb-3 lg:pb-4" style={{ backgroundColor: isChristmasMode ? '#051a0e' : '#F7F7F5' }}>
       <div className="max-w-7xl mx-auto w-full flex flex-col flex-1 min-h-0">
         <header className="mb-4 sm:mb-6 flex-shrink-0">
           <div className="relative flex flex-col sm:flex-row items-center gap-4">
             <div className="flex justify-between items-center w-full sm:w-auto sm:flex-1">
               <Link
                 href="/"
-                className={`group p-2 ${backButtonClass} transition-colors flex items-center justify-center min-h-[44px] min-w-[44px] rounded-2xl border shadow-sm`}
+                className={`px-3 py-2 rounded transition-colors flex items-center justify-center min-h-[44px] min-w-[44px] ${
+                  isChristmasMode
+                    ? 'text-[#f8f1e7]/70 hover:text-[#f8f1e7] hover:bg-white/10'
+                    : 'text-gray-600 hover:text-gray-800 hover:bg-gray-100'
+                }`}
                 title="戻る"
                 aria-label="戻る"
               >
-                <CaretLeft size={24} weight="bold" className="group-hover:-translate-x-1 transition-transform" />
+                <CaretLeft size={24} weight="bold" />
               </Link>
               <div className="flex items-center gap-2 sm:hidden">
                 <div id="filter-button-container-mobile" className="min-w-[1px]"></div>
@@ -353,7 +338,7 @@ function TastingPageContent() {
               </div>
             </div>
 
-            <h1 className={`hidden sm:block absolute left-1/2 transform -translate-x-1/2 text-2xl sm:text-3xl font-black ${textPrimaryClass} tracking-tight`}>
+            <h1 className={`hidden sm:block absolute left-1/2 transform -translate-x-1/2 text-2xl sm:text-3xl font-black tracking-tight ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
               試飲感想記録
             </h1>
 
@@ -383,8 +368,6 @@ function TastingPageContent() {
             filterButtonContainerIdMobile="filter-button-container-mobile"
           />
         </main>
-
-
       </div>
     </div>
   );
@@ -397,4 +380,3 @@ export default function TastingPage() {
     </Suspense>
   );
 }
-

--- a/app/tasting/page.tsx
+++ b/app/tasting/page.tsx
@@ -14,6 +14,8 @@ import type { TastingSession, TastingRecord } from '@/types';
 import { CaretLeft, PencilCircle, Notebook, Coffee as CoffeeIcon, Plus } from 'phosphor-react';
 import { useToastContext } from '@/components/Toast';
 import { motion } from 'framer-motion';
+import { useChristmasMode } from '@/hooks/useChristmasMode';
+import { Button, IconButton } from '@/components/ui';
 
 function TastingPageContent() {
   const { user, loading: authLoading } = useAuth();
@@ -22,6 +24,20 @@ function TastingPageContent() {
   const searchParams = useSearchParams();
   const hasRedirected = useRef(false);
   const { showToast } = useToastContext();
+  const { isChristmasMode } = useChristmasMode();
+
+  // クリスマスモード用のスタイル
+  const bgPageClass = isChristmasMode ? 'bg-[#0f1f15]' : 'bg-[#F7F7F5]';
+  const textPrimaryClass = isChristmasMode ? 'text-[#f8f1e7]' : 'text-stone-800';
+  const textSecondaryClass = isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-stone-400';
+  const textLinkClass = isChristmasMode ? 'text-[#d4af37]/80 hover:text-[#d4af37]' : 'text-stone-400 hover:text-amber-600';
+  const iconBgClass = isChristmasMode ? 'bg-[#1a3d2a] border-[#d4af37]/30' : 'bg-white border-stone-100';
+  const iconGlowClass = isChristmasMode ? 'bg-[#d4af37]/20' : 'bg-amber-50';
+  const iconColorClass = isChristmasMode ? 'text-[#d4af37]' : 'text-amber-600';
+  const cardBgClass = isChristmasMode ? 'bg-[#1a3d2a] border-[#d4af37]/30' : 'bg-white border-stone-100';
+  const backButtonClass = isChristmasMode
+    ? 'text-[#d4af37]/70 hover:text-[#d4af37] bg-[#1a3d2a] border-[#d4af37]/30'
+    : 'text-stone-400 hover:text-amber-600 bg-white border-stone-100';
 
   // クエリパラメータからIDを取得
   const sessionId = searchParams?.get('sessionId');
@@ -57,11 +73,11 @@ function TastingPageContent() {
     const session = tastingSessions.find((s) => s.id === sessionId);
     if (!session) {
       return (
-        <div className="min-h-screen py-4 sm:py-6 lg:py-8 px-4 sm:px-6 lg:px-8" style={{ backgroundColor: '#F7F7F5' }}>
+        <div className={`min-h-screen py-4 sm:py-6 lg:py-8 px-4 sm:px-6 lg:px-8 ${bgPageClass}`}>
           <div className="max-w-2xl mx-auto">
-            <div className="bg-white rounded-lg shadow-md p-6 text-center">
-              <p className="text-gray-600 mb-4">セッションが見つかりません</p>
-              <Link href="/tasting" className="text-[#8B4513] hover:underline">
+            <div className={`${cardBgClass} rounded-lg shadow-md p-6 text-center border`}>
+              <p className={`${textSecondaryClass} mb-4`}>セッションが見つかりません</p>
+              <Link href="/tasting" className={`${isChristmasMode ? 'text-[#d4af37]' : 'text-[#8B4513]'} hover:underline`}>
                 一覧に戻る
               </Link>
             </div>
@@ -112,7 +128,7 @@ function TastingPageContent() {
     };
 
     return (
-      <div className="min-h-screen py-8 sm:py-12 lg:py-16 px-4 sm:px-6 lg:px-8" style={{ backgroundColor: '#F7F7F5' }}>
+      <div className={`min-h-screen py-8 sm:py-12 lg:py-16 px-4 sm:px-6 lg:px-8 ${bgPageClass}`}>
         <div className="max-w-2xl mx-auto space-y-10">
           <motion.header
             initial={{ opacity: 0, y: -10 }}
@@ -121,21 +137,21 @@ function TastingPageContent() {
           >
             <Link
               href="/tasting"
-              className="absolute left-0 top-0 group flex items-center gap-2 text-stone-400 hover:text-amber-600 transition-colors font-bold text-sm uppercase tracking-widest"
+              className={`absolute left-0 top-0 group flex items-center gap-2 ${textLinkClass} transition-colors font-bold text-sm uppercase tracking-widest`}
             >
               <CaretLeft size={20} weight="bold" className="group-hover:-translate-x-1 transition-transform" />
               一覧に戻る
             </Link>
 
             <div className="flex flex-col items-center space-y-2">
-              <div className="p-5 bg-white rounded-[2.5rem] shadow-sm border border-stone-100 mb-4 relative">
-                <div className="absolute inset-0 bg-amber-50 rounded-[2.5rem] scale-110 blur-2xl opacity-30 -z-10" />
-                <PencilCircle size={48} weight="duotone" className="text-amber-600" />
+              <div className={`p-5 ${iconBgClass} rounded-[2.5rem] shadow-sm border mb-4 relative`}>
+                <div className={`absolute inset-0 ${iconGlowClass} rounded-[2.5rem] scale-110 blur-2xl opacity-30 -z-10`} />
+                <PencilCircle size={48} weight="duotone" className={iconColorClass} />
               </div>
-              <h1 className="text-3xl sm:text-4xl font-black text-stone-800 tracking-tight">
+              <h1 className={`text-3xl sm:text-4xl font-black ${textPrimaryClass} tracking-tight`}>
                 セッションを編集
               </h1>
-              <p className="text-stone-400 font-medium">セッションの情報を更新します</p>
+              <p className={`${textSecondaryClass} font-medium`}>セッションの情報を更新します</p>
             </div>
           </motion.header>
 
@@ -157,11 +173,11 @@ function TastingPageContent() {
     const record = tastingRecords.find((r) => r.id === recordId);
     if (!record) {
       return (
-        <div className="min-h-screen py-4 sm:py-6 lg:py-8 px-4 sm:px-6 lg:px-8" style={{ backgroundColor: '#F7F7F5' }}>
+        <div className={`min-h-screen py-4 sm:py-6 lg:py-8 px-4 sm:px-6 lg:px-8 ${bgPageClass}`}>
           <div className="max-w-2xl mx-auto">
-            <div className="bg-white rounded-lg shadow-md p-6 text-center">
-              <p className="text-gray-600 mb-4">記録が見つかりません</p>
-              <Link href="/tasting" className="text-[#8B4513] hover:underline">
+            <div className={`${cardBgClass} rounded-lg shadow-md p-6 text-center border`}>
+              <p className={`${textSecondaryClass} mb-4`}>記録が見つかりません</p>
+              <Link href="/tasting" className={`${isChristmasMode ? 'text-[#d4af37]' : 'text-[#8B4513]'} hover:underline`}>
                 一覧に戻る
               </Link>
             </div>
@@ -210,7 +226,7 @@ function TastingPageContent() {
     };
 
     return (
-      <div className="min-h-screen py-8 sm:py-12 lg:py-16 px-4 sm:px-6 lg:px-8" style={{ backgroundColor: '#F7F7F5' }}>
+      <div className={`min-h-screen py-8 sm:py-12 lg:py-16 px-4 sm:px-6 lg:px-8 ${bgPageClass}`}>
         <div className="max-w-2xl mx-auto space-y-10">
           <motion.header
             initial={{ opacity: 0, y: -10 }}
@@ -219,21 +235,21 @@ function TastingPageContent() {
           >
             <Link
               href="/tasting"
-              className="absolute left-0 top-0 group flex items-center gap-2 text-stone-400 hover:text-amber-600 transition-colors font-bold text-sm uppercase tracking-widest"
+              className={`absolute left-0 top-0 group flex items-center gap-2 ${textLinkClass} transition-colors font-bold text-sm uppercase tracking-widest`}
             >
               <CaretLeft size={20} weight="bold" className="group-hover:-translate-x-1 transition-transform" />
               一覧に戻る
             </Link>
 
             <div className="flex flex-col items-center space-y-3">
-              <div className="p-5 bg-white rounded-[2.5rem] shadow-sm border border-stone-100 mb-4 relative">
-                <div className="absolute inset-0 bg-amber-50 rounded-[2.5rem] scale-110 blur-2xl opacity-30 -z-10" />
-                <Notebook size={48} weight="duotone" className="text-amber-600" />
+              <div className={`p-5 ${iconBgClass} rounded-[2.5rem] shadow-sm border mb-4 relative`}>
+                <div className={`absolute inset-0 ${iconGlowClass} rounded-[2.5rem] scale-110 blur-2xl opacity-30 -z-10`} />
+                <Notebook size={48} weight="duotone" className={iconColorClass} />
               </div>
-              <h1 className="text-3xl sm:text-4xl font-black text-stone-800 tracking-tight">
+              <h1 className={`text-3xl sm:text-4xl font-black ${textPrimaryClass} tracking-tight`}>
                 記録を編集
               </h1>
-              <p className="text-stone-400 font-medium">試飲の感想を更新します</p>
+              <p className={`${textSecondaryClass} font-medium`}>試飲の感想を更新します</p>
             </div>
           </motion.header>
 
@@ -256,11 +272,11 @@ function TastingPageContent() {
     const session = tastingSessions.find((s) => s.id === sessionId);
     if (!session) {
       return (
-        <div className="min-h-screen py-4 sm:py-6 lg:py-8 px-4 sm:px-6 lg:px-8" style={{ backgroundColor: '#F7F7F5' }}>
+        <div className={`min-h-screen py-4 sm:py-6 lg:py-8 px-4 sm:px-6 lg:px-8 ${bgPageClass}`}>
           <div className="max-w-4xl mx-auto">
-            <div className="bg-white rounded-lg shadow-md p-6 text-center">
-              <p className="text-gray-600 mb-4">セッションが見つかりません</p>
-              <Link href="/tasting" className="text-[#8B4513] hover:underline">
+            <div className={`${cardBgClass} rounded-lg shadow-md p-6 text-center border`}>
+              <p className={`${textSecondaryClass} mb-4`}>セッションが見つかりません</p>
+              <Link href="/tasting" className={`${isChristmasMode ? 'text-[#d4af37]' : 'text-[#8B4513]'} hover:underline`}>
                 一覧に戻る
               </Link>
             </div>
@@ -270,7 +286,7 @@ function TastingPageContent() {
     }
 
     return (
-      <div className="min-h-screen py-8 sm:py-12 lg:py-16 px-4 sm:px-6 lg:px-8" style={{ backgroundColor: '#F7F7F5' }}>
+      <div className={`min-h-screen py-8 sm:py-12 lg:py-16 px-4 sm:px-6 lg:px-8 ${bgPageClass}`}>
         <div className="max-w-4xl mx-auto space-y-10">
           <motion.header
             initial={{ opacity: 0, y: -10 }}
@@ -279,21 +295,21 @@ function TastingPageContent() {
           >
             <Link
               href="/tasting"
-              className="absolute left-0 top-0 group flex items-center gap-2 text-stone-400 hover:text-amber-600 transition-colors font-bold text-sm uppercase tracking-widest"
+              className={`absolute left-0 top-0 group flex items-center gap-2 ${textLinkClass} transition-colors font-bold text-sm uppercase tracking-widest`}
             >
               <CaretLeft size={20} weight="bold" className="group-hover:-translate-x-1 transition-transform" />
               一覧に戻る
             </Link>
 
             <div className="flex flex-col items-center space-y-3">
-              <div className="p-5 bg-white rounded-[2.5rem] shadow-sm border border-stone-100 mb-4 relative">
-                <div className="absolute inset-0 bg-amber-50 rounded-[2.5rem] scale-110 blur-2xl opacity-30 -z-10" />
-                <CoffeeIcon size={48} weight="duotone" className="text-amber-600" />
+              <div className={`p-5 ${iconBgClass} rounded-[2.5rem] shadow-sm border mb-4 relative`}>
+                <div className={`absolute inset-0 ${iconGlowClass} rounded-[2.5rem] scale-110 blur-2xl opacity-30 -z-10`} />
+                <CoffeeIcon size={48} weight="duotone" className={iconColorClass} />
               </div>
-              <h1 className="text-3xl sm:text-4xl font-black text-stone-800 tracking-tight">
+              <h1 className={`text-3xl sm:text-4xl font-black ${textPrimaryClass} tracking-tight`}>
                 記録の追加・編集
               </h1>
-              <p className="text-stone-400 font-medium">セッションの試飲記録を管理します</p>
+              <p className={`${textSecondaryClass} font-medium`}>セッションの試飲記録を管理します</p>
             </div>
           </motion.header>
 
@@ -309,14 +325,14 @@ function TastingPageContent() {
   const isEmpty = tastingSessions.length === 0;
 
   return (
-    <div className="min-h-screen flex flex-col px-4 sm:px-6 lg:px-8 pt-4 sm:pt-6 lg:pt-8 pb-2 sm:pb-3 lg:pb-4" style={{ backgroundColor: '#F7F7F5' }}>
+    <div className={`min-h-screen flex flex-col px-4 sm:px-6 lg:px-8 pt-4 sm:pt-6 lg:pt-8 pb-2 sm:pb-3 lg:pb-4 ${bgPageClass}`}>
       <div className="max-w-7xl mx-auto w-full flex flex-col flex-1 min-h-0">
         <header className="mb-4 sm:mb-6 flex-shrink-0">
           <div className="relative flex flex-col sm:flex-row items-center gap-4">
             <div className="flex justify-between items-center w-full sm:w-auto sm:flex-1">
               <Link
                 href="/"
-                className="group p-2 text-stone-400 hover:text-amber-600 transition-colors flex items-center justify-center min-h-[44px] min-w-[44px] bg-white rounded-2xl border border-stone-100 shadow-sm"
+                className={`group p-2 ${backButtonClass} transition-colors flex items-center justify-center min-h-[44px] min-w-[44px] rounded-2xl border shadow-sm`}
                 title="戻る"
                 aria-label="戻る"
               >
@@ -325,32 +341,35 @@ function TastingPageContent() {
               <div className="flex items-center gap-2 sm:hidden">
                 <div id="filter-button-container-mobile" className="min-w-[1px]"></div>
                 {!isEmpty && (
-                  <Link
-                    href="/tasting/sessions/new"
-                    className="p-2.5 bg-gradient-to-r from-amber-600 to-amber-500 text-white rounded-2xl shadow-md hover:from-amber-700 hover:to-amber-600 transition-all active:scale-95 flex items-center justify-center min-h-[44px] min-w-[44px]"
+                  <IconButton
+                    variant="primary"
+                    onClick={() => router.push('/tasting/sessions/new')}
                     aria-label="新規セッション作成"
+                    isChristmasMode={isChristmasMode}
                   >
                     <Plus size={22} weight="bold" />
-                  </Link>
+                  </IconButton>
                 )}
               </div>
             </div>
 
-            <h1 className="hidden sm:block absolute left-1/2 transform -translate-x-1/2 text-2xl sm:text-3xl font-black text-stone-800 tracking-tight">
+            <h1 className={`hidden sm:block absolute left-1/2 transform -translate-x-1/2 text-2xl sm:text-3xl font-black ${textPrimaryClass} tracking-tight`}>
               試飲感想記録
             </h1>
 
             <div className="hidden sm:flex justify-end items-center gap-2 sm:gap-3 w-full sm:w-auto sm:flex-1">
               <div id="filter-button-container" className="min-w-[1px]"></div>
               {!isEmpty && (
-                <Link
-                  href="/tasting/sessions/new"
-                  className="px-4 py-2.5 bg-gradient-to-r from-amber-600 to-amber-500 text-white rounded-2xl font-black text-sm shadow-md hover:from-amber-700 hover:to-amber-600 transition-all active:scale-95 flex items-center gap-2 min-h-[44px] flex-shrink-0"
+                <Button
+                  variant="primary"
+                  onClick={() => router.push('/tasting/sessions/new')}
                   aria-label="新規セッション作成"
+                  isChristmasMode={isChristmasMode}
+                  className="flex items-center gap-2"
                 >
                   <Plus size={20} weight="bold" />
                   <span className="whitespace-nowrap">セッションを作成</span>
-                </Link>
+                </Button>
               )}
             </div>
           </div>

--- a/app/tasting/page.tsx
+++ b/app/tasting/page.tsx
@@ -11,11 +11,11 @@ import { TastingRecordForm } from '@/components/TastingRecordForm';
 import { TastingSessionForm } from '@/components/TastingSessionForm';
 import { Loading } from '@/components/Loading';
 import type { TastingSession, TastingRecord } from '@/types';
-import { CaretLeft, Plus } from 'phosphor-react';
+import { Plus } from 'phosphor-react';
 import { useToastContext } from '@/components/Toast';
 import { motion } from 'framer-motion';
 import { useChristmasMode } from '@/hooks/useChristmasMode';
-import { Button, IconButton, Card } from '@/components/ui';
+import { Button, IconButton, Card, BackLink } from '@/components/ui';
 
 function TastingPageContent() {
   const { user, loading: authLoading } = useAuth();
@@ -115,29 +115,24 @@ function TastingPageContent() {
     };
 
     return (
-      <div className="min-h-screen py-8 sm:py-12 lg:py-16 px-4 sm:px-6 lg:px-8" style={{ backgroundColor: isChristmasMode ? '#051a0e' : '#F7F7F5' }}>
-        <div className="max-w-2xl mx-auto space-y-10">
+      <div className="min-h-screen py-6 sm:py-8 px-4 sm:px-6" style={{ backgroundColor: isChristmasMode ? '#051a0e' : '#F7F7F5' }}>
+        <div className="max-w-lg mx-auto space-y-6">
           <motion.header
             initial={{ opacity: 0, y: -10 }}
             animate={{ opacity: 1, y: 0 }}
-            className="relative flex flex-col items-center text-center pt-12"
+            className="relative flex flex-col items-center text-center pt-6"
           >
-            <Link
+            <BackLink
               href="/tasting"
-              className={`absolute left-0 top-0 group flex items-center gap-2 transition-colors font-bold text-sm uppercase tracking-widest ${
-                isChristmasMode
-                  ? 'text-[#f8f1e7]/70 hover:text-[#f8f1e7]'
-                  : 'text-gray-600 hover:text-gray-800'
-              }`}
-            >
-              <CaretLeft size={20} weight="bold" className="group-hover:-translate-x-1 transition-transform" />
-              一覧に戻る
-            </Link>
+              variant="icon-only"
+              isChristmasMode={isChristmasMode}
+              className="absolute left-0 top-0"
+            />
 
-            <h1 className={`text-3xl sm:text-4xl font-black tracking-tight ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
+            <h1 className={`text-2xl sm:text-3xl font-black tracking-tight ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
               セッションを編集
             </h1>
-            <p className={`mt-2 font-medium ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500'}`}>セッションの情報を更新します</p>
+            <p className={`mt-1 text-sm font-medium ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500'}`}>セッションの情報を更新します</p>
           </motion.header>
 
           <main>
@@ -211,29 +206,24 @@ function TastingPageContent() {
     };
 
     return (
-      <div className="min-h-screen py-8 sm:py-12 lg:py-16 px-4 sm:px-6 lg:px-8" style={{ backgroundColor: isChristmasMode ? '#051a0e' : '#F7F7F5' }}>
-        <div className="max-w-2xl mx-auto space-y-10">
+      <div className="min-h-screen py-6 sm:py-8 px-4 sm:px-6" style={{ backgroundColor: isChristmasMode ? '#051a0e' : '#F7F7F5' }}>
+        <div className="max-w-lg mx-auto space-y-6">
           <motion.header
             initial={{ opacity: 0, y: -10 }}
             animate={{ opacity: 1, y: 0 }}
-            className="relative flex flex-col items-center text-center pt-12"
+            className="relative flex flex-col items-center text-center pt-6"
           >
-            <Link
+            <BackLink
               href="/tasting"
-              className={`absolute left-0 top-0 group flex items-center gap-2 transition-colors font-bold text-sm uppercase tracking-widest ${
-                isChristmasMode
-                  ? 'text-[#f8f1e7]/70 hover:text-[#f8f1e7]'
-                  : 'text-gray-600 hover:text-gray-800'
-              }`}
-            >
-              <CaretLeft size={20} weight="bold" className="group-hover:-translate-x-1 transition-transform" />
-              一覧に戻る
-            </Link>
+              variant="icon-only"
+              isChristmasMode={isChristmasMode}
+              className="absolute left-0 top-0"
+            />
 
-            <h1 className={`text-3xl sm:text-4xl font-black tracking-tight ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
+            <h1 className={`text-2xl sm:text-3xl font-black tracking-tight ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
               記録を編集
             </h1>
-            <p className={`mt-2 font-medium ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500'}`}>試飲の感想を更新します</p>
+            <p className={`mt-1 text-sm font-medium ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500'}`}>試飲の感想を更新します</p>
           </motion.header>
 
           <main>
@@ -269,29 +259,24 @@ function TastingPageContent() {
     }
 
     return (
-      <div className="min-h-screen py-8 sm:py-12 lg:py-16 px-4 sm:px-6 lg:px-8" style={{ backgroundColor: isChristmasMode ? '#051a0e' : '#F7F7F5' }}>
-        <div className="max-w-4xl mx-auto space-y-10">
+      <div className="min-h-screen py-6 sm:py-8 px-4 sm:px-6" style={{ backgroundColor: isChristmasMode ? '#051a0e' : '#F7F7F5' }}>
+        <div className="max-w-lg mx-auto space-y-6">
           <motion.header
             initial={{ opacity: 0, y: -10 }}
             animate={{ opacity: 1, y: 0 }}
-            className="relative flex flex-col items-center text-center pt-12"
+            className="relative flex flex-col items-center text-center pt-6"
           >
-            <Link
+            <BackLink
               href="/tasting"
-              className={`absolute left-0 top-0 group flex items-center gap-2 transition-colors font-bold text-sm uppercase tracking-widest ${
-                isChristmasMode
-                  ? 'text-[#f8f1e7]/70 hover:text-[#f8f1e7]'
-                  : 'text-gray-600 hover:text-gray-800'
-              }`}
-            >
-              <CaretLeft size={20} weight="bold" className="group-hover:-translate-x-1 transition-transform" />
-              一覧に戻る
-            </Link>
+              variant="icon-only"
+              isChristmasMode={isChristmasMode}
+              className="absolute left-0 top-0"
+            />
 
-            <h1 className={`text-3xl sm:text-4xl font-black tracking-tight ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
+            <h1 className={`text-2xl sm:text-3xl font-black tracking-tight ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
               記録の追加・編集
             </h1>
-            <p className={`mt-2 font-medium ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500'}`}>セッションの試飲記録を管理します</p>
+            <p className={`mt-1 text-sm font-medium ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500'}`}>セッションの試飲記録を管理します</p>
           </motion.header>
 
           <main>
@@ -311,18 +296,11 @@ function TastingPageContent() {
         <header className="mb-4 sm:mb-6 flex-shrink-0">
           <div className="relative flex flex-col sm:flex-row items-center gap-4">
             <div className="flex justify-between items-center w-full sm:w-auto sm:flex-1">
-              <Link
+              <BackLink
                 href="/"
-                className={`px-3 py-2 rounded transition-colors flex items-center justify-center min-h-[44px] min-w-[44px] ${
-                  isChristmasMode
-                    ? 'text-[#f8f1e7]/70 hover:text-[#f8f1e7] hover:bg-white/10'
-                    : 'text-gray-600 hover:text-gray-800 hover:bg-gray-100'
-                }`}
-                title="戻る"
-                aria-label="戻る"
-              >
-                <CaretLeft size={24} weight="bold" />
-              </Link>
+                variant="icon-only"
+                isChristmasMode={isChristmasMode}
+              />
               <div className="flex items-center gap-2 sm:hidden">
                 <div id="filter-button-container-mobile" className="min-w-[1px]"></div>
                 {!isEmpty && (

--- a/app/tasting/sessions/new/page.tsx
+++ b/app/tasting/sessions/new/page.tsx
@@ -7,10 +7,11 @@ import { useAppData } from '@/hooks/useAppData';
 import { TastingSessionForm } from '@/components/TastingSessionForm';
 import { Loading } from '@/components/Loading';
 import type { TastingSession } from '@/types';
-import Link from 'next/link';
-import { CaretLeft, PlusCircle } from 'phosphor-react';
+import { PlusCircle } from 'phosphor-react';
 import { useToastContext } from '@/components/Toast';
 import { motion } from 'framer-motion';
+import { useChristmasMode } from '@/hooks/useChristmasMode';
+import { BackLink } from '@/components/ui';
 
 export default function NewTastingSessionPage() {
   const { user, loading: authLoading } = useAuth();
@@ -18,6 +19,7 @@ export default function NewTastingSessionPage() {
   const router = useRouter();
   const { showToast } = useToastContext();
   const hasRedirected = useRef(false);
+  const { isChristmasMode } = useChristmasMode();
 
   // 未認証時にログインページにリダイレクト
   useEffect(() => {
@@ -69,30 +71,42 @@ export default function NewTastingSessionPage() {
   };
 
   return (
-    <div className="min-h-screen py-8 sm:py-12 lg:py-16 px-4 sm:px-6 lg:px-8" style={{ backgroundColor: '#F7F7F5' }}>
-      <div className="max-w-2xl mx-auto space-y-10">
+    <div
+      className="min-h-screen py-6 sm:py-8 px-4 sm:px-6"
+      style={{ backgroundColor: isChristmasMode ? '#051a0e' : '#F7F7F5' }}
+    >
+      <div className="max-w-lg mx-auto space-y-6">
         <motion.header
           initial={{ opacity: 0, y: -10 }}
           animate={{ opacity: 1, y: 0 }}
-          className="relative flex flex-col items-center text-center pt-12"
+          className="relative flex flex-col items-center text-center pt-6"
         >
-          <Link
+          <BackLink
             href="/tasting"
-            className="absolute left-0 top-0 group flex items-center gap-2 text-stone-400 hover:text-amber-600 transition-colors font-bold text-sm uppercase tracking-widest"
-          >
-            <CaretLeft size={20} weight="bold" className="group-hover:-translate-x-1 transition-transform" />
-            一覧に戻る
-          </Link>
+            variant="icon-only"
+            isChristmasMode={isChristmasMode}
+            className="absolute left-0 top-0"
+          />
 
-          <div className="flex flex-col items-center space-y-3">
-            <div className="p-5 bg-white rounded-[2.5rem] shadow-sm border border-stone-100 mb-4 relative">
-              <div className="absolute inset-0 bg-amber-50 rounded-[2.5rem] scale-110 blur-2xl opacity-30 -z-10" />
-              <PlusCircle size={48} weight="duotone" className="text-amber-600" />
+          <div className="flex flex-col items-center space-y-2">
+            <div className={`p-3 rounded-2xl shadow-sm mb-2 relative ${
+              isChristmasMode
+                ? 'bg-[#0a2f1a] border border-[#d4af37]/30'
+                : 'bg-white border border-stone-100'
+            }`}>
+              <div className={`absolute inset-0 rounded-2xl scale-110 blur-xl opacity-30 -z-10 ${
+                isChristmasMode ? 'bg-[#d4af37]/20' : 'bg-amber-50'
+              }`} />
+              <PlusCircle size={32} weight="duotone" className={isChristmasMode ? 'text-[#d4af37]' : 'text-amber-600'} />
             </div>
-            <h1 className="text-3xl sm:text-4xl font-black text-stone-800 tracking-tight">
+            <h1 className={`text-2xl sm:text-3xl font-black tracking-tight ${
+              isChristmasMode ? 'text-[#f8f1e7]' : 'text-stone-800'
+            }`}>
               新規セッション作成
             </h1>
-            <p className="text-stone-400 font-medium">新しい試飲の記録を開始しましょう</p>
+            <p className={`text-sm font-medium ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-stone-400'}`}>
+              新しい試飲の記録を開始しましょう
+            </p>
           </div>
         </motion.header>
 

--- a/app/ui-test/page.tsx
+++ b/app/ui-test/page.tsx
@@ -1,34 +1,30 @@
 'use client';
 
-import { useState } from 'react';
 import Link from 'next/link';
-import { Button, Input, Select, Textarea, Card, IconButton, NumberInput, InlineInput, Checkbox, Switch, Badge, Tabs, TabsList, TabsTrigger, TabsContent, ProgressBar, EmptyState, Accordion, AccordionItem, AccordionTrigger, AccordionContent } from '@/components/ui';
+import { Button, Card } from '@/components/ui';
+import { componentRegistry, categoryLabels, getComponentsByCategory } from '@/components/ui/registry';
 import { useChristmasMode } from '@/hooks/useChristmasMode';
-import { HiArrowLeft, HiX, HiTrash, HiPlus, HiCheck, HiCog, HiPencil, HiInbox } from 'react-icons/hi';
-import { MdClose, MdAdd, MdDelete } from 'react-icons/md';
+import { HiArrowLeft } from 'react-icons/hi';
 
+/**
+ * UIコンポーネントテストページ
+ *
+ * 全共通コンポーネントを一覧表示し、クリスマスモードの切り替えテストが可能。
+ * 新しいコンポーネントを追加する場合は、components/ui/registry.tsx に追加するだけで
+ * 自動的にこのページに表示されます。
+ */
 export default function UITestPage() {
   const { isChristmasMode, toggleChristmasMode } = useChristmasMode();
-  const [name, setName] = useState('');
-  const [password, setPassword] = useState('');
-  const [category, setCategory] = useState('');
-  const [memo, setMemo] = useState('');
-  const [loading, setLoading] = useState(false);
-  // 新規追加コンポーネント用
-  const [width, setWidth] = useState(160);
-  const [height, setHeight] = useState(60);
-  const [inlineValue, setInlineValue] = useState('テスト値');
-  // Checkbox/Switch用
-  const [checked1, setChecked1] = useState(false);
-  const [checked2, setChecked2] = useState(true);
-  const [switchOn, setSwitchOn] = useState(false);
-  // Progress用
-  const [progress] = useState(65);
+  const componentsByCategory = getComponentsByCategory();
 
-  const handleSubmit = () => {
-    setLoading(true);
-    setTimeout(() => setLoading(false), 2000);
-  };
+  // 表示するカテゴリの順序
+  const categoryOrder: Array<keyof typeof categoryLabels> = [
+    'button',
+    'form',
+    'container',
+    'display',
+    'feedback',
+  ];
 
   return (
     <div
@@ -36,6 +32,7 @@ export default function UITestPage() {
       style={{ backgroundColor: isChristmasMode ? '#051a0e' : '#F7F7F5' }}
     >
       <div className="max-w-2xl mx-auto space-y-6">
+        {/* ヘッダー */}
         <header className="flex items-center justify-between mb-8">
           <div className="flex items-center gap-3">
             <Link
@@ -64,512 +61,62 @@ export default function UITestPage() {
           </Button>
         </header>
 
-        {/* Button Variants */}
-        <Card isChristmasMode={isChristmasMode}>
-          <h2 className={`text-lg font-bold mb-4 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
-            Button Variants
-          </h2>
-          <div className="flex flex-wrap gap-3">
-            <Button variant="primary" isChristmasMode={isChristmasMode}>Primary</Button>
-            <Button variant="secondary" isChristmasMode={isChristmasMode}>Secondary</Button>
-            <Button variant="danger" isChristmasMode={isChristmasMode}>Danger</Button>
-            <Button variant="success" isChristmasMode={isChristmasMode}>Success</Button>
-            <Button variant="outline" isChristmasMode={isChristmasMode}>Outline</Button>
-            <Button variant="ghost" isChristmasMode={isChristmasMode}>Ghost</Button>
-            <Button variant="coffee" isChristmasMode={isChristmasMode}>Coffee</Button>
-          </div>
-        </Card>
-
-        {/* Button Sizes */}
-        <Card isChristmasMode={isChristmasMode}>
-          <h2 className={`text-lg font-bold mb-4 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
-            Button Sizes
-          </h2>
-          <div className="flex flex-wrap items-center gap-3">
-            <Button size="sm" isChristmasMode={isChristmasMode}>Small</Button>
-            <Button size="md" isChristmasMode={isChristmasMode}>Medium</Button>
-            <Button size="lg" isChristmasMode={isChristmasMode}>Large</Button>
-          </div>
-        </Card>
-
-        {/* Button States */}
-        <Card isChristmasMode={isChristmasMode}>
-          <h2 className={`text-lg font-bold mb-4 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
-            Button States
-          </h2>
-          <div className="flex flex-wrap gap-3">
-            <Button disabled isChristmasMode={isChristmasMode}>Disabled</Button>
-            <Button loading={loading} onClick={handleSubmit} isChristmasMode={isChristmasMode}>
-              {loading ? '処理中...' : 'Loading Test'}
-            </Button>
-            <Button fullWidth isChristmasMode={isChristmasMode}>Full Width</Button>
-          </div>
-        </Card>
-
-        {/* Form Elements */}
-        <Card isChristmasMode={isChristmasMode}>
-          <h2 className={`text-lg font-bold mb-4 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
-            Form Elements
-          </h2>
-          <div className="space-y-4">
-            <Input
-              label="名前"
-              placeholder="山田太郎"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              isChristmasMode={isChristmasMode}
-            />
-            <Input
-              label="パスワード（トグル付き）"
-              type="password"
-              placeholder="パスワードを入力"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              showPasswordToggle
-              isChristmasMode={isChristmasMode}
-            />
-            <Input
-              label="エラー表示テスト"
-              placeholder="入力してください"
-              error="このフィールドは必須です"
-              isChristmasMode={isChristmasMode}
-            />
-            <Select
-              label="カテゴリ"
-              placeholder="選択してください"
-              options={[
-                { value: 'light', label: 'ライトロースト' },
-                { value: 'medium', label: 'ミディアムロースト' },
-                { value: 'dark', label: 'ダークロースト' },
-              ]}
-              value={category}
-              onChange={(e) => setCategory(e.target.value)}
-              isChristmasMode={isChristmasMode}
-            />
-            <Textarea
-              label="メモ"
-              placeholder="焙煎に関するメモを入力"
-              rows={4}
-              value={memo}
-              onChange={(e) => setMemo(e.target.value)}
-              isChristmasMode={isChristmasMode}
-            />
-          </div>
-        </Card>
-
-        {/* Card Variants */}
-        <div className="space-y-4">
-          <h2 className={`text-lg font-bold ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
-            Card Variants
-          </h2>
-          <Card variant="default" isChristmasMode={isChristmasMode}>
-            <p className={isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}>
-              Default Card - 基本的なカード
-            </p>
-          </Card>
-          <Card variant="hoverable" isChristmasMode={isChristmasMode}>
-            <p className={isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}>
-              Hoverable Card - ホバーするとシャドウが変化
-            </p>
-          </Card>
-          <Card variant="action" isChristmasMode={isChristmasMode}>
-            <p className={isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}>
-              Action Card - ホームページ用カード
-            </p>
-          </Card>
-          <Card variant="coffee" isChristmasMode={isChristmasMode}>
-            <p className="text-white">
-              Coffee Card - ダークブラウン背景（#211714）
-            </p>
-          </Card>
+        {/* 統計情報 */}
+        <div className={`p-4 rounded-lg ${isChristmasMode ? 'bg-white/5' : 'bg-amber-50'}`}>
+          <p className={`text-sm ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-amber-800'}`}>
+            <span className="font-bold">{componentRegistry.length}</span> 個の共通コンポーネントが登録されています
+          </p>
         </div>
 
-        {/* IconButton - NEW */}
-        <Card isChristmasMode={isChristmasMode}>
-          <h2 className={`text-lg font-bold mb-4 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
-            IconButton <span className="text-xs font-normal text-amber-500 ml-2">NEW</span>
-          </h2>
-          <p className={`text-sm mb-4 ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>
-            アイコンのみのボタン。閉じるボタン、削除ボタン等に使用。
-          </p>
+        {/* カテゴリ別コンポーネント表示 */}
+        {categoryOrder.map((category) => {
+          const components = componentsByCategory[category];
+          if (components.length === 0) return null;
 
-          <h3 className={`text-sm font-semibold mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
-            Variants
-          </h3>
-          <div className="flex flex-wrap items-center gap-3 mb-4">
-            <div className="flex flex-col items-center gap-1">
-              <IconButton variant="default" isChristmasMode={isChristmasMode}><HiX size={20} /></IconButton>
-              <span className={`text-xs ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'}`}>default</span>
+          return (
+            <div key={category} className="space-y-4">
+              {/* カテゴリヘッダー */}
+              <h2 className={`text-lg font-bold ${isChristmasMode ? 'text-[#d4af37]' : 'text-amber-700'}`}>
+                {categoryLabels[category]}
+                <span className={`ml-2 text-sm font-normal ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'}`}>
+                  ({components.length})
+                </span>
+              </h2>
+
+              {/* コンポーネントカード */}
+              {components.map((item) => (
+                <Card key={item.name} isChristmasMode={isChristmasMode}>
+                  <div className="flex items-start justify-between mb-4">
+                    <div>
+                      <h3 className={`text-lg font-bold ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
+                        {item.name}
+                        {item.isNew && (
+                          <span className="text-xs font-normal text-amber-500 ml-2">NEW</span>
+                        )}
+                      </h3>
+                      <p className={`text-sm mt-1 ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>
+                        {item.description}
+                      </p>
+                    </div>
+                  </div>
+                  <item.Demo isChristmasMode={isChristmasMode} />
+                </Card>
+              ))}
             </div>
-            <div className="flex flex-col items-center gap-1">
-              <IconButton variant="primary" isChristmasMode={isChristmasMode}><HiPlus size={20} /></IconButton>
-              <span className={`text-xs ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'}`}>primary</span>
-            </div>
-            <div className="flex flex-col items-center gap-1">
-              <IconButton variant="danger" isChristmasMode={isChristmasMode}><HiTrash size={20} /></IconButton>
-              <span className={`text-xs ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'}`}>danger</span>
-            </div>
-            <div className="flex flex-col items-center gap-1">
-              <IconButton variant="success" isChristmasMode={isChristmasMode}><HiCheck size={20} /></IconButton>
-              <span className={`text-xs ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'}`}>success</span>
-            </div>
-            <div className="flex flex-col items-center gap-1">
-              <IconButton variant="ghost" isChristmasMode={isChristmasMode}><HiCog size={20} /></IconButton>
-              <span className={`text-xs ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'}`}>ghost</span>
-            </div>
-          </div>
+          );
+        })}
 
-          <h3 className={`text-sm font-semibold mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
-            Sizes
-          </h3>
-          <div className="flex flex-wrap items-center gap-3 mb-4">
-            <div className="flex flex-col items-center gap-1">
-              <IconButton size="sm" isChristmasMode={isChristmasMode}><MdClose size={16} /></IconButton>
-              <span className={`text-xs ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'}`}>sm</span>
-            </div>
-            <div className="flex flex-col items-center gap-1">
-              <IconButton size="md" isChristmasMode={isChristmasMode}><MdClose size={20} /></IconButton>
-              <span className={`text-xs ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'}`}>md</span>
-            </div>
-            <div className="flex flex-col items-center gap-1">
-              <IconButton size="lg" isChristmasMode={isChristmasMode}><MdClose size={24} /></IconButton>
-              <span className={`text-xs ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'}`}>lg</span>
-            </div>
-          </div>
-
-          <h3 className={`text-sm font-semibold mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
-            Rounded (円形)
-          </h3>
-          <div className="flex flex-wrap items-center gap-3">
-            <IconButton rounded variant="primary" isChristmasMode={isChristmasMode}><MdAdd size={20} /></IconButton>
-            <IconButton rounded variant="danger" isChristmasMode={isChristmasMode}><MdDelete size={20} /></IconButton>
-            <IconButton rounded variant="ghost" isChristmasMode={isChristmasMode}><HiPencil size={20} /></IconButton>
-          </div>
-        </Card>
-
-        {/* NumberInput - NEW */}
-        <Card isChristmasMode={isChristmasMode}>
-          <h2 className={`text-lg font-bold mb-4 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
-            NumberInput <span className="text-xs font-normal text-amber-500 ml-2">NEW</span>
-          </h2>
-          <p className={`text-sm mb-4 ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>
-            数値入力専用コンポーネント。幅・高さ設定などに使用。suffixで単位を表示可能。
+        {/* フッター */}
+        <div className={`text-center py-8 ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-400'}`}>
+          <p className="text-sm">
+            新しいコンポーネントを追加するには<br />
+            <code className={`px-2 py-1 rounded ${isChristmasMode ? 'bg-white/10' : 'bg-gray-100'}`}>
+              components/ui/registry.tsx
+            </code>
+            <br />
+            にエントリを追加してください
           </p>
-          <div className="space-y-4">
-            <NumberInput
-              label="幅設定"
-              suffix="px"
-              value={width}
-              onChange={(e) => setWidth(parseInt(e.target.value) || 0)}
-              isChristmasMode={isChristmasMode}
-            />
-            <NumberInput
-              label="高さ設定"
-              suffix="px"
-              value={height}
-              onChange={(e) => setHeight(parseInt(e.target.value) || 0)}
-              isChristmasMode={isChristmasMode}
-            />
-            <NumberInput
-              label="エラー表示テスト"
-              suffix="px"
-              value={0}
-              onChange={() => {}}
-              error="0以上の値を入力してください"
-              isChristmasMode={isChristmasMode}
-            />
-          </div>
-        </Card>
-
-        {/* InlineInput - NEW */}
-        <Card isChristmasMode={isChristmasMode}>
-          <h2 className={`text-lg font-bold mb-4 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
-            InlineInput <span className="text-xs font-normal text-amber-500 ml-2">NEW</span>
-          </h2>
-          <p className={`text-sm mb-4 ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>
-            インライン編集用の軽量入力。テーブルセルやヘッダー内での編集に最適化。
-          </p>
-
-          <h3 className={`text-sm font-semibold mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
-            Light Background (通常の背景)
-          </h3>
-          <div className={`p-4 rounded-lg mb-4 ${isChristmasMode ? 'bg-white/5' : 'bg-gray-50'}`}>
-            <div className="flex items-center gap-2">
-              <InlineInput
-                value={inlineValue}
-                onChange={(e) => setInlineValue(e.target.value)}
-                variant="light"
-                isChristmasMode={isChristmasMode}
-              />
-              <IconButton variant="success" size="sm" isChristmasMode={isChristmasMode}>
-                <HiCheck size={16} />
-              </IconButton>
-            </div>
-          </div>
-
-          <h3 className={`text-sm font-semibold mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
-            Dark Background (ヘッダー等)
-          </h3>
-          <div className={`p-4 rounded-lg mb-4 ${isChristmasMode ? 'bg-[#0a1f12]' : 'bg-gray-800'}`}>
-            <div className="flex items-center gap-2">
-              <InlineInput
-                value={inlineValue}
-                onChange={(e) => setInlineValue(e.target.value)}
-                variant="dark"
-                isChristmasMode={isChristmasMode}
-                placeholder="班名を入力"
-              />
-              <IconButton variant="primary" size="sm" isChristmasMode={isChristmasMode}>
-                <MdAdd size={16} />
-              </IconButton>
-            </div>
-          </div>
-
-          <h3 className={`text-sm font-semibold mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
-            Text Alignment
-          </h3>
-          <div className="space-y-2">
-            <InlineInput
-              value="左揃え"
-              textAlign="left"
-              variant="light"
-              isChristmasMode={isChristmasMode}
-              readOnly
-            />
-            <InlineInput
-              value="中央揃え"
-              textAlign="center"
-              variant="light"
-              isChristmasMode={isChristmasMode}
-              readOnly
-            />
-            <InlineInput
-              value="右揃え"
-              textAlign="right"
-              variant="light"
-              isChristmasMode={isChristmasMode}
-              readOnly
-            />
-          </div>
-        </Card>
-
-        {/* Checkbox - NEW */}
-        <Card isChristmasMode={isChristmasMode}>
-          <h2 className={`text-lg font-bold mb-4 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
-            Checkbox <span className="text-xs font-normal text-amber-500 ml-2">NEW</span>
-          </h2>
-          <p className={`text-sm mb-4 ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>
-            チェックボックス。設定画面やフィルターで使用。
-          </p>
-          <div className="space-y-4">
-            <Checkbox
-              label="基本的なチェックボックス"
-              checked={checked1}
-              onChange={(e) => setChecked1(e.target.checked)}
-              isChristmasMode={isChristmasMode}
-            />
-            <Checkbox
-              label="説明文付き"
-              description="このオプションを有効にすると、通知が送信されます。"
-              checked={checked2}
-              onChange={(e) => setChecked2(e.target.checked)}
-              isChristmasMode={isChristmasMode}
-            />
-            <Checkbox
-              label="無効状態"
-              disabled
-              isChristmasMode={isChristmasMode}
-            />
-          </div>
-        </Card>
-
-        {/* Switch - NEW */}
-        <Card isChristmasMode={isChristmasMode}>
-          <h2 className={`text-lg font-bold mb-4 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
-            Switch <span className="text-xs font-normal text-amber-500 ml-2">NEW</span>
-          </h2>
-          <p className={`text-sm mb-4 ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>
-            ON/OFFトグルスイッチ。モード切替などに使用。
-          </p>
-
-          <h3 className={`text-sm font-semibold mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
-            基本
-          </h3>
-          <div className="space-y-4 mb-4">
-            <Switch
-              label="通知を有効にする"
-              checked={switchOn}
-              onChange={(e) => setSwitchOn(e.target.checked)}
-              isChristmasMode={isChristmasMode}
-            />
-            <Switch
-              label="無効状態"
-              checked={false}
-              disabled
-              isChristmasMode={isChristmasMode}
-            />
-          </div>
-
-          <h3 className={`text-sm font-semibold mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
-            サイズ
-          </h3>
-          <div className="flex flex-wrap items-center gap-6">
-            <Switch size="sm" checked={true} label="Small" isChristmasMode={isChristmasMode} />
-            <Switch size="md" checked={true} label="Medium" isChristmasMode={isChristmasMode} />
-            <Switch size="lg" checked={true} label="Large" isChristmasMode={isChristmasMode} />
-          </div>
-        </Card>
-
-        {/* Badge - NEW */}
-        <Card isChristmasMode={isChristmasMode}>
-          <h2 className={`text-lg font-bold mb-4 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
-            Badge <span className="text-xs font-normal text-amber-500 ml-2">NEW</span>
-          </h2>
-          <p className={`text-sm mb-4 ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>
-            ラベル/タグ表示。ステータスやカテゴリ表示に使用。
-          </p>
-
-          <h3 className={`text-sm font-semibold mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
-            Variants
-          </h3>
-          <div className="flex flex-wrap gap-2 mb-4">
-            <Badge variant="default" isChristmasMode={isChristmasMode}>Default</Badge>
-            <Badge variant="primary" isChristmasMode={isChristmasMode}>Primary</Badge>
-            <Badge variant="secondary" isChristmasMode={isChristmasMode}>Secondary</Badge>
-            <Badge variant="success" isChristmasMode={isChristmasMode}>Success</Badge>
-            <Badge variant="warning" isChristmasMode={isChristmasMode}>Warning</Badge>
-            <Badge variant="danger" isChristmasMode={isChristmasMode}>Danger</Badge>
-            <Badge variant="coffee" isChristmasMode={isChristmasMode}>Coffee</Badge>
-          </div>
-
-          <h3 className={`text-sm font-semibold mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
-            Sizes
-          </h3>
-          <div className="flex flex-wrap items-center gap-2">
-            <Badge size="sm" variant="primary" isChristmasMode={isChristmasMode}>Small</Badge>
-            <Badge size="md" variant="primary" isChristmasMode={isChristmasMode}>Medium</Badge>
-            <Badge size="lg" variant="primary" isChristmasMode={isChristmasMode}>Large</Badge>
-          </div>
-        </Card>
-
-        {/* Tabs - NEW */}
-        <Card isChristmasMode={isChristmasMode}>
-          <h2 className={`text-lg font-bold mb-4 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
-            Tabs <span className="text-xs font-normal text-amber-500 ml-2">NEW</span>
-          </h2>
-          <p className={`text-sm mb-4 ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>
-            タブ切り替えコンポーネント。ページ内の表示切り替えに使用。
-          </p>
-          <Tabs defaultValue="tab1" isChristmasMode={isChristmasMode}>
-            <TabsList className="mb-4">
-              <TabsTrigger value="tab1">タブ1</TabsTrigger>
-              <TabsTrigger value="tab2">タブ2</TabsTrigger>
-              <TabsTrigger value="tab3">タブ3</TabsTrigger>
-            </TabsList>
-            <TabsContent value="tab1">
-              <div className={`p-4 rounded-lg ${isChristmasMode ? 'bg-white/5' : 'bg-gray-50'}`}>
-                <p className={isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}>
-                  タブ1の内容です。
-                </p>
-              </div>
-            </TabsContent>
-            <TabsContent value="tab2">
-              <div className={`p-4 rounded-lg ${isChristmasMode ? 'bg-white/5' : 'bg-gray-50'}`}>
-                <p className={isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}>
-                  タブ2の内容です。
-                </p>
-              </div>
-            </TabsContent>
-            <TabsContent value="tab3">
-              <div className={`p-4 rounded-lg ${isChristmasMode ? 'bg-white/5' : 'bg-gray-50'}`}>
-                <p className={isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}>
-                  タブ3の内容です。
-                </p>
-              </div>
-            </TabsContent>
-          </Tabs>
-        </Card>
-
-        {/* ProgressBar - NEW */}
-        <Card isChristmasMode={isChristmasMode}>
-          <h2 className={`text-lg font-bold mb-4 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
-            ProgressBar <span className="text-xs font-normal text-amber-500 ml-2">NEW</span>
-          </h2>
-          <p className={`text-sm mb-4 ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>
-            進捗バー。タスク進捗やローディング表示に使用。
-          </p>
-
-          <h3 className={`text-sm font-semibold mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
-            Variants
-          </h3>
-          <div className="space-y-3 mb-4">
-            <ProgressBar value={progress} variant="primary" label="Primary" showValue isChristmasMode={isChristmasMode} />
-            <ProgressBar value={80} variant="success" label="Success" showValue isChristmasMode={isChristmasMode} />
-            <ProgressBar value={45} variant="warning" label="Warning" showValue isChristmasMode={isChristmasMode} />
-            <ProgressBar value={30} variant="danger" label="Danger" showValue isChristmasMode={isChristmasMode} />
-            <ProgressBar value={60} variant="coffee" label="Coffee" showValue isChristmasMode={isChristmasMode} />
-          </div>
-
-          <h3 className={`text-sm font-semibold mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
-            Sizes
-          </h3>
-          <div className="space-y-3">
-            <ProgressBar value={70} size="sm" isChristmasMode={isChristmasMode} />
-            <ProgressBar value={70} size="md" isChristmasMode={isChristmasMode} />
-            <ProgressBar value={70} size="lg" isChristmasMode={isChristmasMode} />
-          </div>
-        </Card>
-
-        {/* EmptyState - NEW */}
-        <Card isChristmasMode={isChristmasMode}>
-          <h2 className={`text-lg font-bold mb-4 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
-            EmptyState <span className="text-xs font-normal text-amber-500 ml-2">NEW</span>
-          </h2>
-          <p className={`text-sm mb-4 ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>
-            空状態表示。データがない場合の表示に使用。
-          </p>
-
-          <div className={`border rounded-lg ${isChristmasMode ? 'border-[#d4af37]/20' : 'border-gray-200'}`}>
-            <EmptyState
-              icon={<HiInbox className="h-12 w-12" />}
-              title="データがありません"
-              description="新しいアイテムを追加して始めましょう。"
-              action={<Button size="sm" isChristmasMode={isChristmasMode}>追加する</Button>}
-              isChristmasMode={isChristmasMode}
-            />
-          </div>
-        </Card>
-
-        {/* Accordion - NEW */}
-        <Card isChristmasMode={isChristmasMode}>
-          <h2 className={`text-lg font-bold mb-4 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
-            Accordion <span className="text-xs font-normal text-amber-500 ml-2">NEW</span>
-          </h2>
-          <p className={`text-sm mb-4 ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>
-            アコーディオン。折りたたみ可能なセクション表示に使用。
-          </p>
-
-          <Accordion isChristmasMode={isChristmasMode}>
-            <AccordionItem defaultOpen>
-              <AccordionTrigger>セクション1（デフォルトで開く）</AccordionTrigger>
-              <AccordionContent>
-                <p>このセクションはデフォルトで開いた状態です。追加の情報や詳細をここに表示できます。</p>
-              </AccordionContent>
-            </AccordionItem>
-            <AccordionItem>
-              <AccordionTrigger>セクション2</AccordionTrigger>
-              <AccordionContent>
-                <p>クリックすると開閉できます。履歴表示や詳細情報の表示に便利です。</p>
-              </AccordionContent>
-            </AccordionItem>
-            <AccordionItem>
-              <AccordionTrigger>セクション3</AccordionTrigger>
-              <AccordionContent>
-                <p>複数のアコーディオンを同時に開くことができます。</p>
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
-        </Card>
+        </div>
       </div>
     </div>
   );

--- a/components/SliderInput.tsx
+++ b/components/SliderInput.tsx
@@ -10,6 +10,7 @@ interface SliderInputProps {
   min?: number;
   max?: number;
   step?: number;
+  isChristmasMode?: boolean;
 }
 
 export function SliderInput({
@@ -24,33 +25,52 @@ export function SliderInput({
   min = 1.0,
   max = 5.0,
   step = 0.125,
+  isChristmasMode = false,
 }: SliderInputProps) {
+  // クリスマスモード用のスタイル
+  const containerClass = readOnly
+    ? isChristmasMode
+      ? 'bg-white/5 border-[#d4af37]/20'
+      : 'bg-gray-50 border-gray-100'
+    : isChristmasMode
+      ? 'bg-[#0a2f1a] border-[#d4af37]/30 hover:border-[#d4af37]/50 hover:shadow-md hover:shadow-[#d4af37]/10'
+      : 'bg-white border-gray-200 hover:border-amber-200 hover:shadow-md';
+
+  const labelClass = isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800';
+  const descriptionClass = isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500';
+  const minMaxClass = isChristmasMode ? 'text-[#f8f1e7]/40' : 'text-gray-400';
+  const dotActiveClass = isChristmasMode ? 'bg-[#d4af37]' : 'bg-amber-500';
+  const dotInactiveClass = isChristmasMode ? 'bg-white/20' : 'bg-gray-200';
+  const sliderTrackColor = isChristmasMode ? '#1a3d2a' : '#F3F4F6';
+  const iconContainerClass = isChristmasMode
+    ? colorClass.replace('bg-', 'bg-').replace('-50', '-900/30').replace('-100', '-900/30')
+    : colorClass;
+
+  // クリスマスモードでのアクセントカラー（値表示とスライダー）
+  const christmasAccentColor = isChristmasMode ? 'text-[#d4af37]' : accentColor;
+
   return (
     <div
-      className={`p-5 rounded-2xl border transition-all duration-200 ${
-        readOnly
-          ? 'bg-gray-50 border-gray-100'
-          : 'bg-white border-gray-200 hover:border-amber-200 hover:shadow-md'
-      }`}
+      className={`p-4 rounded-xl border transition-all duration-200 ${containerClass}`}
     >
-      <div className="flex items-start justify-between mb-5">
-        <div className="flex items-center gap-3">
-          <div className={`p-3 rounded-xl ${colorClass}`}>{icon}</div>
+      <div className="flex items-start justify-between mb-3">
+        <div className="flex items-center gap-2.5">
+          <div className={`p-2 rounded-lg ${iconContainerClass}`}>{icon}</div>
           <div>
-            <label className="text-lg font-bold text-gray-800 block leading-tight">{label}</label>
-            {description && <span className="text-xs text-gray-500 font-medium">{description}</span>}
+            <label className={`text-base font-bold block leading-tight ${labelClass}`}>{label}</label>
+            {description && <span className={`text-[11px] font-medium ${descriptionClass}`}>{description}</span>}
           </div>
         </div>
         <div className="flex flex-col items-end">
           <span
-            className={`text-3xl font-black ${accentColor} tabular-nums leading-none tracking-tight`}
+            className={`text-2xl font-black tabular-nums leading-none tracking-tight ${christmasAccentColor}`}
           >
             {value.toFixed(1)}
           </span>
         </div>
       </div>
 
-      <div className="px-1 relative">
+      <div className="relative">
         <input
           type="range"
           min={min}
@@ -58,44 +78,45 @@ export function SliderInput({
           step={step}
           value={value}
           onChange={(e) => onChange(parseFloat(e.target.value))}
-          className={`w-full h-3 bg-gray-100 rounded-full appearance-none cursor-pointer transition-all
-          [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-8 [&::-webkit-slider-thumb]:h-8
-          [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-white
-          [&::-webkit-slider-thumb]:border-4 [&::-webkit-slider-thumb]:shadow-lg
-          ${accentColor.replace('text-', 'border-')}
+          className={`w-full h-2.5 rounded-full appearance-none cursor-pointer transition-all
+          [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-6 [&::-webkit-slider-thumb]:h-6
+          [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:border-[3px] [&::-webkit-slider-thumb]:shadow-md
+          ${isChristmasMode ? '[&::-webkit-slider-thumb]:bg-[#0a2f1a] [&::-webkit-slider-thumb]:border-[#d4af37]' : `[&::-webkit-slider-thumb]:bg-white ${accentColor.replace('text-', '[&::-webkit-slider-thumb]:border-')}`}
           hover:[&::-webkit-slider-thumb]:scale-110 active:[&::-webkit-slider-thumb]:scale-95
           disabled:cursor-not-allowed`}
           style={{
-            background: `linear-gradient(to right, currentColor 0%, currentColor ${
+            background: `linear-gradient(to right, ${isChristmasMode ? '#d4af37' : 'currentColor'} 0%, ${isChristmasMode ? '#d4af37' : 'currentColor'} ${
               ((value - min) / (max - min)) * 100
-            }%, #F3F4F6 ${((value - min) / (max - min)) * 100}%, #F3F4F6 100%)`,
-            color: accentColor.includes('amber')
-              ? '#D97706'
-              : accentColor.includes('orange')
-                ? '#EA580C'
-                : accentColor.includes('stone')
-                  ? '#44403C'
-                  : accentColor.includes('rose')
-                    ? '#E11D48'
-                    : accentColor.includes('emerald')
-                      ? '#059669'
-                      : '#D97706',
+            }%, ${sliderTrackColor} ${((value - min) / (max - min)) * 100}%, ${sliderTrackColor} 100%)`,
+            color: isChristmasMode
+              ? '#d4af37'
+              : accentColor.includes('amber')
+                ? '#D97706'
+                : accentColor.includes('orange')
+                  ? '#EA580C'
+                  : accentColor.includes('stone')
+                    ? '#44403C'
+                    : accentColor.includes('rose')
+                      ? '#E11D48'
+                      : accentColor.includes('emerald')
+                        ? '#059669'
+                        : '#D97706',
           }}
           disabled={readOnly}
         />
-        <div className="flex justify-between text-[10px] font-bold text-gray-400 mt-3 uppercase tracking-widest px-1">
-          <span>Min</span>
-          <div className="flex gap-2 items-center">
+        <div className={`flex justify-between text-[9px] font-bold mt-2 tracking-wider ${minMaxClass}`}>
+          <span>最小</span>
+          <div className="flex gap-1.5 items-center">
             {[1, 2, 3, 4, 5].map((v) => (
               <div
                 key={v}
-                className={`w-1.5 h-1.5 rounded-full transition-colors duration-300 ${
-                  value >= v ? 'bg-amber-500' : 'bg-gray-200'
+                className={`w-1 h-1 rounded-full transition-colors duration-300 ${
+                  value >= v ? dotActiveClass : dotInactiveClass
                 }`}
               />
             ))}
           </div>
-          <span>Max</span>
+          <span>最大</span>
         </div>
       </div>
     </div>

--- a/components/TastingRecordForm.tsx
+++ b/components/TastingRecordForm.tsx
@@ -2,21 +2,17 @@
 
 import { useState } from 'react';
 import type { TastingRecord, AppData, TastingSession } from '@/types';
-import dynamic from 'next/dynamic';
-
-const TastingRadarChart = dynamic(() =>
-  import('./TastingRadarChart').then((mod) => ({ default: mod.TastingRadarChart }))
-);
 import { getRecordsBySessionId } from '@/lib/tastingUtils';
 import { useToastContext } from '@/components/Toast';
 import { useMembers, getActiveMembers } from '@/hooks/useMembers';
 import { useAuth } from '@/lib/auth';
-import { User, Calendar, Thermometer, Smiley, ChatCircleText, Coffee } from 'phosphor-react';
+import { User, Calendar, Thermometer, Smiley, Coffee } from 'phosphor-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Input, Select, Textarea, Button } from '@/components/ui';
 import { ROAST_LEVELS } from '@/lib/constants';
 import { formatDateString } from '@/lib/dateUtils';
 import { TastingRecordFormScores } from './TastingRecordFormScores';
+import { useChristmasMode } from '@/hooks/useChristmasMode';
 
 interface TastingRecordFormProps {
   record: TastingRecord | null;
@@ -42,6 +38,7 @@ export function TastingRecordForm({
   const { showToast } = useToastContext();
   const { user } = useAuth();
   const userId = user?.uid ?? null;
+  const { isChristmasMode } = useChristmasMode();
 
   const { members: allMembers, manager } = useMembers(userId);
 
@@ -186,20 +183,26 @@ export function TastingRecordForm({
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
       onSubmit={handleSubmit}
-      className="space-y-8 pb-10"
+      className="space-y-5 pb-8"
     >
       {/* 基本情報カード */}
-      <div className="bg-white rounded-3xl p-6 border border-gray-100 shadow-sm space-y-6">
-        <div className="flex items-center gap-2 mb-2">
-          <div className="w-1 h-6 bg-amber-500 rounded-full" />
-          <h3 className="text-lg font-bold text-gray-800">基本情報</h3>
+      <div className={`rounded-2xl p-5 shadow-sm space-y-4 ${
+        isChristmasMode
+          ? 'bg-[#0a2f1a] border border-[#d4af37]/30'
+          : 'bg-white border border-gray-100'
+      }`}>
+        <div className="flex items-center gap-2">
+          <div className={`w-1 h-5 rounded-full ${isChristmasMode ? 'bg-[#d4af37]' : 'bg-amber-500'}`} />
+          <h3 className={`text-base font-bold ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>基本情報</h3>
         </div>
 
-        <div className="grid grid-cols-1 gap-6">
+        <div className="grid grid-cols-1 gap-4">
           {/* メンバー選択 */}
-          <div className="relative group">
-            <label className="flex items-center gap-2 text-sm font-bold text-gray-600 mb-2 ml-1">
-              <User size={18} weight="bold" className="text-amber-500" />
+          <div>
+            <label className={`flex items-center gap-2 text-sm font-bold mb-1.5 ml-1 ${
+              isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'
+            }`}>
+              <User size={16} weight="bold" className={isChristmasMode ? 'text-[#d4af37]' : 'text-amber-500'} />
               メンバー <span className="text-red-500">*</span>
             </label>
             <Select
@@ -209,14 +212,17 @@ export function TastingRecordForm({
               placeholder="選択してください"
               required
               disabled={readOnly}
+              isChristmasMode={isChristmasMode}
             />
           </div>
 
           {/* 豆の名前（セッションモードでは非表示） */}
           {!isSessionMode && (
-            <div className="relative group">
-              <label className="flex items-center gap-2 text-sm font-bold text-gray-600 mb-2 ml-1">
-                <Coffee size={18} weight="bold" className="text-amber-500" />
+            <div>
+              <label className={`flex items-center gap-2 text-sm font-bold mb-1.5 ml-1 ${
+                isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'
+              }`}>
+                <Coffee size={16} weight="bold" className={isChristmasMode ? 'text-[#d4af37]' : 'text-amber-500'} />
                 豆の名前 <span className="text-red-500">*</span>
               </label>
               <Input
@@ -226,16 +232,19 @@ export function TastingRecordForm({
                 placeholder="例: エチオピア イルガチェフェ"
                 required
                 disabled={readOnly}
+                isChristmasMode={isChristmasMode}
               />
             </div>
           )}
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             {/* 試飲日（セッションモードでは非表示） */}
             {!isSessionMode && (
-              <div className="relative group">
-                <label className="flex items-center gap-2 text-sm font-bold text-gray-600 mb-2 ml-1">
-                  <Calendar size={18} weight="bold" className="text-amber-500" />
+              <div>
+                <label className={`flex items-center gap-2 text-sm font-bold mb-1.5 ml-1 ${
+                  isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'
+                }`}>
+                  <Calendar size={16} weight="bold" className={isChristmasMode ? 'text-[#d4af37]' : 'text-amber-500'} />
                   試飲日 <span className="text-red-500">*</span>
                 </label>
                 <Input
@@ -244,15 +253,18 @@ export function TastingRecordForm({
                   onChange={(e) => setTastingDate(e.target.value)}
                   required
                   disabled={readOnly}
+                  isChristmasMode={isChristmasMode}
                 />
               </div>
             )}
 
             {/* 焙煎度合い（セッションモードでは非表示） */}
             {!isSessionMode && (
-              <div className="relative group">
-                <label className="flex items-center gap-2 text-sm font-bold text-gray-600 mb-2 ml-1">
-                  <Thermometer size={18} weight="bold" className="text-amber-500" />
+              <div>
+                <label className={`flex items-center gap-2 text-sm font-bold mb-1.5 ml-1 ${
+                  isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'
+                }`}>
+                  <Thermometer size={16} weight="bold" className={isChristmasMode ? 'text-[#d4af37]' : 'text-amber-500'} />
                   焙煎度合い <span className="text-red-500">*</span>
                 </label>
                 <Select
@@ -263,6 +275,7 @@ export function TastingRecordForm({
                   options={ROAST_LEVELS.map((level) => ({ value: level, label: level }))}
                   required
                   disabled={readOnly}
+                  isChristmasMode={isChristmasMode}
                 />
               </div>
             )}
@@ -283,48 +296,27 @@ export function TastingRecordForm({
         onSweetnessChange={setSweetness}
         onAromaChange={setAroma}
         readOnly={readOnly}
+        isChristmasMode={isChristmasMode}
       />
 
-      {/* プレビュー & コメント */}
-      <div className="grid grid-cols-1 gap-8">
-        <div className="bg-white rounded-3xl p-6 border border-gray-100 shadow-sm flex flex-col items-center justify-center">
-          <div className="w-full flex items-center gap-2 mb-6">
-            <div className="w-1 h-6 bg-amber-500 rounded-full" />
-            <h3 className="text-lg font-bold text-gray-800">プレビュー</h3>
-          </div>
-          <div className="bg-gray-50 rounded-2xl p-4 w-full flex justify-center">
-            <TastingRadarChart
-              record={{
-                bitterness,
-                acidity,
-                body,
-                sweetness,
-                aroma,
-              }}
-              size={240}
-            />
-          </div>
+      {/* コメント */}
+      <div className={`rounded-2xl p-5 shadow-sm space-y-4 ${
+        isChristmasMode
+          ? 'bg-[#0a2f1a] border border-[#d4af37]/30'
+          : 'bg-white border border-gray-100'
+      }`}>
+        <div className="w-full flex items-center gap-2">
+          <div className={`w-1 h-5 rounded-full ${isChristmasMode ? 'bg-[#d4af37]' : 'bg-amber-500'}`} />
+          <h3 className={`text-base font-bold ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>全体的な印象</h3>
         </div>
-
-        <div className="bg-white rounded-3xl p-6 border border-gray-100 shadow-sm space-y-6">
-          <div className="w-full flex items-center gap-2 mb-2">
-            <div className="w-1 h-6 bg-amber-500 rounded-full" />
-            <h3 className="text-lg font-bold text-gray-800">全体的な印象</h3>
-          </div>
-          <div className="relative">
-            <label className="flex items-center gap-2 text-sm font-bold text-gray-600 mb-2 ml-1">
-              <ChatCircleText size={18} weight="bold" className="text-amber-500" />
-              コメント
-            </label>
-            <Textarea
-              value={overallImpression}
-              onChange={(e) => setOverallImpression(e.target.value)}
-              rows={6}
-              placeholder="コーヒーの全体的な印象、味の深み、後味などを自由に記録してください..."
-              disabled={readOnly}
-            />
-          </div>
-        </div>
+        <Textarea
+          value={overallImpression}
+          onChange={(e) => setOverallImpression(e.target.value)}
+          rows={4}
+          placeholder="コーヒーの全体的な印象、味の深み、後味などを自由に記録してください..."
+          disabled={readOnly}
+          isChristmasMode={isChristmasMode}
+        />
       </div>
 
       {/* アクションボタン */}
@@ -333,14 +325,18 @@ export function TastingRecordForm({
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
-            className="sticky bottom-6 flex gap-4 bg-white/80 backdrop-blur-md p-4 rounded-3xl shadow-xl border border-white/20 z-20"
+            className={`sticky bottom-6 flex gap-4 backdrop-blur-md p-4 rounded-3xl shadow-xl z-20 ${
+              isChristmasMode
+                ? 'bg-[#0a2f1a]/80 border border-[#d4af37]/20'
+                : 'bg-white/80 border border-white/20'
+            }`}
           >
             {onDelete && record && (
-              <Button type="button" variant="outline" onClick={handleDelete} className="flex-1">
+              <Button type="button" variant="outline" onClick={handleDelete} className="flex-1" isChristmasMode={isChristmasMode}>
                 削除
               </Button>
             )}
-            <Button type="submit" variant="primary" size="lg" className="flex-[2]">
+            <Button type="submit" variant="primary" size="lg" className="flex-[2]" isChristmasMode={isChristmasMode}>
               <Smiley size={24} weight="bold" />
               {existingRecordId || record ? '記録を更新する' : '記録を保存する'}
             </Button>
@@ -350,7 +346,7 @@ export function TastingRecordForm({
 
       {readOnly && (
         <div className="flex gap-4">
-          <Button type="button" variant="secondary" onClick={onCancel} fullWidth size="lg">
+          <Button type="button" variant="secondary" onClick={onCancel} fullWidth size="lg" isChristmasMode={isChristmasMode}>
             戻る
           </Button>
         </div>

--- a/components/TastingRecordFormScores.tsx
+++ b/components/TastingRecordFormScores.tsx
@@ -13,6 +13,7 @@ interface TastingRecordFormScoresProps {
   onSweetnessChange: (value: number) => void;
   onAromaChange: (value: number) => void;
   readOnly?: boolean;
+  isChristmasMode?: boolean;
 }
 
 export function TastingRecordFormScores({
@@ -27,34 +28,42 @@ export function TastingRecordFormScores({
   onSweetnessChange,
   onAromaChange,
   readOnly = false,
+  isChristmasMode = false,
 }: TastingRecordFormScoresProps) {
   return (
-    <div className="space-y-6">
-      <div className="flex flex-col gap-2 px-2">
+    <div className="space-y-4">
+      <div className="flex flex-col gap-1.5 px-1">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <div className="w-1 h-6 bg-amber-500 rounded-full" />
-            <h3 className="text-lg font-bold text-gray-800">評価項目</h3>
+            <div className={`w-1 h-5 rounded-full ${isChristmasMode ? 'bg-[#d4af37]' : 'bg-amber-500'}`} />
+            <h3 className={`text-base font-bold ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>評価項目</h3>
           </div>
-          <div className="px-3 py-1 bg-amber-100 text-amber-700 rounded-full text-xs font-bold uppercase tracking-wider">
-            1.0 - 5.0 Scale
+          <div className={`px-2.5 py-0.5 rounded-full text-[10px] font-bold tracking-wider ${
+            isChristmasMode
+              ? 'bg-[#d4af37]/20 text-[#d4af37]'
+              : 'bg-amber-100 text-amber-700'
+          }`}>
+            1.0 - 5.0 スケール
           </div>
         </div>
-        <p className="text-xs text-gray-500 font-medium leading-relaxed">
+        <p className={`text-[11px] font-medium leading-relaxed ${
+          isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'
+        }`}>
           ※ これらの項目は、味わいのバランスや特徴の数値であり、味の良し悪しを評価するものではありません。
         </p>
       </div>
 
-      <div className="grid grid-cols-1 gap-4">
+      <div className="grid grid-cols-1 gap-3">
         <SliderInput
           label="苦味"
           value={bitterness}
           onChange={onBitternessChange}
           description="コーヒーの苦みの強さ"
           readOnly={readOnly}
-          icon={<Coffee size={24} weight="fill" className="text-stone-700" />}
+          icon={<Coffee size={24} weight="fill" className={isChristmasMode ? 'text-[#d4af37]' : 'text-stone-700'} />}
           colorClass="bg-stone-100"
           accentColor="text-stone-800"
+          isChristmasMode={isChristmasMode}
         />
         <SliderInput
           label="酸味"
@@ -62,9 +71,10 @@ export function TastingRecordFormScores({
           onChange={onAcidityChange}
           description="コーヒーの酸っぱさや爽やかさ"
           readOnly={readOnly}
-          icon={<Sun size={24} weight="fill" className="text-orange-600" />}
+          icon={<Sun size={24} weight="fill" className={isChristmasMode ? 'text-[#d4af37]' : 'text-orange-600'} />}
           colorClass="bg-orange-50"
           accentColor="text-orange-600"
+          isChristmasMode={isChristmasMode}
         />
         <SliderInput
           label="ボディ"
@@ -72,9 +82,10 @@ export function TastingRecordFormScores({
           onChange={onBodyChange}
           description="コーヒーの口当たりや重厚感"
           readOnly={readOnly}
-          icon={<Drop size={24} weight="fill" className="text-amber-800" />}
+          icon={<Drop size={24} weight="fill" className={isChristmasMode ? 'text-[#d4af37]' : 'text-amber-800'} />}
           colorClass="bg-amber-50"
           accentColor="text-amber-800"
+          isChristmasMode={isChristmasMode}
         />
         <SliderInput
           label="甘み"
@@ -82,9 +93,10 @@ export function TastingRecordFormScores({
           onChange={onSweetnessChange}
           description="コーヒーに感じられる甘さ"
           readOnly={readOnly}
-          icon={<Cookie size={24} weight="fill" className="text-rose-600" />}
+          icon={<Cookie size={24} weight="fill" className={isChristmasMode ? 'text-[#d4af37]' : 'text-rose-600'} />}
           colorClass="bg-rose-50"
           accentColor="text-rose-600"
+          isChristmasMode={isChristmasMode}
         />
         <SliderInput
           label="香り"
@@ -92,9 +104,10 @@ export function TastingRecordFormScores({
           onChange={onAromaChange}
           description="コーヒーの香りの強さや豊かさ"
           readOnly={readOnly}
-          icon={<Wind size={24} weight="fill" className="text-emerald-600" />}
+          icon={<Wind size={24} weight="fill" className={isChristmasMode ? 'text-[#d4af37]' : 'text-emerald-600'} />}
           colorClass="bg-emerald-50"
           accentColor="text-emerald-600"
+          isChristmasMode={isChristmasMode}
         />
       </div>
     </div>

--- a/components/TastingRecordList.tsx
+++ b/components/TastingRecordList.tsx
@@ -9,7 +9,7 @@ const TastingRadarChart = dynamic(
 );
 import { StarRating } from './StarRating';
 import { HiTrash } from 'react-icons/hi';
-import { Card, IconButton } from '@/components/ui';
+import { Card, IconButton, RoastLevelBadge } from '@/components/ui';
 import { useChristmasMode } from '@/hooks/useChristmasMode';
 
 interface TastingRecordListProps {
@@ -58,8 +58,8 @@ export function TastingRecordList({ data, onUpdate }: TastingRecordListProps) {
   if (sortedRecords.length === 0) {
     return (
       <div className="text-center py-12">
-        <p className="text-gray-600">試飲記録がありません</p>
-        <p className="text-sm text-gray-500 mt-2">右下のボタンから新規作成できます</p>
+        <p className={isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}>試飲記録がありません</p>
+        <p className={`text-sm mt-2 ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'}`}>右下のボタンから新規作成できます</p>
       </div>
     );
   }
@@ -73,32 +73,18 @@ export function TastingRecordList({ data, onUpdate }: TastingRecordListProps) {
             variant="hoverable"
             className="p-6"
             onClick={() => handleCardClick(record.id)}
+            isChristmasMode={isChristmasMode}
           >
             <div className="flex flex-col md:flex-row gap-4">
               {/* 左側: 豆名と基本情報 */}
               <div className="flex-1">
                 <div className="flex items-start justify-between mb-2">
-                  <h3 className="text-xl font-semibold text-gray-800">
+                  <h3 className={`text-xl font-semibold ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
                     {record.beanName}
                   </h3>
                   <div className="flex items-center gap-2">
-                    <span
-                      className="px-3 py-1 text-white text-sm rounded-full"
-                      style={
-                        record.roastLevel === '深煎り'
-                          ? { backgroundColor: '#120C0A' }
-                          : record.roastLevel === '中深煎り'
-                            ? { backgroundColor: '#4E3526' }
-                            : record.roastLevel === '中煎り'
-                              ? { backgroundColor: '#745138' }
-                              : record.roastLevel === '浅煎り'
-                                ? { backgroundColor: '#C78F5D' }
-                                : { backgroundColor: '#6B7280' }
-                      }
-                    >
-                      {record.roastLevel}
-                    </span>
-                    <span className="text-sm text-gray-600">
+                    <RoastLevelBadge level={record.roastLevel} size="sm" isChristmasMode={isChristmasMode} />
+                    <span className={`text-sm ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>
                       {formatDate(record.tastingDate)}
                     </span>
                     <IconButton
@@ -122,7 +108,7 @@ export function TastingRecordList({ data, onUpdate }: TastingRecordListProps) {
 
                 {/* コメント */}
                 {record.overallImpression && (
-                  <p className="text-sm text-gray-600 line-clamp-2">
+                  <p className={`text-sm line-clamp-2 ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>
                     {record.overallImpression}
                   </p>
                 )}

--- a/components/TastingRecordList.tsx
+++ b/components/TastingRecordList.tsx
@@ -9,7 +9,8 @@ const TastingRadarChart = dynamic(
 );
 import { StarRating } from './StarRating';
 import { HiTrash } from 'react-icons/hi';
-import { Card } from '@/components/ui';
+import { Card, IconButton } from '@/components/ui';
+import { useChristmasMode } from '@/hooks/useChristmasMode';
 
 interface TastingRecordListProps {
   data: AppData;
@@ -18,6 +19,7 @@ interface TastingRecordListProps {
 
 export function TastingRecordList({ data, onUpdate }: TastingRecordListProps) {
   const router = useRouter();
+  const { isChristmasMode } = useChristmasMode();
 
   // tastingRecordsが配列でない場合のフォールバック
   const tastingRecords = Array.isArray(data.tastingRecords) ? data.tastingRecords : [];
@@ -99,16 +101,17 @@ export function TastingRecordList({ data, onUpdate }: TastingRecordListProps) {
                     <span className="text-sm text-gray-600">
                       {formatDate(record.tastingDate)}
                     </span>
-                    <button
+                    <IconButton
+                      variant="danger"
                       onClick={(e) => {
                         e.stopPropagation();
                         handleDelete(record.id);
                       }}
-                      className="p-2 text-red-500 hover:bg-red-50 rounded transition-colors"
                       aria-label="削除"
+                      isChristmasMode={isChristmasMode}
                     >
                       <HiTrash className="w-5 h-5" />
-                    </button>
+                    </IconButton>
                   </div>
                 </div>
 

--- a/components/TastingSessionCardDesktop.tsx
+++ b/components/TastingSessionCardDesktop.tsx
@@ -154,7 +154,7 @@ export function TastingSessionCardDesktop({
                               className="h-full transition-all duration-700"
                               style={{
                                 width: `${((item.value - 1) / 4) * 100}%`,
-                                backgroundColor: item.color,
+                                backgroundColor: isChristmasMode ? '#d4af37' : item.color,
                               }}
                             />
                           </div>

--- a/components/TastingSessionCardDesktop.tsx
+++ b/components/TastingSessionCardDesktop.tsx
@@ -11,6 +11,8 @@ import {
 } from 'phosphor-react';
 import type { TastingSession } from '@/types';
 import type { AverageScores } from '@/lib/tastingUtils';
+import { IconButton, Card } from '@/components/ui';
+import { useChristmasMode } from '@/hooks/useChristmasMode';
 
 interface TastingSessionCardDesktopProps {
   session: TastingSession;
@@ -34,21 +36,33 @@ export function TastingSessionCardDesktop({
   formatDate,
 }: TastingSessionCardDesktopProps) {
   const router = useRouter();
+  const { isChristmasMode } = useChristmasMode();
   const roastStyle = getRoastBadgeStyle(session.roastLevel);
   const hasAnalysis = !!session.aiAnalysis;
+
+  // クリスマスモード用のスタイル
+  const cardBorderClass = isChristmasMode ? 'border-[#d4af37]/30' : 'border-gray-200';
+  const textPrimaryClass = isChristmasMode ? 'text-[#f8f1e7]' : 'text-[#4a3728]';
+  const textSecondaryClass = isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500';
+  const textMutedClass = isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-400';
+  const bgMutedClass = isChristmasMode ? 'bg-white/10' : 'bg-gray-100';
+  const bgSectionClass = isChristmasMode ? 'bg-white/5' : 'bg-gray-50';
+  const borderSectionClass = isChristmasMode ? 'border-[#d4af37]/20' : 'border-gray-100';
+  const iconAccentClass = isChristmasMode ? 'text-[#d4af37]' : 'text-[#f5821f]';
+  const spinnerClass = isChristmasMode ? 'border-[#d4af37]' : 'border-[#f5821f]';
 
   return (
     <div>
       <Link href={`/tasting?sessionId=${session.id}`} className="block group relative">
-        <div className="rounded-2xl shadow-xl hover:shadow-2xl transition-all duration-500 overflow-hidden relative border border-gray-100 bg-white">
+        <Card variant="hoverable" isChristmasMode={isChristmasMode} className="p-0 overflow-hidden shadow-xl hover:shadow-2xl transition-all duration-500">
           <div className="relative z-10">
             <div className="h-full flex flex-col">
               {/* ヘッダー */}
-              <div className="px-8 pt-8 pb-6 border-b border-dashed border-gray-200 flex items-center justify-between">
+              <div className={`px-8 pt-8 pb-6 border-b border-dashed ${cardBorderClass} flex items-center justify-between`}>
                 <div className="flex items-center gap-6 flex-1 min-w-0">
                   <div>
                     <div className="flex items-center gap-4 mb-1">
-                      <h3 className="text-4xl font-serif font-bold text-[#4a3728] tracking-tight leading-tight truncate">
+                      <h3 className={`text-4xl font-serif font-bold ${textPrimaryClass} tracking-tight leading-tight truncate`}>
                         {session.beanName}
                       </h3>
                       <div className="flex items-center gap-2">
@@ -66,29 +80,31 @@ export function TastingSessionCardDesktop({
                   </div>
                 </div>
 
-                <button
+                <IconButton
+                  variant="ghost"
                   onClick={(e) => {
                     e.preventDefault();
                     e.stopPropagation();
                     router.push(`/tasting?sessionId=${session.id}&edit=true`);
                   }}
-                  className="p-3 text-gray-400 hover:text-[#f5821f] transition-colors"
+                  aria-label="編集"
+                  isChristmasMode={isChristmasMode}
                 >
                   <PencilSimple size={22} weight="duotone" />
-                </button>
+                </IconButton>
               </div>
 
               {/* メインコンテンツ */}
-              <div className="flex items-stretch border-b border-dashed border-gray-200">
+              <div className={`flex items-stretch border-b border-dashed ${cardBorderClass}`}>
                 {/* 感想 (左) */}
-                <div className="flex-1 p-8 border-r border-dashed border-gray-200 relative bg-white">
+                <div className={`flex-1 p-8 border-r border-dashed ${cardBorderClass} relative`}>
                   <div className="relative z-10 flex flex-col h-full">
                     <div className="flex items-center justify-between mb-6">
-                      <div className="flex items-center gap-2 text-[#4a3728]">
+                      <div className={`flex items-center gap-2 ${textPrimaryClass}`}>
                         <Quotes size={20} weight="fill" />
                         <h4 className="text-base font-bold">感想</h4>
                       </div>
-                      <div className="flex items-center gap-1.5 px-2 py-1 bg-gray-100 rounded-md text-xs text-gray-500">
+                      <div className={`flex items-center gap-1.5 px-2 py-1 ${bgMutedClass} rounded-md text-xs ${textSecondaryClass}`}>
                         <Users size={14} weight="fill" />
                         <span>
                           {recordCount} / {activeMemberCount}
@@ -101,7 +117,7 @@ export function TastingSessionCardDesktop({
                           {comments.map((comment, commentIndex) => (
                             <li
                               key={commentIndex}
-                              className="text-sm italic text-gray-600 leading-relaxed relative pl-4 border-l-2 border-gray-200"
+                              className={`text-sm italic ${textSecondaryClass} leading-relaxed relative pl-4 border-l-2 ${cardBorderClass}`}
                             >
                               &ldquo;{comment}&rdquo;
                             </li>
@@ -109,8 +125,8 @@ export function TastingSessionCardDesktop({
                         </ul>
                       ) : (
                         <div className="flex flex-col items-center justify-center h-full opacity-40 py-4">
-                          <Coffee size={40} weight="thin" className="text-gray-300 mb-2" />
-                          <p className="text-xs text-gray-400 italic">まだ感想がありません...</p>
+                          <Coffee size={40} weight="thin" className={textMutedClass} />
+                          <p className={`text-xs ${textMutedClass} italic`}>まだ感想がありません...</p>
                         </div>
                       )}
                     </div>
@@ -118,7 +134,7 @@ export function TastingSessionCardDesktop({
                 </div>
 
                 {/* チャート (右) */}
-                <div className="w-80 flex-shrink-0 p-8 flex flex-col justify-center relative overflow-hidden bg-white">
+                <div className="w-80 flex-shrink-0 p-8 flex flex-col justify-center relative overflow-hidden">
                   {recordCount > 0 ? (
                     <div className="space-y-5 w-full relative z-10">
                       {[
@@ -129,11 +145,11 @@ export function TastingSessionCardDesktop({
                         { label: '香り', value: averageScores.aroma, color: '#00897b' },
                       ].map((item) => (
                         <div key={item.label} className="space-y-1">
-                          <div className="flex justify-between items-center text-xs font-bold text-gray-500">
+                          <div className={`flex justify-between items-center text-xs font-bold ${textSecondaryClass}`}>
                             <span>{item.label}</span>
                             <span>{item.value.toFixed(1)}</span>
                           </div>
-                          <div className="w-full bg-gray-200 h-1.5 rounded overflow-hidden">
+                          <div className={`w-full ${bgMutedClass} h-1.5 rounded overflow-hidden`}>
                             <div
                               className="h-full transition-all duration-700"
                               style={{
@@ -146,9 +162,9 @@ export function TastingSessionCardDesktop({
                       ))}
                     </div>
                   ) : (
-                    <div className="flex flex-col items-center justify-center w-full h-full border-2 border-dashed border-gray-200 rounded-xl p-8 opacity-60">
-                      <Coffee size={40} weight="thin" className="text-gray-300 mb-3" />
-                      <p className="text-xs font-bold text-gray-400 tracking-widest text-center">
+                    <div className={`flex flex-col items-center justify-center w-full h-full border-2 border-dashed ${cardBorderClass} rounded-xl p-8 opacity-60`}>
+                      <Coffee size={40} weight="thin" className={textMutedClass} />
+                      <p className={`text-xs font-bold ${textMutedClass} tracking-widest text-center`}>
                         データなし
                       </p>
                     </div>
@@ -161,7 +177,7 @@ export function TastingSessionCardDesktop({
                 <div className="relative z-10">
                   {!hasAnalysis && !isAnalyzing && recordCount === 0 && (
                     <div className="flex items-center justify-center py-2">
-                      <p className="text-xs text-gray-500 italic">
+                      <p className={`text-xs ${textSecondaryClass} italic`}>
                         記録が追加されるとAI分析が開始されます
                       </p>
                     </div>
@@ -169,22 +185,22 @@ export function TastingSessionCardDesktop({
 
                   {isAnalyzing && (
                     <div className="flex flex-col items-center justify-center py-6 gap-3">
-                      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#f5821f]"></div>
-                      <p className="text-xs text-gray-500 animate-pulse">
+                      <div className={`animate-spin rounded-full h-8 w-8 border-b-2 ${spinnerClass}`}></div>
+                      <p className={`text-xs ${textSecondaryClass} animate-pulse`}>
                         コーヒーの香りを分析中...
                       </p>
                     </div>
                   )}
 
                   {hasAnalysis && (
-                    <div className="bg-gray-50 rounded-xl p-6 border border-gray-100">
+                    <div className={`${bgSectionClass} rounded-xl p-6 border ${borderSectionClass}`}>
                       <div className="flex items-center gap-2 mb-4">
-                        <Notepad size={20} weight="fill" className="text-[#f5821f]" />
-                        <h4 className="text-sm font-bold tracking-wide text-[#4a3728]">
+                        <Notepad size={20} weight="fill" className={iconAccentClass} />
+                        <h4 className={`text-sm font-bold tracking-wide ${textPrimaryClass}`}>
                           AIコーヒーマイスターのコメント
                         </h4>
                       </div>
-                      <p className="text-sm leading-relaxed text-[#4a3728] whitespace-pre-wrap">
+                      <p className={`text-sm leading-relaxed ${textPrimaryClass} whitespace-pre-wrap`}>
                         {session.aiAnalysis}
                       </p>
                     </div>
@@ -193,18 +209,18 @@ export function TastingSessionCardDesktop({
               </div>
 
               {/* フッター */}
-              <div className="px-8 py-4 bg-gray-50 border-t border-gray-100 flex justify-between items-center">
-                <div className="flex items-center gap-1.5 text-xs text-gray-400">
+              <div className={`px-8 py-4 ${bgSectionClass} border-t ${borderSectionClass} flex justify-between items-center`}>
+                <div className={`flex items-center gap-1.5 text-xs ${textMutedClass}`}>
                   <CalendarBlank size={14} weight="fill" />
                   <span>{formatDate(session.createdAt)}</span>
                 </div>
-                <div className="flex items-center gap-1 text-xs font-bold text-gray-500 hover:text-[#f5821f] transition-colors cursor-pointer">
+                <div className={`flex items-center gap-1 text-xs font-bold ${textSecondaryClass} hover:${iconAccentClass} transition-colors cursor-pointer`}>
                   記録を追加する <CaretRight size={14} weight="bold" />
                 </div>
               </div>
             </div>
           </div>
-        </div>
+        </Card>
       </Link>
     </div>
   );

--- a/components/TastingSessionCardMobile.tsx
+++ b/components/TastingSessionCardMobile.tsx
@@ -4,6 +4,8 @@ import { Coffee, Quotes, Notepad, CaretRight } from 'phosphor-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import type { TastingSession } from '@/types';
 import type { AverageScores } from '@/lib/tastingUtils';
+import { Button, Card } from '@/components/ui';
+import { useChristmasMode } from '@/hooks/useChristmasMode';
 
 interface TastingSessionCardMobileProps {
   session: TastingSession;
@@ -25,20 +27,30 @@ export function TastingSessionCardMobile({
   formatDate,
 }: TastingSessionCardMobileProps) {
   const [aiModalSession, setAiModalSession] = useState<TastingSession | null>(null);
+  const { isChristmasMode } = useChristmasMode();
   const hasAnalysis = !!session.aiAnalysis;
+
+  // クリスマスモード用のスタイル
+  const cardBorderClass = isChristmasMode ? 'border-[#d4af37]/30' : 'border-gray-200';
+  const textPrimaryClass = isChristmasMode ? 'text-[#f8f1e7]' : 'text-[#4a3728]';
+  const textSecondaryClass = isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500';
+  const textMutedClass = isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-400';
+  const bgMutedClass = isChristmasMode ? 'bg-white/10' : 'bg-gray-200';
+  const iconAccentClass = isChristmasMode ? 'text-[#d4af37]' : 'text-[#f5821f]';
+  const spinnerClass = isChristmasMode ? 'border-[#d4af37]' : 'border-[#f5821f]';
 
   return (
     <>
       <div className="flex-shrink-0 w-[calc(100vw-2rem)] h-full snap-center">
         <Link href={`/tasting?sessionId=${session.id}`} className="block h-full">
-          <div className="rounded-2xl shadow-lg flex flex-col h-full overflow-hidden relative border border-gray-100 bg-white">
+          <Card variant="hoverable" isChristmasMode={isChristmasMode} className="p-0 flex flex-col h-full overflow-hidden shadow-lg">
             <div className="relative z-10 flex flex-col h-full">
               <div className="flex flex-col h-full">
                 {/* ヘッダー（タイトル） */}
-                <div className="flex-shrink-0 p-5 pb-4 border-b border-dashed border-gray-200">
+                <div className={`flex-shrink-0 p-5 pb-4 border-b border-dashed ${cardBorderClass}`}>
                   <div className="flex items-center gap-3">
                     <div className="flex-1 min-w-0">
-                      <h3 className="text-2xl font-serif font-bold text-[#4a3728] tracking-tight leading-tight truncate mb-2">
+                      <h3 className={`text-2xl font-serif font-bold ${textPrimaryClass} tracking-tight leading-tight truncate mb-2`}>
                         {session.beanName}
                       </h3>
                       <div className="flex items-center gap-2">
@@ -51,7 +63,7 @@ export function TastingSessionCardMobile({
                         >
                           {session.roastLevel}
                         </span>
-                        <span className="text-[10px] text-gray-400">
+                        <span className={`text-[10px] ${textMutedClass}`}>
                           {formatDate(session.createdAt)}
                         </span>
                       </div>
@@ -61,7 +73,7 @@ export function TastingSessionCardMobile({
 
                 {/* 横バーチャート（スコア表示） */}
                 {recordCount > 0 && (
-                  <div className="flex-shrink-0 px-4 py-3 bg-white border-b border-dashed border-gray-200">
+                  <div className={`flex-shrink-0 px-4 py-3 border-b border-dashed ${cardBorderClass}`}>
                     <div className="space-y-2.5">
                       {[
                         { label: '苦味', value: averageScores.bitterness, color: '#3e2723' },
@@ -71,10 +83,10 @@ export function TastingSessionCardMobile({
                         { label: '香り', value: averageScores.aroma, color: '#00897b' },
                       ].map((item) => (
                         <div key={item.label} className="flex items-center gap-2">
-                          <span className="text-[10px] font-bold text-gray-500 w-10 flex-shrink-0">
+                          <span className={`text-[10px] font-bold ${textSecondaryClass} w-10 flex-shrink-0`}>
                             {item.label}
                           </span>
-                          <div className="flex-1 h-1.5 bg-gray-200 rounded overflow-hidden">
+                          <div className={`flex-1 h-1.5 ${bgMutedClass} rounded overflow-hidden`}>
                             <div
                               className="h-full transition-all duration-500"
                               style={{
@@ -83,7 +95,7 @@ export function TastingSessionCardMobile({
                               }}
                             />
                           </div>
-                          <span className="text-[10px] font-bold text-gray-500 w-6 text-right">
+                          <span className={`text-[10px] font-bold ${textSecondaryClass} w-6 text-right`}>
                             {item.value.toFixed(1)}
                           </span>
                         </div>
@@ -93,13 +105,13 @@ export function TastingSessionCardMobile({
                 )}
 
                 {/* 感想 + AIコメント */}
-                <div className="flex-1 flex flex-col min-h-0 p-4 bg-white">
+                <div className="flex-1 flex flex-col min-h-0 p-4">
                   {/* 感想セクション */}
                   <div className="flex-1 min-h-0 overflow-hidden">
                     <div className="flex items-center gap-2 mb-3">
-                      <Quotes size={16} weight="fill" className="text-[#4a3728]" />
-                      <h4 className="text-sm font-bold text-[#4a3728]">感想</h4>
-                      <span className="text-[10px] font-bold text-gray-400 ml-auto">
+                      <Quotes size={16} weight="fill" className={textPrimaryClass} />
+                      <h4 className={`text-sm font-bold ${textPrimaryClass}`}>感想</h4>
+                      <span className={`text-[10px] font-bold ${textMutedClass} ml-auto`}>
                         {recordCount}件の記録
                       </span>
                     </div>
@@ -110,7 +122,7 @@ export function TastingSessionCardMobile({
                           {comments.map((comment, commentIndex) => (
                             <li
                               key={commentIndex}
-                              className="text-sm italic text-gray-600 leading-relaxed pl-3 border-l-2 border-gray-200"
+                              className={`text-sm italic ${textSecondaryClass} leading-relaxed pl-3 border-l-2 ${cardBorderClass}`}
                             >
                               {comment}
                             </li>
@@ -118,51 +130,54 @@ export function TastingSessionCardMobile({
                         </ul>
                       ) : (
                         <div className="flex flex-col items-center justify-center h-full opacity-40">
-                          <Coffee size={32} weight="thin" className="text-gray-300 mb-2" />
-                          <p className="text-xs text-gray-400 italic">まだ感想がありません</p>
+                          <Coffee size={32} weight="thin" className={textMutedClass} />
+                          <p className={`text-xs ${textMutedClass} italic`}>まだ感想がありません</p>
                         </div>
                       )}
                     </div>
                   </div>
 
                   {/* AI分析ボタン */}
-                  <div className="flex-shrink-0 border-t border-dashed border-gray-200 pt-3 mt-3">
+                  <div className={`flex-shrink-0 border-t border-dashed ${cardBorderClass} pt-3 mt-3`}>
                     {!hasAnalysis && !isAnalyzing && recordCount === 0 && (
-                      <p className="text-center text-xs text-gray-500 italic py-2">
+                      <p className={`text-center text-xs ${textSecondaryClass} italic py-2`}>
                         記録が追加されるとAI分析が開始されます
                       </p>
                     )}
 
                     {isAnalyzing && (
                       <div className="flex items-center justify-center gap-2 py-2">
-                        <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-[#f5821f]"></div>
-                        <span className="text-xs text-gray-500">分析中...</span>
+                        <div className={`animate-spin rounded-full h-4 w-4 border-b-2 ${spinnerClass}`}></div>
+                        <span className={`text-xs ${textSecondaryClass}`}>分析中...</span>
                       </div>
                     )}
 
                     {hasAnalysis && (
-                      <button
+                      <Button
+                        variant="outline"
                         onClick={(e) => {
                           e.preventDefault();
                           e.stopPropagation();
                           setAiModalSession(session);
                         }}
-                        className="w-full flex items-center justify-between gap-2 bg-gray-50 p-3 rounded border border-gray-200 hover:bg-gray-100 transition-colors active:scale-[0.98]"
+                        fullWidth
+                        isChristmasMode={isChristmasMode}
+                        className="justify-between !p-3"
                       >
                         <div className="flex items-center gap-2">
-                          <Notepad size={16} weight="fill" className="text-[#f5821f]" />
-                          <span className="text-xs font-bold text-[#4a3728]">
+                          <Notepad size={16} weight="fill" className={iconAccentClass} />
+                          <span className={`text-xs font-bold ${textPrimaryClass}`}>
                             AIコーヒーマイスター
                           </span>
                         </div>
-                        <CaretRight size={16} weight="bold" className="text-gray-400" />
-                      </button>
+                        <CaretRight size={16} weight="bold" className={textMutedClass} />
+                      </Button>
                     )}
                   </div>
                 </div>
               </div>
             </div>
-          </div>
+          </Card>
         </Link>
       </div>
 
@@ -181,39 +196,41 @@ export function TastingSessionCardMobile({
               initial={{ opacity: 0, y: 100 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: 100 }}
-              className="relative bg-white rounded-t-[2rem] shadow-2xl w-full max-h-[80vh] overflow-hidden flex flex-col"
+              className={`relative ${isChristmasMode ? 'bg-[#0a2f1a]' : 'bg-white'} rounded-t-[2rem] shadow-2xl w-full max-h-[80vh] overflow-hidden flex flex-col`}
             >
               {/* ハンドル */}
               <div className="flex justify-center pt-3 pb-2">
-                <div className="w-10 h-1 bg-gray-300 rounded-full" />
+                <div className={`w-10 h-1 ${isChristmasMode ? 'bg-[#d4af37]/50' : 'bg-gray-300'} rounded-full`} />
               </div>
 
               {/* ヘッダー */}
-              <div className="px-6 pb-4 border-b border-dashed border-gray-200">
+              <div className={`px-6 pb-4 border-b border-dashed ${cardBorderClass}`}>
                 <div className="flex items-center gap-3">
-                  <Notepad size={24} weight="fill" className="text-[#f5821f]" />
+                  <Notepad size={24} weight="fill" className={iconAccentClass} />
                   <div>
-                    <h3 className="text-lg font-bold text-[#4a3728]">AIコーヒーマイスター</h3>
-                    <p className="text-xs text-gray-500">{aiModalSession.beanName}</p>
+                    <h3 className={`text-lg font-bold ${textPrimaryClass}`}>AIコーヒーマイスター</h3>
+                    <p className={`text-xs ${textSecondaryClass}`}>{aiModalSession.beanName}</p>
                   </div>
                 </div>
               </div>
 
               {/* コンテンツ */}
               <div className="flex-1 overflow-y-auto p-6">
-                <p className="text-sm leading-relaxed text-[#4a3728] whitespace-pre-wrap">
+                <p className={`text-sm leading-relaxed ${textPrimaryClass} whitespace-pre-wrap`}>
                   {aiModalSession.aiAnalysis}
                 </p>
               </div>
 
               {/* 閉じるボタン */}
-              <div className="p-4 border-t border-gray-100 bg-gray-50">
-                <button
+              <div className={`p-4 border-t ${isChristmasMode ? 'border-[#d4af37]/20 bg-white/5' : 'border-gray-100 bg-gray-50'}`}>
+                <Button
+                  variant="primary"
                   onClick={() => setAiModalSession(null)}
-                  className="w-full py-3 bg-[#f5821f] hover:bg-orange-600 text-white rounded-full font-bold text-sm transition-colors active:scale-[0.98] shadow-lg"
+                  fullWidth
+                  isChristmasMode={isChristmasMode}
                 >
                   閉じる
-                </button>
+                </Button>
               </div>
             </motion.div>
           </div>

--- a/components/TastingSessionCardMobile.tsx
+++ b/components/TastingSessionCardMobile.tsx
@@ -91,7 +91,7 @@ export function TastingSessionCardMobile({
                               className="h-full transition-all duration-500"
                               style={{
                                 width: `${((item.value - 1) / 4) * 100}%`,
-                                backgroundColor: item.color,
+                                backgroundColor: isChristmasMode ? '#d4af37' : item.color,
                               }}
                             />
                           </div>

--- a/components/TastingSessionCarousel.tsx
+++ b/components/TastingSessionCarousel.tsx
@@ -1,16 +1,17 @@
 import { useRef, useEffect, useState, useMemo } from 'react';
-import { useRouter } from 'next/navigation';
+import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime';
 import type { TastingRecord, TastingSession } from '@/types';
 import { calculateAverageScores, getRecordsBySessionId } from '@/lib/tastingUtils';
 import { useTastingAIAnalysis } from '@/hooks/useTastingAIAnalysis';
 import { TastingSessionCardDesktop } from './TastingSessionCardDesktop';
 import { TastingSessionCardMobile } from './TastingSessionCardMobile';
+import { useChristmasMode } from '@/hooks/useChristmasMode';
 
 interface TastingSessionCarouselProps {
   sessions: TastingSession[];
   tastingRecords: TastingRecord[];
   activeMemberCount: number;
-  router: ReturnType<typeof useRouter>;
+  router: AppRouterInstance;
   onUpdateSession?: (sessionId: string, aiAnalysis: string, recordCount: number) => void;
 }
 
@@ -66,6 +67,7 @@ export function TastingSessionCarousel({
 }: TastingSessionCarouselProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [activeIndex, setActiveIndex] = useState(0);
+  const { isChristmasMode } = useChristmasMode();
 
   // セッションカードの共通データを準備
   const sessionData = useMemo(
@@ -124,7 +126,9 @@ export function TastingSessionCarousel({
   if (sessions.length === 0) {
     return (
       <div className="text-center py-12">
-        <p className="text-stone-500 font-serif italic">試飲セッションがありません</p>
+        <p className={`font-serif italic ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-stone-500'}`}>
+          試飲セッションがありません
+        </p>
       </div>
     );
   }
@@ -155,9 +159,13 @@ export function TastingSessionCarousel({
         {/* 横スクロールコンテナ */}
         <div
           ref={scrollContainerRef}
-          className="flex flex-row gap-4 px-4 h-full overflow-x-auto overflow-y-hidden snap-x snap-mandatory
-                     [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-track]:bg-stone-200/50 [&::-webkit-scrollbar-track]:mx-8 [&::-webkit-scrollbar-track]:rounded-full
-                     [&::-webkit-scrollbar-thumb]:bg-[#8D6E63] [&::-webkit-scrollbar-thumb]:rounded-full"
+          className={`flex flex-row gap-4 px-4 h-full overflow-x-auto overflow-y-hidden snap-x snap-mandatory
+                     [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-track]:mx-8 [&::-webkit-scrollbar-track]:rounded-full
+                     [&::-webkit-scrollbar-thumb]:rounded-full ${
+                       isChristmasMode
+                         ? '[&::-webkit-scrollbar-track]:bg-[#d4af37]/20 [&::-webkit-scrollbar-thumb]:bg-[#d4af37]'
+                         : '[&::-webkit-scrollbar-track]:bg-stone-200/50 [&::-webkit-scrollbar-thumb]:bg-[#8D6E63]'
+                     }`}
           style={{
             WebkitOverflowScrolling: 'touch',
           }}
@@ -182,7 +190,9 @@ export function TastingSessionCarousel({
             <div
               key={index}
               className={`w-1.5 h-1.5 rounded-full transition-all duration-300 ${
-                index === activeIndex ? 'bg-gray-700 scale-125' : 'bg-gray-300'
+                index === activeIndex
+                  ? isChristmasMode ? 'bg-[#d4af37] scale-125' : 'bg-gray-700 scale-125'
+                  : isChristmasMode ? 'bg-[#d4af37]/30' : 'bg-gray-300'
               }`}
             />
           ))}

--- a/components/TastingSessionDetail.tsx
+++ b/components/TastingSessionDetail.tsx
@@ -8,6 +8,8 @@ import { TastingRecordForm } from './TastingRecordForm';
 import { getRecordsBySessionId } from '@/lib/tastingUtils';
 import { Coffee } from 'phosphor-react';
 import { useToastContext } from '@/components/Toast';
+import { Card, RoastLevelBadge } from '@/components/ui';
+import { useChristmasMode } from '@/hooks/useChristmasMode';
 
 interface TastingSessionDetailProps {
   session: TastingSession;
@@ -23,6 +25,7 @@ export function TastingSessionDetail({
   const router = useRouter();
   const { user } = useAuth();
   const { showToast } = useToastContext();
+  const { isChristmasMode } = useChristmasMode();
   const [editingRecordId, setEditingRecordId] = useState<string | null>(null);
 
   const tastingRecords = Array.isArray(data.tastingRecords)
@@ -119,41 +122,26 @@ export function TastingSessionDetail({
   return (
     <div className="space-y-8 max-w-2xl mx-auto">
       {/* ヘッダーカード */}
-      <div className="bg-white rounded-3xl p-6 border border-gray-100 shadow-sm">
+      <Card isChristmasMode={isChristmasMode} className="p-6">
         <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
           <div className="flex items-center gap-3">
-            <div className="p-3 bg-amber-50 rounded-2xl">
-              <Coffee size={32} weight="fill" className="text-amber-700" />
+            <div className={`p-3 rounded-2xl ${isChristmasMode ? 'bg-[#d4af37]/20' : 'bg-amber-50'}`}>
+              <Coffee size={32} weight="fill" className={isChristmasMode ? 'text-[#d4af37]' : 'text-amber-700'} />
             </div>
             <div>
-              <h2 className="text-2xl font-black text-gray-800 tracking-tight">
+              <h2 className={`text-2xl font-black tracking-tight ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
                 {session.beanName}
               </h2>
               <div className="flex items-center gap-2 mt-1">
-                <span 
-                  className="px-3 py-1 text-white text-xs font-bold rounded-full shadow-sm uppercase tracking-wider"
-                  style={
-                    session.roastLevel === '深煎り' 
-                      ? { backgroundColor: '#120C0A' }
-                      : session.roastLevel === '中深煎り'
-                      ? { backgroundColor: '#4E3526' }
-                      : session.roastLevel === '中煎り'
-                      ? { backgroundColor: '#745138' }
-                      : session.roastLevel === '浅煎り'
-                      ? { backgroundColor: '#C78F5D' }
-                      : { backgroundColor: '#6B7280' }
-                  }
-                >
-                  {session.roastLevel}
-                </span>
-                <span className="text-sm font-medium text-gray-400">
+                <RoastLevelBadge level={session.roastLevel} size="sm" isChristmasMode={isChristmasMode} />
+                <span className={`text-sm font-medium ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-400'}`}>
                   {new Date(session.createdAt).toLocaleDateString('ja-JP')}
                 </span>
               </div>
             </div>
           </div>
         </div>
-      </div>
+      </Card>
 
       {/* 記録編集フォーム（自分の記録がある場合、または編集モードの場合） */}
       {editingRecord ? (

--- a/components/TastingSessionFilterModal.tsx
+++ b/components/TastingSessionFilterModal.tsx
@@ -49,12 +49,18 @@ export function TastingSessionFilterModal({
   const [tempSelectedRoastLevels, setTempSelectedRoastLevels] = useState(selectedRoastLevels);
 
   // モーダルが開かれたときに現在の値を設定
+  // NOTE: モーダルの一時状態を親のpropsと同期させる必要があるためeffect内でsetStateを使用
   useEffect(() => {
     if (isOpen) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- モーダルオープン時の状態同期に必要
       setTempSearchQuery(searchQuery);
+       
       setTempSortOption(sortOption);
+       
       setTempDateFrom(dateFrom);
+       
       setTempDateTo(dateTo);
+       
       setTempSelectedRoastLevels(selectedRoastLevels);
     }
   }, [isOpen, searchQuery, sortOption, dateFrom, dateTo, selectedRoastLevels]);
@@ -100,15 +106,6 @@ export function TastingSessionFilterModal({
   const hasActiveFilters =
     tempSearchQuery.trim() || tempDateFrom || tempDateTo || tempSelectedRoastLevels.length > 0;
 
-  // クリスマスモード用のスタイル
-  const modalBgClass = isChristmasMode ? 'bg-[#0a2f1a]' : 'bg-white';
-  const modalBorderClass = isChristmasMode ? 'border-[#d4af37]/30' : 'border-stone-100';
-  const textPrimaryClass = isChristmasMode ? 'text-[#f8f1e7]' : 'text-stone-800';
-  const textLabelClass = isChristmasMode ? 'text-[#d4af37]/80' : 'text-stone-400';
-  const iconBgClass = isChristmasMode ? 'bg-[#d4af37]/20' : 'bg-amber-50';
-  const iconColorClass = isChristmasMode ? 'text-[#d4af37]' : 'text-amber-600';
-  const footerBgClass = isChristmasMode ? 'bg-white/5' : 'bg-stone-50/50';
-
   return (
     <AnimatePresence>
       {isOpen && (
@@ -118,21 +115,27 @@ export function TastingSessionFilterModal({
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             onClick={onClose}
-            className="absolute inset-0 bg-stone-900/40 backdrop-blur-sm"
+            className="absolute inset-0 bg-black/20"
           />
           <motion.div
             initial={{ opacity: 0, scale: 0.95, y: 20 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.95, y: 20 }}
-            className={`relative ${modalBgClass} rounded-[3rem] shadow-2xl max-w-md w-full max-h-[90vh] overflow-hidden flex flex-col border ${modalBorderClass}`}
+            className={`relative rounded-2xl shadow-xl max-w-md w-full max-h-[90vh] overflow-hidden flex flex-col ${
+              isChristmasMode
+                ? 'bg-[#0a2f1a] border-2 border-[#d4af37]/30'
+                : 'bg-white border-2 border-gray-300'
+            }`}
           >
             {/* ヘッダー */}
-            <div className="p-8 pb-4 flex items-center justify-between">
+            <div className={`p-6 pb-4 flex items-center justify-between border-b ${
+              isChristmasMode ? 'border-[#d4af37]/20' : 'border-gray-200'
+            }`}>
               <div className="flex items-center gap-3">
-                <div className={`p-2 ${iconBgClass} rounded-xl`}>
-                  <Faders size={24} weight="fill" className={iconColorClass} />
+                <div className={`p-2 rounded-xl ${isChristmasMode ? 'bg-[#d4af37]/20' : 'bg-amber-50'}`}>
+                  <Faders size={24} weight="fill" className={isChristmasMode ? 'text-[#d4af37]' : 'text-amber-600'} />
                 </div>
-                <h2 className={`text-2xl font-black ${textPrimaryClass} tracking-tight`}>フィルター設定</h2>
+                <h2 className={`text-xl font-bold ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>フィルター設定</h2>
               </div>
               <IconButton
                 variant="ghost"
@@ -145,10 +148,10 @@ export function TastingSessionFilterModal({
             </div>
 
             {/* コンテンツ */}
-            <div className="flex-1 overflow-y-auto px-8 py-4 space-y-8">
+            <div className="flex-1 overflow-y-auto px-6 py-4 space-y-6">
               {/* 検索バー */}
-              <div className="space-y-3">
-                <label className={`flex items-center gap-2 text-xs font-black ${textLabelClass} uppercase tracking-widest ml-1`}>
+              <div className="space-y-2">
+                <label className={`flex items-center gap-2 text-xs font-bold uppercase tracking-wide ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500'}`}>
                   <MagnifyingGlass size={16} weight="bold" />
                   豆の名前で検索
                 </label>
@@ -162,8 +165,8 @@ export function TastingSessionFilterModal({
               </div>
 
               {/* ソート */}
-              <div className="space-y-3">
-                <label className={`flex items-center gap-2 text-xs font-black ${textLabelClass} uppercase tracking-widest ml-1`}>
+              <div className="space-y-2">
+                <label className={`flex items-center gap-2 text-xs font-bold uppercase tracking-wide ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500'}`}>
                   <SortAscending size={16} weight="bold" />
                   並び替え
                 </label>
@@ -187,8 +190,8 @@ export function TastingSessionFilterModal({
               </div>
 
               {/* 日付範囲 */}
-              <div className="space-y-3">
-                <label className={`flex items-center gap-2 text-xs font-black ${textLabelClass} uppercase tracking-widest ml-1`}>
+              <div className="space-y-2">
+                <label className={`flex items-center gap-2 text-xs font-bold uppercase tracking-wide ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500'}`}>
                   <CalendarBlank size={16} weight="bold" />
                   日付範囲
                 </label>
@@ -209,8 +212,8 @@ export function TastingSessionFilterModal({
               </div>
 
               {/* 焙煎度合い */}
-              <div className="space-y-3 pb-4">
-                <label className={`flex items-center gap-2 text-xs font-black ${textLabelClass} uppercase tracking-widest ml-1`}>
+              <div className="space-y-2 pb-2">
+                <label className={`flex items-center gap-2 text-xs font-bold uppercase tracking-wide ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500'}`}>
                   <Thermometer size={16} weight="bold" />
                   焙煎度合い
                 </label>
@@ -231,7 +234,11 @@ export function TastingSessionFilterModal({
             </div>
 
             {/* フッター */}
-            <div className={`p-8 pt-4 ${footerBgClass} flex flex-col gap-3`}>
+            <div className={`p-6 pt-4 border-t flex flex-col gap-3 ${
+              isChristmasMode
+                ? 'bg-[#0a2f1a]/50 border-[#d4af37]/20'
+                : 'bg-gray-50 border-gray-200'
+            }`}>
               {hasActiveFilters && (
                 <Button
                   variant="ghost"

--- a/components/TastingSessionFilterModal.tsx
+++ b/components/TastingSessionFilterModal.tsx
@@ -9,6 +9,7 @@ import {
   Thermometer,
 } from 'phosphor-react';
 import { ROAST_LEVELS } from '@/lib/constants';
+import { Button, IconButton, Input } from '@/components/ui';
 
 type SortOption = 'newest' | 'oldest' | 'beanName';
 
@@ -27,6 +28,7 @@ interface TastingSessionFilterModalProps {
     dateTo: string;
     selectedRoastLevels: Array<'浅煎り' | '中煎り' | '中深煎り' | '深煎り'>;
   }) => void;
+  isChristmasMode?: boolean;
 }
 
 export function TastingSessionFilterModal({
@@ -38,6 +40,7 @@ export function TastingSessionFilterModal({
   dateTo,
   selectedRoastLevels,
   onApply,
+  isChristmasMode = false,
 }: TastingSessionFilterModalProps) {
   const [tempSearchQuery, setTempSearchQuery] = useState(searchQuery);
   const [tempSortOption, setTempSortOption] = useState(sortOption);
@@ -97,6 +100,15 @@ export function TastingSessionFilterModal({
   const hasActiveFilters =
     tempSearchQuery.trim() || tempDateFrom || tempDateTo || tempSelectedRoastLevels.length > 0;
 
+  // クリスマスモード用のスタイル
+  const modalBgClass = isChristmasMode ? 'bg-[#0a2f1a]' : 'bg-white';
+  const modalBorderClass = isChristmasMode ? 'border-[#d4af37]/30' : 'border-stone-100';
+  const textPrimaryClass = isChristmasMode ? 'text-[#f8f1e7]' : 'text-stone-800';
+  const textLabelClass = isChristmasMode ? 'text-[#d4af37]/80' : 'text-stone-400';
+  const iconBgClass = isChristmasMode ? 'bg-[#d4af37]/20' : 'bg-amber-50';
+  const iconColorClass = isChristmasMode ? 'text-[#d4af37]' : 'text-amber-600';
+  const footerBgClass = isChristmasMode ? 'bg-white/5' : 'bg-stone-50/50';
+
   return (
     <AnimatePresence>
       {isOpen && (
@@ -112,45 +124,46 @@ export function TastingSessionFilterModal({
             initial={{ opacity: 0, scale: 0.95, y: 20 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.95, y: 20 }}
-            className="relative bg-white rounded-[3rem] shadow-2xl max-w-md w-full max-h-[90vh] overflow-hidden flex flex-col border border-stone-100"
+            className={`relative ${modalBgClass} rounded-[3rem] shadow-2xl max-w-md w-full max-h-[90vh] overflow-hidden flex flex-col border ${modalBorderClass}`}
           >
             {/* ヘッダー */}
             <div className="p-8 pb-4 flex items-center justify-between">
               <div className="flex items-center gap-3">
-                <div className="p-2 bg-amber-50 rounded-xl">
-                  <Faders size={24} weight="fill" className="text-amber-600" />
+                <div className={`p-2 ${iconBgClass} rounded-xl`}>
+                  <Faders size={24} weight="fill" className={iconColorClass} />
                 </div>
-                <h2 className="text-2xl font-black text-stone-800 tracking-tight">フィルター設定</h2>
+                <h2 className={`text-2xl font-black ${textPrimaryClass} tracking-tight`}>フィルター設定</h2>
               </div>
-              <button
+              <IconButton
+                variant="ghost"
                 onClick={onClose}
-                className="p-2 hover:bg-stone-50 rounded-full transition-colors text-stone-400"
                 aria-label="閉じる"
+                isChristmasMode={isChristmasMode}
               >
                 <X size={24} weight="bold" />
-              </button>
+              </IconButton>
             </div>
 
             {/* コンテンツ */}
             <div className="flex-1 overflow-y-auto px-8 py-4 space-y-8">
               {/* 検索バー */}
               <div className="space-y-3">
-                <label className="flex items-center gap-2 text-xs font-black text-stone-400 uppercase tracking-widest ml-1">
+                <label className={`flex items-center gap-2 text-xs font-black ${textLabelClass} uppercase tracking-widest ml-1`}>
                   <MagnifyingGlass size={16} weight="bold" />
                   豆の名前で検索
                 </label>
-                <input
+                <Input
                   type="text"
                   value={tempSearchQuery}
                   onChange={(e) => setTempSearchQuery(e.target.value)}
                   placeholder="豆の名前を入力..."
-                  className="w-full px-5 py-4 bg-stone-50 border-2 border-transparent rounded-2xl focus:bg-white focus:border-amber-500 focus:outline-none transition-all text-stone-800 font-bold placeholder:text-stone-300"
+                  isChristmasMode={isChristmasMode}
                 />
               </div>
 
               {/* ソート */}
               <div className="space-y-3">
-                <label className="flex items-center gap-2 text-xs font-black text-stone-400 uppercase tracking-widest ml-1">
+                <label className={`flex items-center gap-2 text-xs font-black ${textLabelClass} uppercase tracking-widest ml-1`}>
                   <SortAscending size={16} weight="bold" />
                   並び替え
                 </label>
@@ -160,90 +173,93 @@ export function TastingSessionFilterModal({
                     { id: 'oldest', label: '古い順' },
                     { id: 'beanName', label: '豆の名前順' },
                   ].map((opt) => (
-                    <button
+                    <Button
                       key={opt.id}
+                      variant={tempSortOption === opt.id ? 'primary' : 'ghost'}
                       onClick={() => setTempSortOption(opt.id as SortOption)}
-                      className={`px-5 py-3.5 rounded-2xl text-left font-bold transition-all border-2 ${
-                        tempSortOption === opt.id
-                          ? 'bg-amber-50 border-amber-500 text-amber-700'
-                          : 'bg-stone-50 border-transparent text-stone-500 hover:bg-stone-100'
-                      }`}
+                      isChristmasMode={isChristmasMode}
+                      className="justify-start"
                     >
                       {opt.label}
-                    </button>
+                    </Button>
                   ))}
                 </div>
               </div>
 
               {/* 日付範囲 */}
               <div className="space-y-3">
-                <label className="flex items-center gap-2 text-xs font-black text-stone-400 uppercase tracking-widest ml-1">
+                <label className={`flex items-center gap-2 text-xs font-black ${textLabelClass} uppercase tracking-widest ml-1`}>
                   <CalendarBlank size={16} weight="bold" />
                   日付範囲
                 </label>
                 <div className="grid grid-cols-2 gap-3">
-                  <input
+                  <Input
                     type="date"
                     value={tempDateFrom}
                     onChange={(e) => setTempDateFrom(e.target.value)}
-                    className="px-4 py-3.5 bg-stone-50 border-2 border-transparent rounded-2xl focus:bg-white focus:border-amber-500 focus:outline-none transition-all text-stone-800 font-bold text-sm"
+                    isChristmasMode={isChristmasMode}
                   />
-                  <input
+                  <Input
                     type="date"
                     value={tempDateTo}
                     onChange={(e) => setTempDateTo(e.target.value)}
-                    className="px-4 py-3.5 bg-stone-50 border-2 border-transparent rounded-2xl focus:bg-white focus:border-amber-500 focus:outline-none transition-all text-stone-800 font-bold text-sm"
+                    isChristmasMode={isChristmasMode}
                   />
                 </div>
               </div>
 
               {/* 焙煎度合い */}
               <div className="space-y-3 pb-4">
-                <label className="flex items-center gap-2 text-xs font-black text-stone-400 uppercase tracking-widest ml-1">
+                <label className={`flex items-center gap-2 text-xs font-black ${textLabelClass} uppercase tracking-widest ml-1`}>
                   <Thermometer size={16} weight="bold" />
                   焙煎度合い
                 </label>
                 <div className="flex flex-wrap gap-2">
                   {ROAST_LEVELS.map((level) => (
-                    <button
+                    <Button
                       key={level}
+                      variant={tempSelectedRoastLevels.includes(level) ? 'coffee' : 'ghost'}
+                      size="sm"
                       onClick={() => handleRoastLevelToggle(level)}
-                      className={`px-4 py-2.5 rounded-xl text-xs font-black transition-all border-2 ${
-                        tempSelectedRoastLevels.includes(level)
-                          ? 'bg-stone-800 border-stone-800 text-white'
-                          : 'bg-stone-50 border-transparent text-stone-500 hover:bg-stone-100'
-                      }`}
+                      isChristmasMode={isChristmasMode}
                     >
                       {level}
-                    </button>
+                    </Button>
                   ))}
                 </div>
               </div>
             </div>
 
             {/* フッター */}
-            <div className="p-8 pt-4 bg-stone-50/50 flex flex-col gap-3">
+            <div className={`p-8 pt-4 ${footerBgClass} flex flex-col gap-3`}>
               {hasActiveFilters && (
-                <button
+                <Button
+                  variant="ghost"
+                  size="sm"
                   onClick={handleReset}
-                  className="text-xs font-black text-amber-600 uppercase tracking-widest hover:underline mb-2 mx-auto"
+                  isChristmasMode={isChristmasMode}
+                  className="mx-auto"
                 >
                   フィルターをリセット
-                </button>
+                </Button>
               )}
               <div className="flex gap-3">
-                <button
+                <Button
+                  variant="secondary"
                   onClick={onClose}
-                  className="flex-1 px-6 py-4 bg-white border-2 border-stone-100 text-stone-400 rounded-2xl font-black transition-all hover:bg-stone-100"
+                  isChristmasMode={isChristmasMode}
+                  className="flex-1"
                 >
                   キャンセル
-                </button>
-                <button
+                </Button>
+                <Button
+                  variant="primary"
                   onClick={handleApply}
-                  className="flex-1 px-6 py-4 bg-stone-800 text-white rounded-2xl font-black transition-all hover:bg-stone-900 shadow-xl shadow-stone-200"
+                  isChristmasMode={isChristmasMode}
+                  className="flex-1"
                 >
                   適用
-                </button>
+                </Button>
               </div>
             </div>
           </motion.div>

--- a/components/TastingSessionForm.tsx
+++ b/components/TastingSessionForm.tsx
@@ -16,6 +16,7 @@ import {
 import { Input, Select, Button } from '@/components/ui';
 import { ROAST_LEVELS } from '@/lib/constants';
 import { formatDateString } from '@/lib/dateUtils';
+import { useChristmasMode } from '@/hooks/useChristmasMode';
 
 interface TastingSessionFormProps {
   session: TastingSession | null;
@@ -32,6 +33,7 @@ export function TastingSessionForm({
 }: TastingSessionFormProps) {
   const isNew = !session;
   const { showToast } = useToastContext();
+  const { isChristmasMode } = useChristmasMode();
 
   const [beanName, setBeanName] = useState(session?.beanName || '');
   const [createdAt, setCreatedAt] = useState(
@@ -70,17 +72,23 @@ export function TastingSessionForm({
   };
 
   return (
-    <motion.form 
+    <motion.form
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
-      onSubmit={handleSubmit} 
-      className="space-y-8"
+      onSubmit={handleSubmit}
+      className="space-y-5"
     >
-      <div className="bg-white rounded-3xl p-6 sm:p-10 border border-gray-100 shadow-sm space-y-10">
+      <div className={`rounded-2xl p-5 sm:p-6 shadow-sm space-y-5 ${
+        isChristmasMode
+          ? 'bg-[#0a2f1a] border border-[#d4af37]/30'
+          : 'bg-white border border-gray-100'
+      }`}>
         {/* 豆の名前（必須） */}
-        <div className="space-y-4">
-          <label className="flex items-center gap-2 text-base font-black text-stone-500 uppercase tracking-widest ml-1">
-            <Coffee size={20} weight="bold" className="text-amber-600" />
+        <div className="space-y-2">
+          <label className={`flex items-center gap-2 text-sm font-bold ml-1 ${
+            isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'
+          }`}>
+            <Coffee size={18} weight="bold" className={isChristmasMode ? 'text-[#d4af37]' : 'text-amber-600'} />
             豆の名前 <span className="text-red-500">*</span>
           </label>
           <Input
@@ -89,14 +97,17 @@ export function TastingSessionForm({
             onChange={(e) => setBeanName(e.target.value)}
             required
             placeholder="例: コロンビア・エチオピアなど"
+            isChristmasMode={isChristmasMode}
           />
         </div>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-10">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
           {/* 焙煎度合い（必須） */}
-          <div className="space-y-4">
-            <label className="flex items-center gap-2 text-base font-black text-stone-500 uppercase tracking-widest ml-1">
-              <Thermometer size={20} weight="bold" className="text-amber-600" />
+          <div className="space-y-2">
+            <label className={`flex items-center gap-2 text-sm font-bold ml-1 ${
+              isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'
+            }`}>
+              <Thermometer size={18} weight="bold" className={isChristmasMode ? 'text-[#d4af37]' : 'text-amber-600'} />
               焙煎度合い <span className="text-red-500">*</span>
             </label>
             <Select
@@ -108,13 +119,16 @@ export function TastingSessionForm({
               }
               options={ROAST_LEVELS.map((level) => ({ value: level, label: level }))}
               required
+              isChristmasMode={isChristmasMode}
             />
           </div>
 
           {/* 試飲日 */}
-          <div className="space-y-4">
-            <label className="flex items-center gap-2 text-base font-black text-stone-500 uppercase tracking-widest ml-1">
-              <CalendarBlank size={20} weight="bold" className="text-amber-600" />
+          <div className="space-y-2">
+            <label className={`flex items-center gap-2 text-sm font-bold ml-1 ${
+              isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'
+            }`}>
+              <CalendarBlank size={18} weight="bold" className={isChristmasMode ? 'text-[#d4af37]' : 'text-amber-600'} />
               試飲日 <span className="text-red-500">*</span>
             </label>
             <Input
@@ -122,22 +136,23 @@ export function TastingSessionForm({
               value={createdAt}
               onChange={(e) => setCreatedAt(e.target.value)}
               required
+              isChristmasMode={isChristmasMode}
             />
           </div>
         </div>
       </div>
 
       {/* ボタン */}
-      <div className="flex flex-col sm:flex-row gap-4">
+      <div className="flex flex-col sm:flex-row gap-3">
         {!isNew && onDelete && (
           <Button
             type="button"
             variant="danger"
             onClick={handleDelete}
-            size="lg"
             className="flex-1 order-3 sm:order-1"
+            isChristmasMode={isChristmasMode}
           >
-            <Trash size={24} weight="bold" />
+            <Trash size={20} weight="bold" />
             削除
           </Button>
         )}
@@ -145,26 +160,26 @@ export function TastingSessionForm({
           type="button"
           variant="secondary"
           onClick={onCancel}
-          size="lg"
           className="flex-1 order-2"
+          isChristmasMode={isChristmasMode}
         >
-          <X size={24} weight="bold" />
+          <X size={20} weight="bold" />
           キャンセル
         </Button>
         <Button
           type="submit"
           variant="primary"
-          size="lg"
           className="flex-[1.5] order-1 sm:order-3"
+          isChristmasMode={isChristmasMode}
         >
           {isNew ? (
             <>
-              <Plus size={24} weight="bold" />
+              <Plus size={20} weight="bold" />
               セッションを作成
             </>
           ) : (
             <>
-              <Check size={24} weight="bold" />
+              <Check size={20} weight="bold" />
               更新する
             </>
           )}

--- a/components/TastingSessionList.tsx
+++ b/components/TastingSessionList.tsx
@@ -69,6 +69,7 @@ export function TastingSessionList({
   }>({ desktop: null, mobile: null });
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- ハイドレーション後のポータル有効化に必要
     setMounted(true);
     const updateContainers = () => {
       const desktopEl = filterButtonContainerId
@@ -133,22 +134,19 @@ export function TastingSessionList({
 
   const filterButton = (
     <Button
-      variant="outline"
-      size="sm"
+      variant="surface"
       onClick={() => setIsFilterModalOpen(true)}
       badge={activeFilterCount}
       isChristmasMode={isChristmasMode}
       title="フィルター"
       aria-label="フィルター"
-      className="gap-2"
+      className="flex items-center gap-2"
     >
       <Faders
         size={20}
         weight={activeFilterCount > 0 ? 'fill' : 'bold'}
       />
-      <span className="hidden md:block text-[10px] font-black uppercase tracking-[0.15em]">
-        フィルター
-      </span>
+      <span className="whitespace-nowrap">フィルター</span>
     </Button>
   );
 
@@ -158,20 +156,34 @@ export function TastingSessionList({
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          className="max-w-md w-full bg-white rounded-[3rem] p-10 border border-stone-100 shadow-sm text-center space-y-8"
+          className={`max-w-md w-full rounded-[3rem] p-10 border shadow-sm text-center space-y-8 ${
+            isChristmasMode
+              ? 'bg-[#0a2f1a] border-[#d4af37]/30'
+              : 'bg-white border-stone-100'
+          }`}
         >
           <div className="relative mx-auto w-32 h-32">
-            <div className="absolute inset-0 bg-amber-50 rounded-full scale-110 blur-2xl opacity-60"></div>
-            <div className="relative w-full h-full rounded-full bg-stone-50 flex items-center justify-center border-2 border-white shadow-inner">
-              <Coffee size={64} weight="duotone" className="text-amber-200" />
+            <div className={`absolute inset-0 rounded-full scale-110 blur-2xl opacity-60 ${
+              isChristmasMode ? 'bg-[#d4af37]/20' : 'bg-amber-50'
+            }`}></div>
+            <div className={`relative w-full h-full rounded-full flex items-center justify-center border-2 shadow-inner ${
+              isChristmasMode
+                ? 'bg-[#0a2f1a] border-[#d4af37]/30'
+                : 'bg-stone-50 border-white'
+            }`}>
+              <Coffee size={64} weight="duotone" className={isChristmasMode ? 'text-[#d4af37]/50' : 'text-amber-200'} />
             </div>
           </div>
 
           <div className="space-y-3">
-            <h3 className="text-2xl font-black text-stone-800 tracking-tight">
+            <h3 className={`text-2xl font-black tracking-tight ${
+              isChristmasMode ? 'text-[#f8f1e7]' : 'text-stone-800'
+            }`}>
               試飲セッションがありません
             </h3>
-            <p className="text-stone-400 text-sm font-medium leading-relaxed">
+            <p className={`text-sm font-medium leading-relaxed ${
+              isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-stone-400'
+            }`}>
               最初の試飲セッションを作成して、
               <br />
               コーヒーの奥深い世界を記録しましょう。
@@ -180,7 +192,11 @@ export function TastingSessionList({
 
           <Link
             href="/tasting/sessions/new"
-            className="inline-flex items-center gap-3 px-8 py-4 bg-gradient-to-r from-amber-600 to-amber-500 text-white rounded-2xl font-black text-lg shadow-xl shadow-amber-200 hover:from-amber-700 hover:to-amber-600 transition-all active:scale-95"
+            className={`inline-flex items-center gap-3 px-8 py-4 text-white rounded-2xl font-black text-lg transition-all active:scale-95 ${
+              isChristmasMode
+                ? 'bg-gradient-to-r from-[#d4af37] to-[#b8962e] shadow-xl shadow-[#d4af37]/20 hover:from-[#c9a633] hover:to-[#a8872a]'
+                : 'bg-gradient-to-r from-amber-600 to-amber-500 shadow-xl shadow-amber-200 hover:from-amber-700 hover:to-amber-600'
+            }`}
           >
             <Plus size={24} weight="bold" />
             <span>セッションを開始</span>

--- a/components/TastingSessionList.tsx
+++ b/components/TastingSessionList.tsx
@@ -12,6 +12,8 @@ import { useMembers, getActiveMembers } from '@/hooks/useMembers';
 import { useAuth } from '@/lib/auth';
 import { useTastingFilters } from '@/hooks/useTastingFilters';
 import { motion } from 'framer-motion';
+import { Button } from '@/components/ui';
+import { useChristmasMode } from '@/hooks/useChristmasMode';
 
 interface TastingSessionListProps {
   data: AppData;
@@ -29,6 +31,7 @@ export function TastingSessionList({
   const router = useRouter();
   const { user } = useAuth();
   const userId = user?.uid ?? null;
+  const { isChristmasMode } = useChristmasMode();
 
   const { members: allMembers, manager } = useMembers(userId);
 
@@ -129,28 +132,24 @@ export function TastingSessionList({
   };
 
   const filterButton = (
-    <button
+    <Button
+      variant="outline"
+      size="sm"
       onClick={() => setIsFilterModalOpen(true)}
-      className={`px-4 py-2 rounded-2xl bg-white shadow-sm border transition-all hover:shadow-md hover:border-amber-200 flex items-center justify-center gap-2 min-h-[44px] relative group ${
-        activeFilterCount > 0 ? 'text-amber-600 border-amber-200' : 'text-stone-500 border-stone-100'
-      }`}
+      badge={activeFilterCount}
+      isChristmasMode={isChristmasMode}
       title="フィルター"
       aria-label="フィルター"
+      className="gap-2"
     >
       <Faders
         size={20}
         weight={activeFilterCount > 0 ? 'fill' : 'bold'}
-        className="group-hover:scale-110 transition-transform"
       />
       <span className="hidden md:block text-[10px] font-black uppercase tracking-[0.15em]">
         フィルター
       </span>
-      {activeFilterCount > 0 && (
-        <span className="absolute -top-1.5 -right-1.5 bg-amber-600 text-white rounded-full w-5 h-5 flex items-center justify-center text-[10px] font-black shadow-sm ring-2 ring-white">
-          {activeFilterCount}
-        </span>
-      )}
-    </button>
+    </Button>
   );
 
   if (tastingSessions.length === 0) {
@@ -208,6 +207,7 @@ export function TastingSessionList({
           dateTo={dateTo}
           selectedRoastLevels={selectedRoastLevels}
           onApply={handleApplyFilters}
+          isChristmasMode={isChristmasMode}
         />
 
         <div className="flex-1 min-h-0 overflow-y-hidden pt-4 pb-8">

--- a/components/ui/BackLink.tsx
+++ b/components/ui/BackLink.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import Link from 'next/link';
+import { CaretLeft } from 'phosphor-react';
+
+/**
+ * 戻るリンクコンポーネント
+ *
+ * ページ上部に配置する「一覧に戻る」「前のページに戻る」などのナビゲーションリンク。
+ * クリスマスモード対応。
+ *
+ * @example
+ * // 基本的な使用
+ * <BackLink href="/tasting">一覧に戻る</BackLink>
+ *
+ * @example
+ * // クリスマスモード対応
+ * <BackLink href="/tasting" isChristmasMode={isChristmasMode}>一覧に戻る</BackLink>
+ *
+ * @example
+ * // アイコンのみ（コンパクト）
+ * <BackLink href="/" variant="icon-only" isChristmasMode={isChristmasMode} />
+ */
+
+export interface BackLinkProps {
+  /** リンク先URL */
+  href: string;
+  /** リンクテキスト（icon-onlyの場合は不要） */
+  children?: React.ReactNode;
+  /** バリアント */
+  variant?: 'default' | 'icon-only';
+  /** クリスマスモードの有効/無効 */
+  isChristmasMode?: boolean;
+  /** 追加のクラス名 */
+  className?: string;
+  /** aria-label（icon-onlyの場合に必須） */
+  'aria-label'?: string;
+  /** title属性 */
+  title?: string;
+}
+
+export function BackLink({
+  href,
+  children,
+  variant = 'default',
+  isChristmasMode = false,
+  className = '',
+  'aria-label': ariaLabel,
+  title,
+}: BackLinkProps) {
+  if (variant === 'icon-only') {
+    return (
+      <Link
+        href={href}
+        className={`px-3 py-2 rounded transition-colors flex items-center justify-center min-h-[44px] min-w-[44px] ${
+          isChristmasMode
+            ? 'text-[#f8f1e7]/70 hover:text-[#f8f1e7] hover:bg-white/10'
+            : 'text-gray-600 hover:text-gray-800 hover:bg-gray-100'
+        } ${className}`}
+        title={title || '戻る'}
+        aria-label={ariaLabel || '戻る'}
+      >
+        <CaretLeft size={24} weight="bold" />
+      </Link>
+    );
+  }
+
+  return (
+    <Link
+      href={href}
+      className={`group flex items-center gap-2 transition-colors font-bold text-sm uppercase tracking-widest ${
+        isChristmasMode
+          ? 'text-[#f8f1e7]/70 hover:text-[#f8f1e7]'
+          : 'text-gray-600 hover:text-gray-800'
+      } ${className}`}
+      title={title}
+      aria-label={ariaLabel}
+    >
+      <CaretLeft
+        size={20}
+        weight="bold"
+        className="group-hover:-translate-x-1 transition-transform"
+      />
+      {children}
+    </Link>
+  );
+}

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -47,11 +47,15 @@ import { forwardRef } from 'react';
  * @example
  * // バッジ付きボタン（通知やフィルター数表示に使用）
  * <Button badge={3} onClick={handleFilter}>フィルター</Button>
+ *
+ * @example
+ * // サーフェスボタン（白背景+影、フィルターや比較ボタンに使用）
+ * <Button variant="surface" onClick={handleFilter}>フィルター</Button>
  */
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /** ボタンのスタイルバリエーション */
-  variant?: 'primary' | 'secondary' | 'danger' | 'success' | 'outline' | 'ghost' | 'coffee';
+  variant?: 'primary' | 'secondary' | 'danger' | 'success' | 'outline' | 'ghost' | 'coffee' | 'surface';
   /** ボタンのサイズ */
   size?: 'sm' | 'md' | 'lg';
   /** ローディング状態 */
@@ -99,6 +103,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       outline: 'border-2 border-amber-500 text-amber-600 bg-transparent hover:bg-amber-50',
       ghost: 'text-amber-600 hover:text-amber-700',
       coffee: 'bg-[#211714] text-white hover:bg-[#2d1f1b]',
+      surface: 'bg-white text-gray-700 shadow-md hover:bg-gray-50',
     };
 
     // クリスマスモードのバリアントスタイル
@@ -110,6 +115,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       outline: 'border-2 border-[#d4af37] text-[#d4af37] bg-transparent hover:bg-[#d4af37]/10',
       ghost: 'text-[#d4af37] hover:text-[#e8c65f]',
       coffee: 'bg-[#211714] text-white hover:bg-[#2d1f1b] border border-[#d4af37]/30',
+      surface: 'bg-white/10 text-[#f8f1e7] shadow-md hover:bg-white/20 border border-[#d4af37]/20',
     };
 
     const variantStyles = isChristmasMode ? christmasVariantStyles : normalVariantStyles;

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -43,6 +43,10 @@ import { forwardRef } from 'react';
  * // クリスマスモード
  * const { isChristmasMode } = useChristmasMode();
  * <Button isChristmasMode={isChristmasMode} onClick={handleAction}>アクション</Button>
+ *
+ * @example
+ * // バッジ付きボタン（通知やフィルター数表示に使用）
+ * <Button badge={3} onClick={handleFilter}>フィルター</Button>
  */
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -56,6 +60,8 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
   fullWidth?: boolean;
   /** クリスマスモードの有効/無効 */
   isChristmasMode?: boolean;
+  /** バッジに表示する数値（0以下の場合は非表示） */
+  badge?: number;
 }
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
@@ -66,6 +72,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       loading = false,
       fullWidth = false,
       isChristmasMode = false,
+      badge,
       className = '',
       disabled,
       children,
@@ -113,6 +120,11 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     // フル幅スタイル
     const fullWidthStyles = fullWidth ? 'w-full' : '';
 
+    // バッジスタイル
+    const badgeStyles = isChristmasMode
+      ? 'absolute -top-1.5 -right-1.5 bg-[#d4af37] text-[#1a1a1a] rounded-full w-5 h-5 flex items-center justify-center text-[10px] font-black shadow-sm ring-2 ring-white'
+      : 'absolute -top-1.5 -right-1.5 bg-amber-600 text-white rounded-full w-5 h-5 flex items-center justify-center text-[10px] font-black shadow-sm ring-2 ring-white';
+
     const buttonStyles = [
       baseStyles,
       sizeStyles[size],
@@ -122,10 +134,12 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       className,
     ].filter(Boolean).join(' ');
 
+    const showBadge = badge !== undefined && badge > 0;
+
     return (
       <button
         ref={ref}
-        className={buttonStyles}
+        className={`${buttonStyles} ${showBadge ? 'relative' : ''}`}
         disabled={disabled || loading}
         aria-busy={loading}
         {...props}
@@ -154,6 +168,11 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           </svg>
         )}
         {children}
+        {showBadge && (
+          <span className={badgeStyles} aria-label={`${badge}件`}>
+            {badge}
+          </span>
+        )}
       </button>
     );
   }

--- a/components/ui/RoastLevelBadge.tsx
+++ b/components/ui/RoastLevelBadge.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { forwardRef } from 'react';
+
+/**
+ * 焙煎度を表示する専用バッジコンポーネント
+ *
+ * @example
+ * // 基本的な使用方法
+ * <RoastLevelBadge level="深煎り" />
+ * <RoastLevelBadge level="中深煎り" />
+ * <RoastLevelBadge level="中煎り" />
+ * <RoastLevelBadge level="浅煎り" />
+ *
+ * @example
+ * // サイズ指定
+ * <RoastLevelBadge level="深煎り" size="sm" />
+ * <RoastLevelBadge level="深煎り" size="md" />
+ * <RoastLevelBadge level="深煎り" size="lg" />
+ *
+ * @example
+ * // クリスマスモード（通常と同じ色を使用するがshadowが追加される）
+ * <RoastLevelBadge level="深煎り" isChristmasMode={isChristmasMode} />
+ */
+
+export type RoastLevel = '深煎り' | '中深煎り' | '中煎り' | '浅煎り';
+
+export interface RoastLevelBadgeProps extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'children'> {
+  /** 焙煎度 */
+  level: RoastLevel | string;
+  /** サイズ */
+  size?: 'sm' | 'md' | 'lg';
+  /** クリスマスモードの有効/無効 */
+  isChristmasMode?: boolean;
+}
+
+// 焙煎度ごとの背景色（コーヒー豆の色を再現）
+const ROAST_COLORS: Record<string, { bg: string; text: string }> = {
+  '深煎り': { bg: '#120C0A', text: '#FFFFFF' },
+  '中深煎り': { bg: '#4E3526', text: '#FFFFFF' },
+  '中煎り': { bg: '#745138', text: '#FFFFFF' },
+  '浅煎り': { bg: '#C78F5D', text: '#FFFFFF' },
+};
+
+// デフォルトの色（不明な焙煎度の場合）
+const DEFAULT_COLOR = { bg: '#6B7280', text: '#FFFFFF' };
+
+export const RoastLevelBadge = forwardRef<HTMLSpanElement, RoastLevelBadgeProps>(
+  ({ level, size = 'md', isChristmasMode = false, className = '', ...props }, ref) => {
+    // サイズスタイル
+    const sizeStyles = {
+      sm: 'px-2 py-0.5 text-[9px]',
+      md: 'px-3 py-1 text-xs',
+      lg: 'px-4 py-1.5 text-sm',
+    };
+
+    // 焙煎度の色を取得
+    const colors = ROAST_COLORS[level] || DEFAULT_COLOR;
+
+    // クリスマスモードでは少し光沢感を追加
+    const christmasShadow = isChristmasMode ? 'shadow-md ring-1 ring-[#d4af37]/20' : 'shadow-sm';
+
+    const badgeStyles = [
+      'inline-flex items-center font-bold rounded-full uppercase tracking-wider',
+      sizeStyles[size],
+      christmasShadow,
+      className,
+    ].filter(Boolean).join(' ');
+
+    return (
+      <span
+        ref={ref}
+        className={badgeStyles}
+        style={{ backgroundColor: colors.bg, color: colors.text }}
+        {...props}
+      >
+        {level}
+      </span>
+    );
+  }
+);
+
+RoastLevelBadge.displayName = 'RoastLevelBadge';

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -91,3 +91,9 @@ export type { EmptyStateProps } from './EmptyState';
 
 export { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from './Accordion';
 export type { AccordionProps, AccordionItemProps, AccordionTriggerProps, AccordionContentProps } from './Accordion';
+
+export { BackLink } from './BackLink';
+export type { BackLinkProps } from './BackLink';
+
+export { RoastLevelBadge } from './RoastLevelBadge';
+export type { RoastLevelBadgeProps, RoastLevel } from './RoastLevelBadge';

--- a/components/ui/registry.tsx
+++ b/components/ui/registry.tsx
@@ -1,0 +1,739 @@
+'use client';
+
+import { useState } from 'react';
+import { HiX, HiTrash, HiPlus, HiCheck, HiCog, HiInbox } from 'react-icons/hi';
+import { MdClose, MdAdd } from 'react-icons/md';
+
+import {
+  Button,
+  IconButton,
+  Input,
+  NumberInput,
+  InlineInput,
+  Select,
+  Textarea,
+  Checkbox,
+  Switch,
+  Card,
+  Modal,
+  Dialog,
+  Badge,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+  ProgressBar,
+  EmptyState,
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+  BackLink,
+  RoastLevelBadge,
+} from './index';
+
+/**
+ * コンポーネントレジストリのアイテム型定義
+ */
+export interface ComponentRegistryItem {
+  /** コンポーネント名 */
+  name: string;
+  /** コンポーネントの説明 */
+  description: string;
+  /** カテゴリ */
+  category: 'button' | 'form' | 'container' | 'display' | 'feedback';
+  /** 新規追加フラグ */
+  isNew?: boolean;
+  /** デモコンポーネント */
+  Demo: React.ComponentType<{ isChristmasMode: boolean }>;
+}
+
+/**
+ * カテゴリのラベル定義
+ */
+export const categoryLabels: Record<ComponentRegistryItem['category'], string> = {
+  button: 'ボタン系',
+  form: 'フォーム系',
+  container: 'コンテナ系',
+  display: '表示系',
+  feedback: 'フィードバック系',
+};
+
+// ============================================
+// デモコンポーネント定義
+// ============================================
+
+function ButtonDemo({ isChristmasMode }: { isChristmasMode: boolean }) {
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = () => {
+    setLoading(true);
+    setTimeout(() => setLoading(false), 2000);
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Variants */}
+      <div>
+        <h3 className={`text-sm font-semibold mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
+          Variants
+        </h3>
+        <div className="flex flex-wrap gap-3">
+          <Button variant="primary" isChristmasMode={isChristmasMode}>Primary</Button>
+          <Button variant="secondary" isChristmasMode={isChristmasMode}>Secondary</Button>
+          <Button variant="danger" isChristmasMode={isChristmasMode}>Danger</Button>
+          <Button variant="success" isChristmasMode={isChristmasMode}>Success</Button>
+          <Button variant="outline" isChristmasMode={isChristmasMode}>Outline</Button>
+          <Button variant="ghost" isChristmasMode={isChristmasMode}>Ghost</Button>
+          <Button variant="coffee" isChristmasMode={isChristmasMode}>Coffee</Button>
+          <Button variant="surface" isChristmasMode={isChristmasMode}>Surface</Button>
+        </div>
+      </div>
+
+      {/* Sizes */}
+      <div>
+        <h3 className={`text-sm font-semibold mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
+          Sizes
+        </h3>
+        <div className="flex flex-wrap items-center gap-3">
+          <Button size="sm" isChristmasMode={isChristmasMode}>Small</Button>
+          <Button size="md" isChristmasMode={isChristmasMode}>Medium</Button>
+          <Button size="lg" isChristmasMode={isChristmasMode}>Large</Button>
+        </div>
+      </div>
+
+      {/* States */}
+      <div>
+        <h3 className={`text-sm font-semibold mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
+          States
+        </h3>
+        <div className="flex flex-wrap gap-3">
+          <Button disabled isChristmasMode={isChristmasMode}>Disabled</Button>
+          <Button loading={loading} onClick={handleSubmit} isChristmasMode={isChristmasMode}>
+            {loading ? '処理中...' : 'Loading Test'}
+          </Button>
+          <Button badge={3} isChristmasMode={isChristmasMode}>Badge</Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function IconButtonDemo({ isChristmasMode }: { isChristmasMode: boolean }) {
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className={`text-sm font-semibold mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
+          Variants
+        </h3>
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="flex flex-col items-center gap-1">
+            <IconButton variant="default" isChristmasMode={isChristmasMode}><HiX size={20} /></IconButton>
+            <span className={`text-xs ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'}`}>default</span>
+          </div>
+          <div className="flex flex-col items-center gap-1">
+            <IconButton variant="primary" isChristmasMode={isChristmasMode}><HiPlus size={20} /></IconButton>
+            <span className={`text-xs ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'}`}>primary</span>
+          </div>
+          <div className="flex flex-col items-center gap-1">
+            <IconButton variant="danger" isChristmasMode={isChristmasMode}><HiTrash size={20} /></IconButton>
+            <span className={`text-xs ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'}`}>danger</span>
+          </div>
+          <div className="flex flex-col items-center gap-1">
+            <IconButton variant="success" isChristmasMode={isChristmasMode}><HiCheck size={20} /></IconButton>
+            <span className={`text-xs ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'}`}>success</span>
+          </div>
+          <div className="flex flex-col items-center gap-1">
+            <IconButton variant="ghost" isChristmasMode={isChristmasMode}><HiCog size={20} /></IconButton>
+            <span className={`text-xs ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'}`}>ghost</span>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <h3 className={`text-sm font-semibold mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
+          Sizes & Rounded
+        </h3>
+        <div className="flex flex-wrap items-center gap-3">
+          <IconButton size="sm" isChristmasMode={isChristmasMode}><MdClose size={16} /></IconButton>
+          <IconButton size="md" isChristmasMode={isChristmasMode}><MdClose size={20} /></IconButton>
+          <IconButton size="lg" isChristmasMode={isChristmasMode}><MdClose size={24} /></IconButton>
+          <IconButton rounded variant="primary" isChristmasMode={isChristmasMode}><MdAdd size={20} /></IconButton>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function InputDemo({ isChristmasMode }: { isChristmasMode: boolean }) {
+  const [name, setName] = useState('');
+  const [password, setPassword] = useState('');
+
+  return (
+    <div className="space-y-4">
+      <Input
+        label="名前"
+        placeholder="山田太郎"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        isChristmasMode={isChristmasMode}
+      />
+      <Input
+        label="パスワード（トグル付き）"
+        type="password"
+        placeholder="パスワードを入力"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        showPasswordToggle
+        isChristmasMode={isChristmasMode}
+      />
+      <Input
+        label="エラー表示テスト"
+        placeholder="入力してください"
+        error="このフィールドは必須です"
+        isChristmasMode={isChristmasMode}
+      />
+    </div>
+  );
+}
+
+function NumberInputDemo({ isChristmasMode }: { isChristmasMode: boolean }) {
+  const [width, setWidth] = useState(160);
+
+  return (
+    <div className="space-y-4">
+      <NumberInput
+        label="幅設定"
+        suffix="px"
+        value={width}
+        onChange={(e) => setWidth(parseInt(e.target.value) || 0)}
+        isChristmasMode={isChristmasMode}
+      />
+      <NumberInput
+        label="エラー表示テスト"
+        suffix="px"
+        value={0}
+        onChange={() => {}}
+        error="0以上の値を入力してください"
+        isChristmasMode={isChristmasMode}
+      />
+    </div>
+  );
+}
+
+function InlineInputDemo({ isChristmasMode }: { isChristmasMode: boolean }) {
+  const [value, setValue] = useState('テスト値');
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className={`text-sm font-semibold mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
+          Light Background
+        </h3>
+        <div className={`p-4 rounded-lg ${isChristmasMode ? 'bg-white/5' : 'bg-gray-50'}`}>
+          <InlineInput
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            variant="light"
+            isChristmasMode={isChristmasMode}
+          />
+        </div>
+      </div>
+      <div>
+        <h3 className={`text-sm font-semibold mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
+          Dark Background
+        </h3>
+        <div className={`p-4 rounded-lg ${isChristmasMode ? 'bg-[#0a1f12]' : 'bg-gray-800'}`}>
+          <InlineInput
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            variant="dark"
+            isChristmasMode={isChristmasMode}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SelectDemo({ isChristmasMode }: { isChristmasMode: boolean }) {
+  const [category, setCategory] = useState('');
+
+  return (
+    <Select
+      label="カテゴリ"
+      placeholder="選択してください"
+      options={[
+        { value: 'light', label: 'ライトロースト' },
+        { value: 'medium', label: 'ミディアムロースト' },
+        { value: 'dark', label: 'ダークロースト' },
+      ]}
+      value={category}
+      onChange={(e) => setCategory(e.target.value)}
+      isChristmasMode={isChristmasMode}
+    />
+  );
+}
+
+function TextareaDemo({ isChristmasMode }: { isChristmasMode: boolean }) {
+  const [memo, setMemo] = useState('');
+
+  return (
+    <Textarea
+      label="メモ"
+      placeholder="焙煎に関するメモを入力"
+      rows={4}
+      value={memo}
+      onChange={(e) => setMemo(e.target.value)}
+      isChristmasMode={isChristmasMode}
+    />
+  );
+}
+
+function CheckboxDemo({ isChristmasMode }: { isChristmasMode: boolean }) {
+  const [checked1, setChecked1] = useState(false);
+  const [checked2, setChecked2] = useState(true);
+
+  return (
+    <div className="space-y-4">
+      <Checkbox
+        label="基本的なチェックボックス"
+        checked={checked1}
+        onChange={(e) => setChecked1(e.target.checked)}
+        isChristmasMode={isChristmasMode}
+      />
+      <Checkbox
+        label="説明文付き"
+        description="このオプションを有効にすると、通知が送信されます。"
+        checked={checked2}
+        onChange={(e) => setChecked2(e.target.checked)}
+        isChristmasMode={isChristmasMode}
+      />
+      <Checkbox
+        label="無効状態"
+        disabled
+        isChristmasMode={isChristmasMode}
+      />
+    </div>
+  );
+}
+
+function SwitchDemo({ isChristmasMode }: { isChristmasMode: boolean }) {
+  const [switchOn, setSwitchOn] = useState(false);
+
+  return (
+    <div className="space-y-4">
+      <Switch
+        label="通知を有効にする"
+        checked={switchOn}
+        onChange={(e) => setSwitchOn(e.target.checked)}
+        isChristmasMode={isChristmasMode}
+      />
+      <div className="flex flex-wrap items-center gap-6">
+        <Switch size="sm" checked={true} label="Small" isChristmasMode={isChristmasMode} />
+        <Switch size="md" checked={true} label="Medium" isChristmasMode={isChristmasMode} />
+        <Switch size="lg" checked={true} label="Large" isChristmasMode={isChristmasMode} />
+      </div>
+    </div>
+  );
+}
+
+function CardDemo({ isChristmasMode }: { isChristmasMode: boolean }) {
+  return (
+    <div className="space-y-4">
+      <Card variant="default" isChristmasMode={isChristmasMode}>
+        <p className={isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}>
+          Default Card - 基本的なカード
+        </p>
+      </Card>
+      <Card variant="hoverable" isChristmasMode={isChristmasMode}>
+        <p className={isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}>
+          Hoverable Card - ホバーでシャドウ変化
+        </p>
+      </Card>
+      <Card variant="coffee" isChristmasMode={isChristmasMode}>
+        <p className="text-white">Coffee Card - ダークブラウン背景</p>
+      </Card>
+    </div>
+  );
+}
+
+function ModalDemo({ isChristmasMode }: { isChristmasMode: boolean }) {
+  const [showModal, setShowModal] = useState(false);
+
+  return (
+    <>
+      <Button variant="primary" onClick={() => setShowModal(true)} isChristmasMode={isChristmasMode}>
+        モーダルを開く
+      </Button>
+      <Modal
+        show={showModal}
+        onClose={() => setShowModal(false)}
+        contentClassName={isChristmasMode
+          ? 'bg-[#0a2618] rounded-2xl shadow-xl overflow-hidden max-w-sm w-full border border-[#d4af37]/40'
+          : 'bg-white rounded-2xl shadow-xl overflow-hidden max-w-sm w-full'
+        }
+      >
+        <div className="p-6">
+          <h3 className={`text-lg font-bold mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-900'}`}>
+            モーダルタイトル
+          </h3>
+          <p className={`text-sm mb-4 ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>
+            これはモーダルの内容です。
+          </p>
+          <div className="flex justify-end">
+            <Button variant="primary" onClick={() => setShowModal(false)} isChristmasMode={isChristmasMode}>
+              閉じる
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    </>
+  );
+}
+
+function DialogDemo({ isChristmasMode }: { isChristmasMode: boolean }) {
+  const [showDialog, setShowDialog] = useState(false);
+  const [showDangerDialog, setShowDangerDialog] = useState(false);
+
+  return (
+    <>
+      <div className="flex flex-wrap gap-3">
+        <Button variant="primary" onClick={() => setShowDialog(true)} isChristmasMode={isChristmasMode}>
+          通常ダイアログ
+        </Button>
+        <Button variant="danger" onClick={() => setShowDangerDialog(true)} isChristmasMode={isChristmasMode}>
+          危険アクション
+        </Button>
+      </div>
+      <Dialog
+        isOpen={showDialog}
+        onClose={() => setShowDialog(false)}
+        title="確認"
+        description="この操作を実行してもよろしいですか？"
+        confirmText="実行する"
+        onConfirm={() => setShowDialog(false)}
+        isChristmasMode={isChristmasMode}
+      />
+      <Dialog
+        isOpen={showDangerDialog}
+        onClose={() => setShowDangerDialog(false)}
+        title="削除の確認"
+        description="このアイテムを削除しますか？この操作は取り消せません。"
+        confirmText="削除する"
+        onConfirm={() => setShowDangerDialog(false)}
+        variant="danger"
+        isChristmasMode={isChristmasMode}
+      />
+    </>
+  );
+}
+
+function BadgeDemo({ isChristmasMode }: { isChristmasMode: boolean }) {
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className={`text-sm font-semibold mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
+          Variants
+        </h3>
+        <div className="flex flex-wrap gap-2">
+          <Badge variant="default" isChristmasMode={isChristmasMode}>Default</Badge>
+          <Badge variant="primary" isChristmasMode={isChristmasMode}>Primary</Badge>
+          <Badge variant="secondary" isChristmasMode={isChristmasMode}>Secondary</Badge>
+          <Badge variant="success" isChristmasMode={isChristmasMode}>Success</Badge>
+          <Badge variant="warning" isChristmasMode={isChristmasMode}>Warning</Badge>
+          <Badge variant="danger" isChristmasMode={isChristmasMode}>Danger</Badge>
+          <Badge variant="coffee" isChristmasMode={isChristmasMode}>Coffee</Badge>
+        </div>
+      </div>
+      <div>
+        <h3 className={`text-sm font-semibold mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
+          Sizes
+        </h3>
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge size="sm" variant="primary" isChristmasMode={isChristmasMode}>Small</Badge>
+          <Badge size="md" variant="primary" isChristmasMode={isChristmasMode}>Medium</Badge>
+          <Badge size="lg" variant="primary" isChristmasMode={isChristmasMode}>Large</Badge>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RoastLevelBadgeDemo({ isChristmasMode }: { isChristmasMode: boolean }) {
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className={`text-sm font-semibold mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
+          焙煎度レベル
+        </h3>
+        <div className="flex flex-wrap gap-3">
+          <RoastLevelBadge level="浅煎り" isChristmasMode={isChristmasMode} />
+          <RoastLevelBadge level="中煎り" isChristmasMode={isChristmasMode} />
+          <RoastLevelBadge level="中深煎り" isChristmasMode={isChristmasMode} />
+          <RoastLevelBadge level="深煎り" isChristmasMode={isChristmasMode} />
+        </div>
+      </div>
+      <div>
+        <h3 className={`text-sm font-semibold mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
+          サイズ
+        </h3>
+        <div className="flex flex-wrap items-center gap-3">
+          <RoastLevelBadge level="中深煎り" size="sm" isChristmasMode={isChristmasMode} />
+          <RoastLevelBadge level="中深煎り" size="md" isChristmasMode={isChristmasMode} />
+          <RoastLevelBadge level="中深煎り" size="lg" isChristmasMode={isChristmasMode} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TabsDemo({ isChristmasMode }: { isChristmasMode: boolean }) {
+  return (
+    <Tabs defaultValue="tab1" isChristmasMode={isChristmasMode}>
+      <TabsList className="mb-4">
+        <TabsTrigger value="tab1">タブ1</TabsTrigger>
+        <TabsTrigger value="tab2">タブ2</TabsTrigger>
+        <TabsTrigger value="tab3">タブ3</TabsTrigger>
+      </TabsList>
+      <TabsContent value="tab1">
+        <div className={`p-4 rounded-lg ${isChristmasMode ? 'bg-white/5' : 'bg-gray-50'}`}>
+          <p className={isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}>タブ1の内容です。</p>
+        </div>
+      </TabsContent>
+      <TabsContent value="tab2">
+        <div className={`p-4 rounded-lg ${isChristmasMode ? 'bg-white/5' : 'bg-gray-50'}`}>
+          <p className={isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}>タブ2の内容です。</p>
+        </div>
+      </TabsContent>
+      <TabsContent value="tab3">
+        <div className={`p-4 rounded-lg ${isChristmasMode ? 'bg-white/5' : 'bg-gray-50'}`}>
+          <p className={isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}>タブ3の内容です。</p>
+        </div>
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+function ProgressBarDemo({ isChristmasMode }: { isChristmasMode: boolean }) {
+  return (
+    <div className="space-y-3">
+      <ProgressBar value={65} variant="primary" label="Primary" showValue isChristmasMode={isChristmasMode} />
+      <ProgressBar value={80} variant="success" label="Success" showValue isChristmasMode={isChristmasMode} />
+      <ProgressBar value={45} variant="warning" label="Warning" showValue isChristmasMode={isChristmasMode} />
+      <ProgressBar value={30} variant="danger" label="Danger" showValue isChristmasMode={isChristmasMode} />
+      <ProgressBar value={60} variant="coffee" label="Coffee" showValue isChristmasMode={isChristmasMode} />
+    </div>
+  );
+}
+
+function EmptyStateDemo({ isChristmasMode }: { isChristmasMode: boolean }) {
+  return (
+    <div className={`border rounded-lg ${isChristmasMode ? 'border-[#d4af37]/20' : 'border-gray-200'}`}>
+      <EmptyState
+        icon={<HiInbox className="h-12 w-12" />}
+        title="データがありません"
+        description="新しいアイテムを追加して始めましょう。"
+        action={<Button size="sm" isChristmasMode={isChristmasMode}>追加する</Button>}
+        isChristmasMode={isChristmasMode}
+      />
+    </div>
+  );
+}
+
+function AccordionDemo({ isChristmasMode }: { isChristmasMode: boolean }) {
+  return (
+    <Accordion isChristmasMode={isChristmasMode}>
+      <AccordionItem defaultOpen>
+        <AccordionTrigger>セクション1（デフォルトで開く）</AccordionTrigger>
+        <AccordionContent>
+          <p>このセクションはデフォルトで開いた状態です。</p>
+        </AccordionContent>
+      </AccordionItem>
+      <AccordionItem>
+        <AccordionTrigger>セクション2</AccordionTrigger>
+        <AccordionContent>
+          <p>クリックすると開閉できます。</p>
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  );
+}
+
+function BackLinkDemo({ isChristmasMode }: { isChristmasMode: boolean }) {
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className={`text-sm font-semibold mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
+          Default（テキスト付き）
+        </h3>
+        <BackLink href="#" isChristmasMode={isChristmasMode}>
+          一覧に戻る
+        </BackLink>
+      </div>
+      <div>
+        <h3 className={`text-sm font-semibold mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
+          Icon Only（アイコンのみ）
+        </h3>
+        <BackLink href="#" variant="icon-only" isChristmasMode={isChristmasMode} />
+      </div>
+    </div>
+  );
+}
+
+// ============================================
+// コンポーネントレジストリ
+// ============================================
+
+/**
+ * 全共通コンポーネントのレジストリ
+ *
+ * 新しいコンポーネントを追加する場合：
+ * 1. 上部にデモコンポーネント（XxxDemo）を作成
+ * 2. このレジストリに新しいエントリを追加
+ * 3. UIテストページは自動的に新しいコンポーネントを表示
+ */
+export const componentRegistry: ComponentRegistryItem[] = [
+  // ボタン系
+  {
+    name: 'Button',
+    description: '統一されたボタンコンポーネント。8種類のvariant（primary, secondary, danger, success, outline, ghost, coffee, surface）と3種類のサイズ。',
+    category: 'button',
+    Demo: ButtonDemo,
+  },
+  {
+    name: 'IconButton',
+    description: 'アイコンのみのボタン。閉じる、削除、追加などのアクションに使用。',
+    category: 'button',
+    Demo: IconButtonDemo,
+  },
+  {
+    name: 'BackLink',
+    description: '戻るリンク。ページ上部に配置する「一覧に戻る」などのナビゲーションリンク。',
+    category: 'button',
+    isNew: true,
+    Demo: BackLinkDemo,
+  },
+
+  // フォーム系
+  {
+    name: 'Input',
+    description: 'テキスト入力フィールド。パスワードトグル、エラー表示に対応。',
+    category: 'form',
+    Demo: InputDemo,
+  },
+  {
+    name: 'NumberInput',
+    description: '数値入力専用フィールド。suffix（単位）表示に対応。',
+    category: 'form',
+    Demo: NumberInputDemo,
+  },
+  {
+    name: 'InlineInput',
+    description: 'インライン編集用の軽量入力。テーブルセルやヘッダー内での使用に最適。',
+    category: 'form',
+    Demo: InlineInputDemo,
+  },
+  {
+    name: 'Select',
+    description: 'セレクトボックス。オプション選択に使用。',
+    category: 'form',
+    Demo: SelectDemo,
+  },
+  {
+    name: 'Textarea',
+    description: '複数行テキスト入力。メモや説明文の入力に使用。',
+    category: 'form',
+    Demo: TextareaDemo,
+  },
+  {
+    name: 'Checkbox',
+    description: 'チェックボックス。設定画面やフィルターで使用。',
+    category: 'form',
+    Demo: CheckboxDemo,
+  },
+  {
+    name: 'Switch',
+    description: 'ON/OFFトグルスイッチ。モード切替などに使用。',
+    category: 'form',
+    Demo: SwitchDemo,
+  },
+
+  // コンテナ系
+  {
+    name: 'Card',
+    description: 'カードコンポーネント。コンテンツのグループ化に使用。',
+    category: 'container',
+    Demo: CardDemo,
+  },
+  {
+    name: 'Modal',
+    description: '汎用モーダル。カスタムコンテンツを表示するための基盤。',
+    category: 'container',
+    Demo: ModalDemo,
+  },
+  {
+    name: 'Dialog',
+    description: '確認ダイアログ。OK/キャンセルの選択が必要な場面で使用。',
+    category: 'container',
+    Demo: DialogDemo,
+  },
+  {
+    name: 'Accordion',
+    description: 'アコーディオン。折りたたみ可能なセクション表示に使用。',
+    category: 'container',
+    Demo: AccordionDemo,
+  },
+  {
+    name: 'Tabs',
+    description: 'タブ切り替えコンポーネント。ページ内の表示切り替えに使用。',
+    category: 'container',
+    Demo: TabsDemo,
+  },
+
+  // 表示系
+  {
+    name: 'Badge',
+    description: 'ラベル/タグ表示。ステータスやカテゴリ表示に使用。',
+    category: 'display',
+    Demo: BadgeDemo,
+  },
+  {
+    name: 'RoastLevelBadge',
+    description: '焙煎度専用バッジ。浅煎り〜深煎りの4段階を色分け表示。',
+    category: 'display',
+    isNew: true,
+    Demo: RoastLevelBadgeDemo,
+  },
+  {
+    name: 'ProgressBar',
+    description: '進捗バー。タスク進捗やローディング表示に使用。',
+    category: 'display',
+    Demo: ProgressBarDemo,
+  },
+  {
+    name: 'EmptyState',
+    description: '空状態表示。データがない場合の表示に使用。',
+    category: 'display',
+    Demo: EmptyStateDemo,
+  },
+];
+
+/**
+ * カテゴリでグループ化されたコンポーネントを取得
+ */
+export function getComponentsByCategory(): Record<ComponentRegistryItem['category'], ComponentRegistryItem[]> {
+  const grouped: Record<ComponentRegistryItem['category'], ComponentRegistryItem[]> = {
+    button: [],
+    form: [],
+    container: [],
+    display: [],
+    feedback: [],
+  };
+
+  componentRegistry.forEach((item) => {
+    grouped[item.category].push(item);
+  });
+
+  return grouped;
+}


### PR DESCRIPTION
## Summary
- 試飲記録ページ（Tasting）の独自UI要素を共通UIコンポーネントに置換
- 全てのUI要素にクリスマスモード対応を追加
- 新規共通コンポーネント追加（BackLink, RoastLevelBadge）
- UIをよりコンパクトに調整

## 新規コンポーネント

| コンポーネント | 用途 |
|--------------|------|
| `BackLink` | 戻るボタン（icon-only/default variant） |
| `RoastLevelBadge` | 焙煎度バッジの統一表示 |
| `registry.tsx` | UIテストページ用コンポーネントレジストリ |

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------| 
| `app/tasting/page.tsx` | BackLink(icon-only)、コンパクト化 |
| `app/tasting/sessions/new/page.tsx` | BackLink(icon-only)、コンパクト化 |
| `components/SliderInput.tsx` | クリスマスモード対応、日本語化 |
| `components/TastingRecordForm.tsx` | レーダーチャートプレビュー削除、コンパクト化 |
| `components/TastingRecordFormScores.tsx` | クリスマスモード対応、"スケール"表記 |
| `components/TastingRecordList.tsx` | RoastLevelBadge使用、テーマ対応 |
| `components/TastingSessionCardDesktop.tsx` | スコアバー色をクリスマスモードで金色 |
| `components/TastingSessionCardMobile.tsx` | スコアバー色をクリスマスモードで金色 |
| `components/TastingSessionCarousel.tsx` | スクロールバー・インジケーター色をテーマ対応 |
| `components/TastingSessionDetail.tsx` | Card、RoastLevelBadge使用 |
| `components/TastingSessionFilterModal.tsx` | Button/IconButton/Input使用 |
| `components/TastingSessionForm.tsx` | コンパクト化 |
| `components/TastingSessionList.tsx` | Button使用、空状態テーマ対応 |
| `app/ui-test/page.tsx` | registryベースに移行 |

## クリスマスモード対応

- **スコアバー**: デフォルト=各属性の固有色、クリスマス=金色(#d4af37)統一
- **スライダー**: 背景・つまみ・トラック色をテーマ対応
- **焙煎度バッジ**: RoastLevelBadge共通コンポーネント化
- **戻るボタン**: BackLink共通コンポーネント化（icon-onlyに統一）

## Test plan
- [x] `npm run build` 成功
- [x] `npm run lint` パス
- [ ] デスクトップビューでクリスマスモードが正しく適用される
- [ ] モバイルビューでクリスマスモードが正しく適用される
- [ ] 試飲記録フォームの評価スライダーがテーマに応じて配色変更

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)
