### PR TITLE
refactor(roast-timer): ローストタイマーページの共通UI化とクリスマスモード対応

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,32 @@ import {
 4. **既存で対応不可の場合** → `components/ui/` に新規共通コンポーネントを作成
 5. **共通コンポーネントの重複禁止** → 作成前に既存コンポーネントを必ず確認
 
+### 新規コンポーネント追加時（レジストリ方式）
+新しい共通UIコンポーネントを作成した場合、**必ず以下の手順で登録すること**：
+
+1. `components/ui/NewComponent.tsx` を作成
+2. `components/ui/index.ts` にエクスポートを追加
+3. `components/ui/registry.tsx` に以下を追加：
+   - デモコンポーネント（`NewComponentDemo`関数）
+   - `componentRegistry`配列にエントリを追加（name, description, category, Demo）
+
+```tsx
+// registry.tsx への追加例
+function NewComponentDemo({ isChristmasMode }: { isChristmasMode: boolean }) {
+  return <NewComponent isChristmasMode={isChristmasMode} />;
+}
+
+// componentRegistry配列に追加
+{
+  name: 'NewComponent',
+  description: 'コンポーネントの説明',
+  category: 'button' | 'form' | 'container' | 'display' | 'feedback',
+  Demo: NewComponentDemo,
+}
+```
+
+→ UIテストページ（`/ui-test`）に自動表示される
+
 ### クリスマスモード対応例
 ```tsx
 const { isChristmasMode } = useChristmasMode();

--- a/app/roast-record/page.tsx
+++ b/app/roast-record/page.tsx
@@ -5,9 +5,11 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { useAuth } from '@/lib/auth';
 import { useAppData } from '@/hooks/useAppData';
+import { useChristmasMode } from '@/hooks/useChristmasMode';
 import { RoastRecordForm } from '@/components/RoastRecordForm';
 import { RoastRecordList } from '@/components/RoastRecordList';
 import { Loading } from '@/components/Loading';
+import { IconButton, Button, Card } from '@/components/ui';
 import type { RoastTimerRecord } from '@/types';
 import { HiPlus, HiArrowLeft } from 'react-icons/hi';
 import { useToastContext } from '@/components/Toast';
@@ -15,6 +17,7 @@ import { useToastContext } from '@/components/Toast';
 function RoastRecordPageContent() {
   const { user, loading: authLoading } = useAuth();
   const { data, updateData, isLoading } = useAppData();
+  const { isChristmasMode } = useChristmasMode();
   const router = useRouter();
   const searchParams = useSearchParams();
   const hasRedirected = useRef(false);
@@ -65,14 +68,14 @@ function RoastRecordPageContent() {
     const record = roastTimerRecords.find((r) => r.id === recordId);
     if (!record) {
       return (
-        <div className="min-h-screen py-4 sm:py-6 lg:py-8 px-4 sm:px-6 lg:px-8" style={{ backgroundColor: '#F7F7F5' }}>
+        <div className="min-h-screen py-4 sm:py-6 lg:py-8 px-4 sm:px-6 lg:px-8" style={{ backgroundColor: isChristmasMode ? '#051a0e' : '#F7F7F5' }}>
           <div className="max-w-2xl mx-auto">
-            <div className="bg-white rounded-lg shadow-md p-6 text-center">
-              <p className="text-gray-600 mb-4">記録が見つかりません</p>
-              <Link href="/roast-record" className="text-amber-600 hover:underline">
+            <Card isChristmasMode={isChristmasMode} className="p-6 text-center">
+              <p className={`mb-4 ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>記録が見つかりません</p>
+              <Link href="/roast-record" className={`${isChristmasMode ? 'text-[#d4af37]' : 'text-amber-600'} hover:underline`}>
                 一覧に戻る
               </Link>
-            </div>
+            </Card>
           </div>
         </div>
       );
@@ -118,35 +121,38 @@ function RoastRecordPageContent() {
     };
 
     return (
-      <div className="min-h-screen py-4 sm:py-6 lg:py-8 px-4 sm:px-6 lg:px-8" style={{ backgroundColor: '#F7F7F5' }}>
+      <div className="min-h-screen py-4 sm:py-6 lg:py-8 px-4 sm:px-6 lg:px-8" style={{ backgroundColor: isChristmasMode ? '#051a0e' : '#F7F7F5' }}>
         <div className="max-w-2xl mx-auto">
           <header className="mb-6 sm:mb-8">
             <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
               <div className="flex justify-start w-full sm:w-auto sm:flex-1">
-                <Link
-                  href="/roast-record"
-                  className="px-4 py-2 sm:px-6 sm:py-3 text-sm sm:text-base text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded transition-colors flex items-center gap-2 flex-shrink-0"
+                <IconButton
+                  onClick={() => router.push('/roast-record')}
+                  size="lg"
+                  title="一覧に戻る"
+                  aria-label="一覧に戻る"
+                  isChristmasMode={isChristmasMode}
                 >
-                  <HiArrowLeft className="text-lg flex-shrink-0" />
-                  一覧に戻る
-                </Link>
+                  <HiArrowLeft className="h-6 w-6" />
+                </IconButton>
               </div>
-              <h1 className="w-full sm:w-auto text-2xl sm:text-3xl font-bold text-gray-800 sm:flex-1 text-center">
+              <h1 className={`w-full sm:w-auto text-2xl sm:text-3xl font-bold sm:flex-1 text-center ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
                 記録を編集
               </h1>
               <div className="hidden sm:block flex-1 flex-shrink-0"></div>
             </div>
           </header>
           <main>
-            <div className="bg-white rounded-lg shadow-md p-4 sm:p-6">
+            <Card isChristmasMode={isChristmasMode} className="p-4 sm:p-6">
               <RoastRecordForm
                 data={data}
                 record={record}
                 onSave={handleSave}
                 onDelete={handleDelete}
                 onCancel={handleCancel}
+                isChristmasMode={isChristmasMode}
               />
-            </div>
+            </Card>
           </main>
         </div>
       </div>
@@ -188,34 +194,37 @@ function RoastRecordPageContent() {
     };
 
     return (
-      <div className="min-h-screen py-4 sm:py-6 lg:py-8 px-4 sm:px-6 lg:px-8" style={{ backgroundColor: '#F7F7F5' }}>
+      <div className="min-h-screen py-4 sm:py-6 lg:py-8 px-4 sm:px-6 lg:px-8" style={{ backgroundColor: isChristmasMode ? '#051a0e' : '#F7F7F5' }}>
         <div className="max-w-2xl mx-auto">
           <header className="mb-6 sm:mb-8">
             <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
               <div className="flex justify-start w-full sm:w-auto sm:flex-1">
-                <Link
-                  href="/roast-record"
-                  className="px-4 py-2 sm:px-6 sm:py-3 text-sm sm:text-base text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded transition-colors flex items-center gap-2 flex-shrink-0"
+                <IconButton
+                  onClick={() => router.push('/roast-record')}
+                  size="lg"
+                  title="一覧に戻る"
+                  aria-label="一覧に戻る"
+                  isChristmasMode={isChristmasMode}
                 >
-                  <HiArrowLeft className="text-lg flex-shrink-0" />
-                  一覧に戻る
-                </Link>
+                  <HiArrowLeft className="h-6 w-6" />
+                </IconButton>
               </div>
-              <h1 className="w-full sm:w-auto text-2xl sm:text-3xl font-bold text-gray-800 sm:flex-1 text-center">
+              <h1 className={`w-full sm:w-auto text-2xl sm:text-3xl font-bold sm:flex-1 text-center ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
                 新規記録を作成
               </h1>
               <div className="hidden sm:block flex-1 flex-shrink-0"></div>
             </div>
           </header>
           <main>
-            <div className="bg-white rounded-lg shadow-md p-4 sm:p-6">
+            <Card isChristmasMode={isChristmasMode} className="p-4 sm:p-6">
               <RoastRecordForm
                 data={data}
                 onSave={handleSave}
                 initialValues={initialValues}
                 onCancel={handleCancel}
+                isChristmasMode={isChristmasMode}
               />
-            </div>
+            </Card>
           </main>
         </div>
       </div>
@@ -224,41 +233,45 @@ function RoastRecordPageContent() {
 
   // 一覧表示（デフォルト）
   return (
-    <div className="h-screen overflow-y-hidden flex flex-col px-4 sm:px-6 lg:px-8 pt-4 sm:pt-6 lg:pt-8 pb-2 sm:pb-3 lg:pb-4" style={{ backgroundColor: '#F7F7F5' }}>
+    <div className="h-screen overflow-y-hidden flex flex-col px-4 sm:px-6 lg:px-8 pt-4 sm:pt-6 lg:pt-8 pb-2 sm:pb-3 lg:pb-4" style={{ backgroundColor: isChristmasMode ? '#051a0e' : '#F7F7F5' }}>
       <div className="max-w-7xl mx-auto w-full flex flex-col flex-1 min-h-0">
         <header className="mb-3 sm:mb-6 flex-shrink-0">
           <div className="flex items-center justify-between gap-2 sm:gap-4">
             <div className="flex items-center gap-2 sm:flex-1">
-              <Link
-                href="/"
-                className="px-3 py-2 text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded transition-colors flex items-center justify-center min-h-[44px] min-w-[44px]"
+              <IconButton
+                onClick={() => router.push('/')}
+                size="lg"
                 title="戻る"
                 aria-label="戻る"
+                isChristmasMode={isChristmasMode}
               >
-                <HiArrowLeft className="h-6 w-6 flex-shrink-0" />
-              </Link>
-              <h1 className="text-xl sm:text-2xl md:text-3xl font-bold text-gray-800 sm:hidden">
+                <HiArrowLeft className="h-6 w-6" />
+              </IconButton>
+              <h1 className={`text-xl sm:text-2xl md:text-3xl font-bold sm:hidden ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
                 ロースト記録
               </h1>
             </div>
-            <h1 className="hidden sm:block text-2xl sm:text-3xl font-bold text-gray-800 sm:flex-1 text-center">
+            <h1 className={`hidden sm:block text-2xl sm:text-3xl font-bold sm:flex-1 text-center ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
               ロースト記録
             </h1>
             <div className="flex justify-end sm:flex-1">
-              <Link
-                href="/roast-record?new=true"
-                className="px-4 py-2 sm:px-6 sm:py-3 text-sm sm:text-base bg-amber-600 text-white rounded-lg shadow-md hover:bg-amber-700 transition-colors flex items-center gap-2 min-h-[44px] flex-shrink-0"
+              <Button
+                variant="primary"
+                size="md"
+                onClick={() => router.push('/roast-record?new=true')}
+                className="flex items-center gap-2"
                 aria-label="新規記録作成"
+                isChristmasMode={isChristmasMode}
               >
                 <HiPlus className="text-base sm:text-lg flex-shrink-0" />
                 <span className="whitespace-nowrap">新規記録を作成</span>
-              </Link>
+              </Button>
             </div>
           </div>
         </header>
 
         <main className="flex-1 min-h-0 overflow-hidden">
-          <RoastRecordList data={data} onUpdate={updateData} />
+          <RoastRecordList data={data} onUpdate={updateData} isChristmasMode={isChristmasMode} />
         </main>
       </div>
     </div>

--- a/app/roast-timer/page.tsx
+++ b/app/roast-timer/page.tsx
@@ -5,11 +5,13 @@ import { RoastTimer } from '@/components/RoastTimer';
 import { Loading } from '@/components/Loading';
 import { useAppLifecycle } from '@/hooks/useAppLifecycle';
 import { requestNotificationPermission } from '@/lib/notifications';
+import { useChristmasMode } from '@/hooks/useChristmasMode';
 import LoginPage from '@/app/login/page';
 import { useEffect } from 'react';
 
 export default function RoastTimerPage() {
   const { user, loading: authLoading } = useAuth();
+  const { isChristmasMode } = useChristmasMode();
   useAppLifecycle();
 
   // アプリ起動時に通知権限をリクエスト
@@ -26,9 +28,9 @@ export default function RoastTimerPage() {
   }
 
   return (
-    <div className="h-screen overflow-hidden flex flex-col px-2 sm:px-4 py-2 sm:py-4" style={{ backgroundColor: '#F7F7F5' }}>
+    <div className="h-screen overflow-hidden flex flex-col px-2 sm:px-4 py-2 sm:py-4" style={{ backgroundColor: isChristmasMode ? '#051a0e' : '#F7F7F5' }}>
           <div className="flex-1 min-h-0">
-            <RoastTimer />
+            <RoastTimer isChristmasMode={isChristmasMode} />
       </div>
     </div>
   );

--- a/components/RoastRecordForm.tsx
+++ b/components/RoastRecordForm.tsx
@@ -24,6 +24,7 @@ interface RoastRecordFormProps {
   };
   onDelete?: (id: string) => void; // 削除機能（編集時のみ）
   onCancel?: () => void; // キャンセル機能
+  isChristmasMode?: boolean;
 }
 
 export function RoastRecordForm(props: RoastRecordFormProps) {
@@ -45,6 +46,7 @@ function RoastRecordFormInner({
   initialValues,
   onDelete,
   onCancel,
+  isChristmasMode = false,
 }: RoastRecordFormProps) {
   const { showToast } = useToastContext();
   void _data;
@@ -152,7 +154,7 @@ function RoastRecordFormInner({
     <form onSubmit={handleSubmit} className="space-y-4 sm:space-y-6">
       {/* 豆の名前 */}
       <div>
-        <label className="block text-sm sm:text-base font-medium text-gray-700 mb-1 sm:mb-2">
+        <label className={`block text-sm sm:text-base font-medium mb-1 sm:mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
           豆の名前 <span className="text-red-500">*</span>
         </label>
         <Select
@@ -161,12 +163,13 @@ function RoastRecordFormInner({
           options={ALL_BEANS.map((bean) => ({ value: bean, label: bean }))}
           placeholder="選択してください"
           required
+          isChristmasMode={isChristmasMode}
         />
       </div>
 
       {/* 重さ */}
       <div>
-        <label className="block text-sm sm:text-base font-medium text-gray-700 mb-1 sm:mb-2">
+        <label className={`block text-sm sm:text-base font-medium mb-1 sm:mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
           重さ <span className="text-red-500">*</span>
         </label>
         <Select
@@ -177,12 +180,13 @@ function RoastRecordFormInner({
           options={WEIGHTS.map((w) => ({ value: w.toString(), label: `${w}g` }))}
           placeholder="選択してください"
           required
+          isChristmasMode={isChristmasMode}
         />
       </div>
 
       {/* 焙煎度合い */}
       <div>
-        <label className="block text-sm sm:text-base font-medium text-gray-700 mb-1 sm:mb-2">
+        <label className={`block text-sm sm:text-base font-medium mb-1 sm:mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
           焙煎度合い <span className="text-red-500">*</span>
         </label>
         <Select
@@ -195,12 +199,13 @@ function RoastRecordFormInner({
           options={ROAST_LEVELS.map((level) => ({ value: level, label: level }))}
           placeholder="選択してください"
           required
+          isChristmasMode={isChristmasMode}
         />
       </div>
 
       {/* 実際のロースト時間 */}
       <div>
-        <label className="block text-sm sm:text-base font-medium text-gray-700 mb-1 sm:mb-2">
+        <label className={`block text-sm sm:text-base font-medium mb-1 sm:mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
           実際のロースト時間 <span className="text-red-500">*</span>
         </label>
         <div className="flex gap-3 sm:gap-4">
@@ -212,6 +217,7 @@ function RoastRecordFormInner({
               onChange={(e) => handleDurationMinutesChange(e.target.value)}
               placeholder="分"
               required
+              isChristmasMode={isChristmasMode}
             />
           </div>
           <div className="flex-1">
@@ -222,11 +228,12 @@ function RoastRecordFormInner({
               onChange={(e) => handleDurationSecondsChange(e.target.value)}
               placeholder="秒"
               maxLength={2}
+              isChristmasMode={isChristmasMode}
             />
           </div>
         </div>
         {durationMinutes && (
-          <p className="mt-1 text-xs sm:text-sm text-gray-500">
+          <p className={`mt-1 text-xs sm:text-sm ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500'}`}>
             合計: {formatTime((parseInt(durationMinutes, 10) || 0) * 60 + (parseInt(durationSeconds, 10) || 0))}
           </p>
         )}
@@ -234,7 +241,7 @@ function RoastRecordFormInner({
 
       {/* 焙煎日 */}
       <div>
-        <label className="block text-sm sm:text-base font-medium text-gray-700 mb-1 sm:mb-2">
+        <label className={`block text-sm sm:text-base font-medium mb-1 sm:mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
           焙煎日 <span className="text-red-500">*</span>
         </label>
         <Input
@@ -242,6 +249,7 @@ function RoastRecordFormInner({
           value={roastDate}
           onChange={(e) => setRoastDate(e.target.value)}
           required
+          isChristmasMode={isChristmasMode}
         />
       </div>
 
@@ -257,6 +265,7 @@ function RoastRecordFormInner({
               }
             }}
             className="w-full sm:w-auto"
+            isChristmasMode={isChristmasMode}
           >
             削除
           </Button>
@@ -267,6 +276,7 @@ function RoastRecordFormInner({
               type="button"
               variant="secondary"
               onClick={onCancel}
+              isChristmasMode={isChristmasMode}
             >
               キャンセル
             </Button>
@@ -275,6 +285,7 @@ function RoastRecordFormInner({
             type="submit"
             variant="primary"
             className="flex-1"
+            isChristmasMode={isChristmasMode}
           >
             {isEditMode ? '更新' : '保存'}
           </Button>

--- a/components/RoastTimer.tsx
+++ b/components/RoastTimer.tsx
@@ -137,6 +137,7 @@ export function RoastTimer({ isChristmasMode }: RoastTimerProps) {
             isRunning={isRunning}
             isPaused={isPaused}
             isCompleted={isCompleted}
+            isChristmasMode={isChristmasMode}
           />
 
           <TimerControls

--- a/components/RoastTimer.tsx
+++ b/components/RoastTimer.tsx
@@ -8,10 +8,15 @@ import { useRoastTimerDialogs } from '@/hooks/useRoastTimerDialogs';
 import { CompletionDialog, ContinuousRoastDialog, AfterPurgeDialog } from './RoastTimerDialogs';
 import { RoastTimerSettings } from './RoastTimerSettings';
 import { TimerDisplay, TimerControls, TimerHeader, SetupPanel } from './roast-timer';
+import { Modal } from '@/components/ui';
 import type { BeanName } from '@/lib/beanConfig';
 import type { RoastLevel, Weight } from '@/lib/constants';
 
-export function RoastTimer() {
+interface RoastTimerProps {
+  isChristmasMode: boolean;
+}
+
+export function RoastTimer({ isChristmasMode }: RoastTimerProps) {
   const { data, updateData, isLoading } = useAppData();
   const router = useRouter();
   const {
@@ -101,17 +106,20 @@ export function RoastTimer() {
         isOpen={showCompletionDialog}
         onClose={handleCompletionClose}
         onContinue={handleCompletionOk}
+        isChristmasMode={isChristmasMode}
       />
       <ContinuousRoastDialog
         isOpen={showContinuousRoastDialog}
         onClose={handleContinuousRoastClose}
         onYes={handleContinuousRoastYes}
         onNo={handleContinuousRoastNo}
+        isChristmasMode={isChristmasMode}
       />
       <AfterPurgeDialog
         isOpen={showAfterPurgeDialog}
         onClose={handleAfterPurgeClose}
         onRecord={handleAfterPurgeRecord}
+        isChristmasMode={isChristmasMode}
       />
 
       {/* タイマー表示（実行中・一時停止中・完了時のみ表示） */}
@@ -121,6 +129,7 @@ export function RoastTimer() {
             onBack={() => router.push('/')}
             onSettingsClick={() => setShowSettings(true)}
             isOverlay
+            isChristmasMode={isChristmasMode}
           />
 
           <TimerDisplay
@@ -138,6 +147,7 @@ export function RoastTimer() {
             onResume={handleResume}
             onSkip={handleSkip}
             onReset={handleReset}
+            isChristmasMode={isChristmasMode}
           />
         </div>
       )}
@@ -148,19 +158,16 @@ export function RoastTimer() {
           <TimerHeader
             onBack={() => router.back()}
             onSettingsClick={() => setShowSettings(true)}
+            isChristmasMode={isChristmasMode}
           />
-          <SetupPanel onStart={handleStart} isLoading={isLoading} />
+          <SetupPanel onStart={handleStart} isLoading={isLoading} isChristmasMode={isChristmasMode} />
         </div>
       )}
 
       {/* 設定モーダル */}
-      {showSettings && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4 overflow-y-auto">
-          <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full p-4 sm:p-6 my-4">
-            <RoastTimerSettings onClose={() => setShowSettings(false)} />
-          </div>
-        </div>
-      )}
+      <Modal show={showSettings} onClose={() => setShowSettings(false)}>
+        <RoastTimerSettings onClose={() => setShowSettings(false)} isChristmasMode={isChristmasMode} />
+      </Modal>
     </div>
   );
 }

--- a/components/RoastTimerDialogs.tsx
+++ b/components/RoastTimerDialogs.tsx
@@ -1,15 +1,16 @@
 'use client';
 
 import { useEffect } from 'react';
-import { Button } from '@/components/ui';
+import { Button, Modal } from '@/components/ui';
 
 interface CompletionDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onContinue: () => void;
+  isChristmasMode: boolean;
 }
 
-export function CompletionDialog({ isOpen, onClose, onContinue }: CompletionDialogProps) {
+export function CompletionDialog({ isOpen, onClose, onContinue, isChristmasMode }: CompletionDialogProps) {
   useEffect(() => {
     if (isOpen) {
       // ダイアログが開いた時にフォーカスを管理
@@ -28,21 +29,19 @@ export function CompletionDialog({ isOpen, onClose, onContinue }: CompletionDial
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="bg-white rounded-lg shadow-xl p-6 sm:p-8 max-w-md w-full mx-4">
-        <h2 className="text-xl sm:text-2xl font-bold text-gray-800 mb-4">
-          もうすぐ焙煎が完了します。
-        </h2>
-        <p className="text-base sm:text-lg text-gray-600 mb-6">
-          タッパーと木べらを持って焙煎室に行きましょう。
-        </p>
-        <div className="flex gap-3 sm:gap-4 justify-end">
-          <Button variant="primary" size="md" onClick={onContinue}>
-            OK
-          </Button>
-        </div>
+    <Modal show={isOpen} onClose={onClose} contentClassName={`rounded-lg shadow-xl p-6 sm:p-8 max-w-md w-full mx-4 ${isChristmasMode ? 'bg-[#0a2818]' : 'bg-white'}`}>
+      <h2 className={`text-xl sm:text-2xl font-bold mb-4 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
+        もうすぐ焙煎が完了します。
+      </h2>
+      <p className={`text-base sm:text-lg mb-6 ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>
+        タッパーと木べらを持って焙煎室に行きましょう。
+      </p>
+      <div className="flex gap-3 sm:gap-4 justify-end">
+        <Button variant="primary" size="md" onClick={onContinue} isChristmasMode={isChristmasMode}>
+          OK
+        </Button>
       </div>
-    </div>
+    </Modal>
   );
 }
 
@@ -51,6 +50,7 @@ interface ContinuousRoastDialogProps {
   onClose: () => void;
   onYes: () => void;
   onNo: () => void;
+  isChristmasMode: boolean;
 }
 
 export function ContinuousRoastDialog({
@@ -58,6 +58,7 @@ export function ContinuousRoastDialog({
   onClose,
   onYes,
   onNo,
+  isChristmasMode,
 }: ContinuousRoastDialogProps) {
   useEffect(() => {
     if (isOpen) {
@@ -74,34 +75,34 @@ export function ContinuousRoastDialog({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="bg-white rounded-lg shadow-xl p-6 sm:p-8 max-w-lg w-full mx-4">
-        <h2 className="text-xl sm:text-2xl font-bold text-gray-800 mb-4 whitespace-nowrap">
-          続けて焙煎しますか？
-        </h2>
-        <p className="text-base sm:text-lg text-gray-600 mb-6 whitespace-nowrap">
-          焙煎機が温かいうちに次の焙煎が可能です。
-        </p>
-        <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center">
-          <Button
-            variant="primary"
-            size="md"
-            onClick={onYes}
-            className="flex-1 sm:flex-none order-1 sm:order-2 whitespace-nowrap"
-          >
-            続けて焙煎する
-          </Button>
-          <Button
-            variant="secondary"
-            size="md"
-            onClick={onNo}
-            className="flex-1 sm:flex-none order-2 sm:order-1 whitespace-nowrap !bg-[#00b8d4] hover:!bg-[#00a0b8]"
-          >
-            アフターパージ
-          </Button>
-        </div>
+    <Modal show={isOpen} onClose={onClose} contentClassName={`rounded-lg shadow-xl p-6 sm:p-8 max-w-lg w-full mx-4 ${isChristmasMode ? 'bg-[#0a2818]' : 'bg-white'}`}>
+      <h2 className={`text-xl sm:text-2xl font-bold mb-4 whitespace-nowrap ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
+        続けて焙煎しますか？
+      </h2>
+      <p className={`text-base sm:text-lg mb-6 whitespace-nowrap ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>
+        焙煎機が温かいうちに次の焙煎が可能です。
+      </p>
+      <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center">
+        <Button
+          variant="primary"
+          size="md"
+          onClick={onYes}
+          className="flex-1 sm:flex-none order-1 sm:order-2 whitespace-nowrap"
+          isChristmasMode={isChristmasMode}
+        >
+          続けて焙煎する
+        </Button>
+        <Button
+          variant="secondary"
+          size="md"
+          onClick={onNo}
+          className="flex-1 sm:flex-none order-2 sm:order-1 whitespace-nowrap !bg-[#00b8d4] hover:!bg-[#00a0b8]"
+          isChristmasMode={isChristmasMode}
+        >
+          アフターパージ
+        </Button>
       </div>
-    </div>
+    </Modal>
   );
 }
 
@@ -109,9 +110,10 @@ interface AfterPurgeDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onRecord: () => void;
+  isChristmasMode: boolean;
 }
 
-export function AfterPurgeDialog({ isOpen, onClose, onRecord }: AfterPurgeDialogProps) {
+export function AfterPurgeDialog({ isOpen, onClose, onRecord, isChristmasMode }: AfterPurgeDialogProps) {
   useEffect(() => {
     if (isOpen) {
       const handleEscape = (e: KeyboardEvent) => {
@@ -127,24 +129,22 @@ export function AfterPurgeDialog({ isOpen, onClose, onRecord }: AfterPurgeDialog
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="bg-white rounded-lg shadow-xl p-6 sm:p-8 max-w-md w-full mx-4">
-        <h2 className="text-xl sm:text-2xl font-bold text-gray-800 mb-4">
-          お疲れ様でした！
-        </h2>
-        <p className="text-base sm:text-lg text-gray-600 mb-6 whitespace-pre-line">
-          機械をアフターパージに設定してください。{'\n'}焙煎時間の記録ができます。
-        </p>
-        <div className="flex gap-3 sm:gap-4 justify-end">
-          <Button variant="secondary" size="md" onClick={onClose}>
-            閉じる
-          </Button>
-          <Button variant="primary" size="md" onClick={onRecord}>
-            記録に進む
-          </Button>
-        </div>
+    <Modal show={isOpen} onClose={onClose} contentClassName={`rounded-lg shadow-xl p-6 sm:p-8 max-w-md w-full mx-4 ${isChristmasMode ? 'bg-[#0a2818]' : 'bg-white'}`}>
+      <h2 className={`text-xl sm:text-2xl font-bold mb-4 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>
+        お疲れ様でした！
+      </h2>
+      <p className={`text-base sm:text-lg mb-6 whitespace-pre-line ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>
+        機械をアフターパージに設定してください。{'\n'}焙煎時間の記録ができます。
+      </p>
+      <div className="flex gap-3 sm:gap-4 justify-end">
+        <Button variant="secondary" size="md" onClick={onClose} isChristmasMode={isChristmasMode}>
+          閉じる
+        </Button>
+        <Button variant="primary" size="md" onClick={onRecord} isChristmasMode={isChristmasMode}>
+          記録に進む
+        </Button>
       </div>
-    </div>
+    </Modal>
   );
 }
 

--- a/components/RoastTimerSettings.tsx
+++ b/components/RoastTimerSettings.tsx
@@ -11,12 +11,15 @@ import { playTimerSound, stopTimerSound } from '@/lib/sounds';
 import { roastTimerSoundFiles } from '@/lib/soundFiles';
 import type { RoastTimerSettings } from '@/types';
 import { useToastContext } from '@/components/Toast';
+import { NumberInput, Checkbox, Select, Button } from '@/components/ui';
+import type { SelectOption } from '@/components/ui';
 
 interface RoastTimerSettingsProps {
   onClose: () => void;
+  isChristmasMode: boolean;
 }
 
-export function RoastTimerSettings({ onClose }: RoastTimerSettingsProps) {
+export function RoastTimerSettings({ onClose, isChristmasMode }: RoastTimerSettingsProps) {
   const { showToast } = useToastContext();
   const [settings, setSettings] = useState<RoastTimerSettings | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -150,18 +153,15 @@ export function RoastTimerSettings({ onClose }: RoastTimerSettingsProps) {
   }
 
   return (
-    <div className="bg-white rounded-lg shadow-md p-4 sm:p-6">
-      <h2 className="text-xl sm:text-2xl font-bold text-gray-800 mb-6">タイマー設定</h2>
+    <div className={`rounded-lg shadow-md p-4 sm:p-6 ${isChristmasMode ? 'bg-[#0a2818]' : 'bg-white'}`}>
+      <h2 className={`text-xl sm:text-2xl font-bold mb-6 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>タイマー設定</h2>
 
       <div className="space-y-6">
         {/* 焙煎室に行くまでの時間 */}
         <div>
-          <label className="block text-sm sm:text-base font-medium text-gray-700 mb-2">
-            焙煎室に行くまでの時間（秒）
-          </label>
-          <input
-            type="number"
-            min="1"
+          <NumberInput
+            label="焙煎室に行くまでの時間（秒）"
+            min={1}
             value={settings.goToRoastRoomTimeSeconds}
             onChange={(e) =>
               setSettings({
@@ -169,76 +169,65 @@ export function RoastTimerSettings({ onClose }: RoastTimerSettingsProps) {
                 goToRoastRoomTimeSeconds: parseInt(e.target.value, 10) || 60,
               })
             }
-            className="w-full rounded-md border border-gray-300 px-3 sm:px-4 py-2 sm:py-2.5 text-base sm:text-lg text-gray-900 bg-white focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500 min-h-[44px]"
+            isChristmasMode={isChristmasMode}
           />
-          <p className="mt-1 text-xs sm:text-sm text-gray-500">
+          <p className={`mt-1 text-xs sm:text-sm ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'}`}>
             おすすめ焙煎タイマーで使用される時間です。平均焙煎時間からこの秒数を引いた値がおすすめタイマー時間として提案されます。
           </p>
         </div>
 
         {/* タイマー音の設定 */}
-        <div className="border-t pt-6">
-          <h3 className="text-lg font-semibold text-gray-800 mb-4">タイマー音</h3>
+        <div className={`border-t pt-6 ${isChristmasMode ? 'border-[#f8f1e7]/20' : ''}`}>
+          <h3 className={`text-lg font-semibold mb-4 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-800'}`}>タイマー音</h3>
 
           <div className="space-y-4">
             <div className="flex items-center justify-between">
-              <label className="flex items-center gap-2">
-                <input
-                  type="checkbox"
-                  checked={settings.timerSoundEnabled}
-                  onChange={(e) =>
-                    setSettings({
-                      ...settings,
-                      timerSoundEnabled: e.target.checked,
-                    })
-                  }
-                  className="w-5 h-5 text-amber-600 rounded focus:ring-amber-500"
-                />
-                <span className="text-sm sm:text-base text-gray-700">タイマー音を有効にする</span>
-              </label>
+              <Checkbox
+                label="タイマー音を有効にする"
+                checked={settings.timerSoundEnabled}
+                onChange={(e) =>
+                  setSettings({
+                    ...settings,
+                    timerSoundEnabled: e.target.checked,
+                  })
+                }
+                isChristmasMode={isChristmasMode}
+              />
               {settings.timerSoundEnabled && (
-                <button
-                  type="button"
+                <Button
+                  variant="primary"
+                  size="sm"
                   onClick={handleTestSound}
                   disabled={isTestingSound}
-                  className="px-4 py-2 bg-amber-500 text-white rounded-lg font-medium hover:bg-amber-600 transition-colors text-sm sm:text-base min-h-[44px] disabled:bg-gray-300 disabled:cursor-not-allowed"
+                  isChristmasMode={isChristmasMode}
                 >
                   {isTestingSound ? '再生中...' : 'テスト'}
-                </button>
+                </Button>
               )}
             </div>
 
             {settings.timerSoundEnabled && testResult && (
-              <p className="text-xs sm:text-sm text-gray-600">{testResult}</p>
+              <p className={`text-xs sm:text-sm ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>{testResult}</p>
             )}
 
             {settings.timerSoundEnabled && (
-              <div>
-                <label className="block text-sm sm:text-base font-medium text-gray-700 mb-2">
-                  音源
-                </label>
-                <select
-                  value={settings.timerSoundFile}
-                  onChange={(e) =>
-                    setSettings({
-                      ...settings,
-                      timerSoundFile: e.target.value,
-                    })
-                  }
-                  className="w-full rounded-md border border-gray-300 px-3 sm:px-4 py-2 sm:py-2.5 text-base sm:text-lg text-gray-900 bg-white focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500 min-h-[44px]"
-                >
-                  {roastTimerSoundFiles.map((f) => (
-                    <option key={f.value} value={f.value}>
-                      {f.label}
-                    </option>
-                  ))}
-                </select>
-              </div>
+              <Select
+                label="音源"
+                value={settings.timerSoundFile}
+                onChange={(e) =>
+                  setSettings({
+                    ...settings,
+                    timerSoundFile: e.target.value,
+                  })
+                }
+                options={roastTimerSoundFiles as SelectOption[]}
+                isChristmasMode={isChristmasMode}
+              />
             )}
 
             {settings.timerSoundEnabled && (
               <div className="pt-2">
-                <label className="block text-sm sm:text-base font-medium text-gray-700 mb-2">
+                <label className={`block text-sm sm:text-base font-medium mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
                   音量: {Math.round(settings.timerSoundVolume * 100)}%
                 </label>
                 <input
@@ -253,7 +242,7 @@ export function RoastTimerSettings({ onClose }: RoastTimerSettingsProps) {
                       timerSoundVolume: parseFloat(e.target.value),
                     })
                   }
-                  className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+                  className={`w-full h-2 rounded-lg appearance-none cursor-pointer ${isChristmasMode ? 'bg-[#f8f1e7]/20' : 'bg-gray-200'}`}
                 />
               </div>
             )}
@@ -261,20 +250,24 @@ export function RoastTimerSettings({ onClose }: RoastTimerSettingsProps) {
         </div>
       </div>
 
-      <div className="flex gap-3 sm:gap-4 justify-end mt-6 pt-6 border-t">
-        <button
+      <div className={`flex gap-3 sm:gap-4 justify-end mt-6 pt-6 border-t ${isChristmasMode ? 'border-[#f8f1e7]/20' : ''}`}>
+        <Button
+          variant="secondary"
+          size="md"
           onClick={onClose}
-          className="px-6 py-3 bg-gray-600 text-white rounded-lg font-semibold hover:bg-gray-700 transition-colors text-base sm:text-lg min-h-[44px]"
+          isChristmasMode={isChristmasMode}
         >
           キャンセル
-        </button>
-        <button
+        </Button>
+        <Button
+          variant="primary"
+          size="md"
           onClick={handleSave}
           disabled={isSaving}
-          className="px-6 py-3 bg-amber-600 text-white rounded-lg font-semibold hover:bg-amber-700 transition-colors text-base sm:text-lg min-h-[44px] disabled:bg-gray-300 disabled:cursor-not-allowed"
+          isChristmasMode={isChristmasMode}
         >
           {isSaving ? '保存中...' : '保存'}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/components/roast-record-list/RoastRecordCard.tsx
+++ b/components/roast-record-list/RoastRecordCard.tsx
@@ -11,6 +11,7 @@ interface RoastRecordCardProps {
   record: RoastTimerRecord;
   onDelete: (id: string, e: React.MouseEvent) => void;
   onClick: (id: string) => void;
+  isChristmasMode?: boolean;
 }
 
 const formatDate = (dateStr: string) => {
@@ -36,17 +37,18 @@ const getRoastLevelColor = (
   }
 };
 
-export function RoastRecordCard({ record, onDelete, onClick }: RoastRecordCardProps) {
+export function RoastRecordCard({ record, onDelete, onClick, isChristmasMode = false }: RoastRecordCardProps) {
   return (
     <Card
       variant="hoverable"
       className="p-3 md:p-4 relative h-auto"
       onClick={() => onClick(record.id)}
+      isChristmasMode={isChristmasMode}
     >
       {/* 削除ボタン（右上） */}
       <button
         onClick={(e) => onDelete(record.id, e)}
-        className="absolute top-2 right-2 p-1.5 text-red-600 hover:bg-red-50 rounded-lg transition-colors min-h-[32px] min-w-[32px] flex items-center justify-center z-10"
+        className={`absolute top-2 right-2 p-1.5 text-red-600 rounded-lg transition-colors min-h-[32px] min-w-[32px] flex items-center justify-center z-10 ${isChristmasMode ? 'hover:bg-red-900/30' : 'hover:bg-red-50'}`}
         aria-label="削除"
       >
         <HiTrash className="h-4 w-4" />
@@ -55,10 +57,10 @@ export function RoastRecordCard({ record, onDelete, onClick }: RoastRecordCardPr
       {/* 豆名と焙煎度合い */}
       <div className="flex items-center gap-2 mb-3 pr-8">
         <div className="flex-shrink-0">
-          <PiCoffeeBeanFill className="h-4 w-4 md:h-5 md:w-5 text-amber-700" />
+          <PiCoffeeBeanFill className={`h-4 w-4 md:h-5 md:w-5 ${isChristmasMode ? 'text-[#d4af37]' : 'text-amber-700'}`} />
         </div>
         <div className="flex-1 min-w-0 flex items-center gap-2 flex-wrap">
-          <h3 className="text-base md:text-lg font-bold text-gray-900 truncate">
+          <h3 className={`text-base md:text-lg font-bold truncate ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-900'}`}>
             {record.beanName}
           </h3>
           <span
@@ -73,35 +75,35 @@ export function RoastRecordCard({ record, onDelete, onClick }: RoastRecordCardPr
       {/* 詳細情報 */}
       <div className="space-y-2">
         {/* 焙煎時間 */}
-        <div className="flex items-center gap-2 text-gray-700">
-          <MdTimer className="h-4 w-4 text-gray-400 flex-shrink-0" />
+        <div className="flex items-center gap-2">
+          <MdTimer className={`h-4 w-4 flex-shrink-0 ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-400'}`} />
           <div className="flex items-center gap-2">
-            <span className="text-xs text-gray-500">焙煎時間</span>
-            <span className="text-sm md:text-base font-medium text-gray-900 font-mono">
+            <span className={`text-xs ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500'}`}>焙煎時間</span>
+            <span className={`text-sm md:text-base font-medium font-mono ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-900'}`}>
               {formatTime(record.duration)}
             </span>
           </div>
         </div>
 
         {/* 重さ */}
-        <div className="flex items-center gap-2 text-gray-700">
+        <div className="flex items-center gap-2">
           <div className="h-4 w-4 flex items-center justify-center flex-shrink-0">
-            <span className="text-gray-400 text-base">⚖</span>
+            <span className={`text-base ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-400'}`}>⚖</span>
           </div>
           <div className="flex items-center gap-2">
-            <span className="text-xs text-gray-500">重さ</span>
-            <span className="text-sm md:text-base font-medium text-gray-900 font-mono">
+            <span className={`text-xs ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500'}`}>重さ</span>
+            <span className={`text-sm md:text-base font-medium font-mono ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-900'}`}>
               {record.weight}g
             </span>
           </div>
         </div>
 
         {/* 焙煎日 */}
-        <div className="flex items-center gap-2 text-gray-700">
-          <HiCalendar className="h-4 w-4 text-gray-400 flex-shrink-0" />
+        <div className="flex items-center gap-2">
+          <HiCalendar className={`h-4 w-4 flex-shrink-0 ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-400'}`} />
           <div className="flex items-center gap-2">
-            <span className="text-xs text-gray-500">焙煎日</span>
-            <span className="text-sm md:text-base font-medium text-gray-900 font-mono">
+            <span className={`text-xs ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500'}`}>焙煎日</span>
+            <span className={`text-sm md:text-base font-medium font-mono ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-900'}`}>
               {formatDate(record.roastDate)}
             </span>
           </div>

--- a/components/roast-record-list/RoastRecordFilters.tsx
+++ b/components/roast-record-list/RoastRecordFilters.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ROAST_LEVELS } from '@/lib/constants';
+import { Input, Select, Button, Card, Checkbox } from '@/components/ui';
 
 const WEIGHTS: Array<200 | 300 | 500> = [200, 300, 500];
 
@@ -22,6 +23,7 @@ interface RoastRecordFiltersProps {
   onRoastLevelToggle: (level: '浅煎り' | '中煎り' | '中深煎り' | '深煎り') => void;
   onWeightToggle: (weight: 200 | 300 | 500) => void;
   onResetFilters: () => void;
+  isChristmasMode?: boolean;
 }
 
 export function RoastRecordFilters({
@@ -40,111 +42,106 @@ export function RoastRecordFilters({
   onRoastLevelToggle,
   onWeightToggle,
   onResetFilters,
+  isChristmasMode = false,
 }: RoastRecordFiltersProps) {
   return (
-    <div className="bg-white rounded-lg shadow-md p-4 space-y-4 flex-shrink-0">
+    <Card isChristmasMode={isChristmasMode} className="p-4 space-y-4 flex-shrink-0">
       {/* 検索バーとソート */}
       <div className="flex flex-col sm:flex-row gap-3">
         <div className="flex-1">
-          <input
+          <Input
             type="text"
             value={searchQuery}
             onChange={(e) => onSearchChange(e.target.value)}
             placeholder="豆の名前で検索"
-            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-600 text-gray-900"
+            isChristmasMode={isChristmasMode}
           />
         </div>
         <div className="sm:w-48">
-          <select
+          <Select
             value={sortOption}
             onChange={(e) => onSortChange(e.target.value as SortOption)}
-            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-600 text-gray-900"
-          >
-            <option value="newest">新しい順</option>
-            <option value="oldest">古い順</option>
-            <option value="beanName">豆の名前順</option>
-            <option value="date">焙煎日順</option>
-          </select>
+            options={[
+              { value: 'newest', label: '新しい順' },
+              { value: 'oldest', label: '古い順' },
+              { value: 'beanName', label: '豆の名前順' },
+              { value: 'date', label: '焙煎日順' },
+            ]}
+            isChristmasMode={isChristmasMode}
+          />
         </div>
-        <button
+        <Button
+          variant="secondary"
+          size="md"
           onClick={onShowFiltersToggle}
-          className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors whitespace-nowrap min-h-[44px]"
+          className="whitespace-nowrap"
+          isChristmasMode={isChristmasMode}
         >
           {showFilters ? 'フィルタを閉じる' : 'フィルタ'}
-        </button>
+        </Button>
       </div>
 
       {/* フィルタパネル */}
       {showFilters && (
-        <div className="border-t border-gray-200 pt-4 space-y-4">
+        <div className={`pt-4 space-y-4 ${isChristmasMode ? 'border-t border-[#f8f1e7]/20' : 'border-t border-gray-200'}`}>
           {/* 日付範囲 */}
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className={`block text-sm font-medium mb-1 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
                 開始日
               </label>
-              <input
+              <Input
                 type="date"
                 value={dateFrom}
                 onChange={(e) => onDateFromChange(e.target.value)}
-                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-600 text-gray-900 min-h-[44px]"
+                isChristmasMode={isChristmasMode}
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className={`block text-sm font-medium mb-1 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
                 終了日
               </label>
-              <input
+              <Input
                 type="date"
                 value={dateTo}
                 onChange={(e) => onDateToChange(e.target.value)}
-                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-600 text-gray-900 min-h-[44px]"
+                isChristmasMode={isChristmasMode}
               />
             </div>
           </div>
 
           {/* 焙煎度合い */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
+            <label className={`block text-sm font-medium mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
               焙煎度合い
             </label>
             <div className="flex flex-wrap gap-3">
               {ROAST_LEVELS.map((level) => (
-                <label
+                <Checkbox
                   key={level}
-                  className="flex items-center gap-2 cursor-pointer"
-                >
-                  <input
-                    type="checkbox"
-                    checked={selectedRoastLevels.includes(level)}
-                    onChange={() => onRoastLevelToggle(level)}
-                    className="w-4 h-4 text-amber-600 border-gray-300 rounded focus:ring-amber-600"
-                  />
-                  <span className="text-sm text-gray-700">{level}</span>
-                </label>
+                  checked={selectedRoastLevels.includes(level)}
+                  onChange={() => onRoastLevelToggle(level)}
+                  label={level}
+                  isChristmasMode={isChristmasMode}
+                />
               ))}
             </div>
           </div>
 
           {/* 重さ */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
+            <label className={`block text-sm font-medium mb-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
               重さ
             </label>
             <div className="flex flex-wrap gap-3">
               {WEIGHTS.map((weight) => (
-                <label
+                <Checkbox
                   key={weight}
-                  className="flex items-center gap-2 cursor-pointer"
-                >
-                  <input
-                    type="checkbox"
-                    checked={selectedWeights.includes(weight)}
-                    onChange={() => onWeightToggle(weight)}
-                    className="w-4 h-4 text-amber-600 border-gray-300 rounded focus:ring-amber-600"
-                  />
-                  <span className="text-sm text-gray-700">{weight}g</span>
-                </label>
+                  checked={selectedWeights.includes(weight)}
+                  onChange={() => onWeightToggle(weight)}
+                  label={`${weight}g`}
+                  isChristmasMode={isChristmasMode}
+                />
               ))}
             </div>
           </div>
@@ -156,13 +153,13 @@ export function RoastRecordFilters({
             selectedWeights.length > 0) && (
             <button
               onClick={onResetFilters}
-              className="text-sm text-amber-600 hover:underline"
+              className={`text-sm hover:underline ${isChristmasMode ? 'text-[#d4af37]' : 'text-amber-600'}`}
             >
               フィルタをリセット
             </button>
           )}
         </div>
       )}
-    </div>
+    </Card>
   );
 }

--- a/components/roast-record-list/RoastRecordList.tsx
+++ b/components/roast-record-list/RoastRecordList.tsx
@@ -9,11 +9,12 @@ import { RoastRecordCard } from './RoastRecordCard';
 interface RoastRecordListProps {
   data: AppData;
   onUpdate: (data: AppData) => void;
+  isChristmasMode?: boolean;
 }
 
 type SortOption = 'newest' | 'oldest' | 'beanName' | 'date';
 
-export function RoastRecordList({ data, onUpdate }: RoastRecordListProps) {
+export function RoastRecordList({ data, onUpdate, isChristmasMode = false }: RoastRecordListProps) {
   const router = useRouter();
 
   const roastTimerRecords = useMemo(
@@ -164,8 +165,8 @@ export function RoastRecordList({ data, onUpdate }: RoastRecordListProps) {
   if (roastTimerRecords.length === 0) {
     return (
       <div className="text-center py-12">
-        <p className="text-gray-600">ロースト記録がありません</p>
-        <p className="text-sm text-gray-500 mt-2">
+        <p className={isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}>ロースト記録がありません</p>
+        <p className={`text-sm mt-2 ${isChristmasMode ? 'text-[#f8f1e7]/50' : 'text-gray-500'}`}>
           右上のボタンから新規記録を作成できます
         </p>
       </div>
@@ -191,12 +192,13 @@ export function RoastRecordList({ data, onUpdate }: RoastRecordListProps) {
         onRoastLevelToggle={handleRoastLevelToggle}
         onWeightToggle={handleWeightToggle}
         onResetFilters={handleResetFilters}
+        isChristmasMode={isChristmasMode}
       />
 
       {/* 結果数表示 */}
       {filteredAndSortedRecords.length === 0 ? (
-        <div className="text-center py-12 bg-white rounded-lg shadow-md flex-shrink-0">
-          <p className="text-gray-600">検索条件に一致する記録がありません</p>
+        <div className={`text-center py-12 rounded-lg shadow-md flex-shrink-0 ${isChristmasMode ? 'bg-[#0a2818]' : 'bg-white'}`}>
+          <p className={isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}>検索条件に一致する記録がありません</p>
         </div>
       ) : (
         <div className="flex-1 min-h-0 overflow-y-auto space-y-3 md:grid md:grid-cols-3 md:gap-4 md:space-y-0 md:items-start md:auto-rows-auto">
@@ -206,6 +208,7 @@ export function RoastRecordList({ data, onUpdate }: RoastRecordListProps) {
               record={record}
               onDelete={handleDelete}
               onClick={handleCardClick}
+              isChristmasMode={isChristmasMode}
             />
           ))}
         </div>

--- a/components/roast-timer/ModeSelectView.tsx
+++ b/components/roast-timer/ModeSelectView.tsx
@@ -2,6 +2,7 @@
 
 import { HiPlay } from 'react-icons/hi';
 import { MdTimer, MdLightbulb } from 'react-icons/md';
+import { Input, Button } from '@/components/ui';
 
 interface ModeSelectViewProps {
   durationMinutes: string;
@@ -11,6 +12,7 @@ interface ModeSelectViewProps {
   onManualStart: () => Promise<void>;
   onRecommendedMode: () => void;
   isStartDisabled: boolean;
+  isChristmasMode: boolean;
 }
 
 /**
@@ -26,6 +28,7 @@ export function ModeSelectView({
   onManualStart,
   onRecommendedMode,
   isStartDisabled,
+  isChristmasMode,
 }: ModeSelectViewProps) {
   return (
     <div className="flex-1 flex flex-col items-center justify-center px-4 sm:px-6 py-8">
@@ -34,40 +37,42 @@ export function ModeSelectView({
         <div className="inline-flex items-center justify-center w-20 h-20 sm:w-24 sm:h-24 rounded-full bg-gradient-to-br from-amber-400 to-amber-600 shadow-lg mb-3">
           <MdTimer className="text-white text-4xl sm:text-5xl" />
         </div>
-        <h3 className="text-3xl sm:text-4xl font-bold text-gray-900 tracking-tight">
+        <h3 className={`text-3xl sm:text-4xl font-bold tracking-tight ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-900'}`}>
           ローストタイマー
         </h3>
-        <p className="text-base sm:text-lg text-gray-500">焙煎時間を設定してスタート</p>
+        <p className={`text-base sm:text-lg ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500'}`}>焙煎時間を設定してスタート</p>
       </div>
 
       {/* 手動入力フィールド */}
       <div className="space-y-4 max-w-md mx-auto w-full mb-8 sm:mb-10">
-        <label className="block text-sm sm:text-base font-semibold text-gray-700 uppercase tracking-wide">
+        <label className={`block text-sm sm:text-base font-semibold uppercase tracking-wide ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
           時間設定
         </label>
         <div className="flex gap-3 sm:gap-4">
           <div className="flex-1">
-            <input
+            <Input
               type="text"
               inputMode="numeric"
               value={durationMinutes}
               onChange={(e) => onDurationMinutesChange(e.target.value)}
               placeholder="分"
-              className="w-full rounded-lg border-2 border-gray-200 px-4 py-3.5 sm:py-4 text-lg sm:text-xl text-gray-900 bg-white focus:border-amber-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-amber-100 transition-all duration-200 font-semibold text-center min-h-[56px] shadow-sm hover:border-gray-300"
+              className="text-center font-semibold text-lg sm:text-xl"
+              isChristmasMode={isChristmasMode}
             />
           </div>
           <div className="flex items-end pb-2">
-            <span className="text-3xl font-bold text-gray-400">:</span>
+            <span className={`text-3xl font-bold ${isChristmasMode ? 'text-[#f8f1e7]/40' : 'text-gray-400'}`}>:</span>
           </div>
           <div className="flex-1">
-            <input
+            <Input
               type="text"
               inputMode="numeric"
               value={durationSeconds}
               onChange={(e) => onDurationSecondsChange(e.target.value)}
               placeholder="秒"
               maxLength={2}
-              className="w-full rounded-lg border-2 border-gray-200 px-4 py-3.5 sm:py-4 text-lg sm:text-xl text-gray-900 bg-white focus:border-amber-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-amber-100 transition-all duration-200 font-semibold text-center min-h-[56px] shadow-sm hover:border-gray-300"
+              className="text-center font-semibold text-lg sm:text-xl"
+              isChristmasMode={isChristmasMode}
             />
           </div>
         </div>
@@ -76,23 +81,29 @@ export function ModeSelectView({
       {/* ボタンセクション */}
       <div className="space-y-3 sm:space-y-4 max-w-md mx-auto w-full">
         {/* 手動スタートボタン */}
-        <button
+        <Button
+          variant="primary"
+          size="lg"
           onClick={onManualStart}
           disabled={isStartDisabled}
-          className="w-full flex items-center justify-center gap-2 px-6 py-4 sm:py-5 bg-gradient-to-r from-amber-500 to-amber-600 text-white rounded-xl font-bold text-base sm:text-lg shadow-lg hover:shadow-xl hover:from-amber-600 hover:to-amber-700 active:scale-[0.98] transition-all duration-200 min-h-[60px] sm:min-h-[64px] disabled:from-gray-300 disabled:to-gray-400 disabled:cursor-not-allowed disabled:hover:shadow-lg disabled:active:scale-100 disabled:hover:from-gray-300 disabled:hover:to-gray-400"
+          className="w-full flex items-center justify-center gap-2"
+          isChristmasMode={isChristmasMode}
         >
           <HiPlay className="text-xl sm:text-2xl" />
           <span>手動でタイマースタート</span>
-        </button>
+        </Button>
 
         {/* おすすめ焙煎ボタン */}
-        <button
+        <Button
+          variant="secondary"
+          size="lg"
           onClick={onRecommendedMode}
-          className="w-full flex items-center justify-center gap-2 px-6 py-4 sm:py-5 bg-gradient-to-r from-amber-50 to-amber-100 text-amber-700 border-2 border-amber-200 rounded-xl font-bold text-base sm:text-lg shadow-sm hover:shadow-md hover:from-amber-100 hover:to-amber-200 hover:border-amber-300 active:scale-[0.98] transition-all duration-200 min-h-[60px] sm:min-h-[64px]"
+          className="w-full flex items-center justify-center gap-2"
+          isChristmasMode={isChristmasMode}
         >
-          <MdLightbulb className="text-xl sm:text-2xl text-amber-600" />
+          <MdLightbulb className="text-xl sm:text-2xl" />
           <span>おすすめタイマー</span>
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/components/roast-timer/RecommendedModeView.tsx
+++ b/components/roast-timer/RecommendedModeView.tsx
@@ -5,6 +5,8 @@ import { MdLightbulb } from 'react-icons/md';
 import { formatTimeAsMinutesAndSeconds } from '@/lib/roastTimerUtils';
 import { WEIGHTS, type RoastLevel, type Weight } from '@/lib/constants';
 import type { BeanName } from '@/lib/beanConfig';
+import { Select, Button, Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui';
+import type { SelectOption } from '@/components/ui';
 
 interface RecommendedModeViewProps {
   recommendedMode: 'weight' | 'history';
@@ -24,6 +26,7 @@ interface RecommendedModeViewProps {
   onRoastLevelChange: (value: RoastLevel | '') => void;
   onStart: () => Promise<void>;
   isStartDisabled: boolean;
+  isChristmasMode: boolean;
 }
 
 /**
@@ -46,12 +49,13 @@ export function RecommendedModeView({
   onRoastLevelChange,
   onStart,
   isStartDisabled,
+  isChristmasMode,
 }: RecommendedModeViewProps) {
   return (
     <div className="flex-1 flex flex-col px-4 sm:px-6">
       <div className="max-w-md mx-auto w-full flex-1 flex flex-col justify-center py-8">
         <div className="flex items-center justify-center mb-6 flex-shrink-0">
-          <h3 className="text-xl sm:text-2xl font-bold text-gray-900 flex items-center gap-2">
+          <h3 className={`text-xl sm:text-2xl font-bold flex items-center gap-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-900'}`}>
             <div className="w-8 h-8 rounded-full bg-gradient-to-br from-amber-400 to-amber-600 flex items-center justify-center">
               <MdLightbulb className="text-white text-lg" />
             </div>
@@ -59,61 +63,53 @@ export function RecommendedModeView({
           </h3>
         </div>
 
-        {/* モード切り替えタブ */}
-        <div className="mb-6 flex-shrink-0">
-          <div className="flex gap-2 bg-gray-100 rounded-lg p-1">
-            <button
-              onClick={() => onRecommendedModeChange('weight')}
-              className={`flex-1 px-4 py-2.5 rounded-md text-sm sm:text-base font-semibold transition-all duration-200 ${
-                recommendedMode === 'weight'
-                  ? 'bg-white text-amber-700 shadow-sm'
-                  : 'text-gray-600 hover:text-gray-900'
-              }`}
-            >
-              重さで設定
-            </button>
-            <button
-              onClick={() => onRecommendedModeChange('history')}
-              className={`flex-1 px-4 py-2.5 rounded-md text-sm sm:text-base font-semibold transition-all duration-200 ${
-                recommendedMode === 'history'
-                  ? 'bg-white text-amber-700 shadow-sm'
-                  : 'text-gray-600 hover:text-gray-900'
-              }`}
-            >
-              過去の記録から設定
-            </button>
-          </div>
-        </div>
-
         <div className="space-y-5 flex-1">
-          {recommendedMode === 'weight' && (
-            <WeightModeSection weight={weight} onWeightChange={onWeightChange} />
-          )}
+          {/* モード切り替えタブ */}
+          <Tabs
+            defaultValue={recommendedMode}
+            value={recommendedMode}
+            onValueChange={(v) => onRecommendedModeChange(v as 'weight' | 'history')}
+            isChristmasMode={isChristmasMode}
+            className="mb-6 flex-shrink-0"
+          >
+            <TabsList>
+              <TabsTrigger value="weight">重さで設定</TabsTrigger>
+              <TabsTrigger value="history">過去の記録から設定</TabsTrigger>
+            </TabsList>
 
-          {recommendedMode === 'history' && (
-            <HistoryModeSection
-              beanName={beanName}
-              weight={weight}
-              roastLevel={roastLevel}
-              availableBeans={availableBeans}
-              availableWeights={availableWeights}
-              availableRoastLevels={availableRoastLevels}
-              recommendedTimeInfo={recommendedTimeInfo}
-              onBeanNameChange={onBeanNameChange}
-              onWeightChange={onWeightChange}
-              onRoastLevelChange={onRoastLevelChange}
-            />
-          )}
+            <TabsContent value="weight">
+              <WeightModeSection weight={weight} onWeightChange={onWeightChange} isChristmasMode={isChristmasMode} />
+            </TabsContent>
+
+            <TabsContent value="history">
+              <HistoryModeSection
+                beanName={beanName}
+                weight={weight}
+                roastLevel={roastLevel}
+                availableBeans={availableBeans}
+                availableWeights={availableWeights}
+                availableRoastLevels={availableRoastLevels}
+                recommendedTimeInfo={recommendedTimeInfo}
+                onBeanNameChange={onBeanNameChange}
+                onWeightChange={onWeightChange}
+                onRoastLevelChange={onRoastLevelChange}
+                isChristmasMode={isChristmasMode}
+              />
+            </TabsContent>
+          </Tabs>
 
           <div className="pt-2 flex-shrink-0">
-            <button
+            <Button
+              variant="primary"
+              size="lg"
               onClick={onStart}
               disabled={isStartDisabled}
-              className="w-full flex items-center justify-center gap-3 px-6 py-4 bg-gradient-to-r from-amber-500 to-amber-600 text-white rounded-xl font-bold shadow-lg hover:shadow-xl hover:from-amber-600 hover:to-amber-700 active:scale-[0.98] transition-all duration-200 text-base sm:text-lg min-h-[56px] disabled:from-gray-300 disabled:to-gray-400 disabled:cursor-not-allowed disabled:hover:shadow-lg disabled:active:scale-100 disabled:hover:from-gray-300 disabled:hover:to-gray-400"
+              className="w-full flex items-center justify-center gap-3"
+              isChristmasMode={isChristmasMode}
             >
               <HiPlay className="text-2xl" />
               <span>スタート</span>
-            </button>
+            </Button>
           </div>
         </div>
       </div>
@@ -126,44 +122,38 @@ export function RecommendedModeView({
 function WeightModeSection({
   weight,
   onWeightChange,
+  isChristmasMode,
 }: {
   weight: Weight | '';
   onWeightChange: (value: Weight | '') => void;
+  isChristmasMode: boolean;
 }) {
+  const weightOptions: SelectOption[] = WEIGHTS.map((w) => ({ value: String(w), label: `${w}g` }));
   return (
-    <>
-      <div>
-        <label className="block text-sm font-semibold text-gray-700 uppercase tracking-wide mb-2">
-          重さ <span className="text-red-500">*</span>
-        </label>
-        <select
-          value={weight}
-          onChange={(e) =>
-            onWeightChange(e.target.value ? (parseInt(e.target.value, 10) as Weight) : '')
-          }
-          className="w-full rounded-xl border-2 border-gray-200 px-4 py-3.5 text-base sm:text-lg text-gray-900 bg-gray-50 focus:border-amber-500 focus:bg-white focus:outline-none focus:ring-4 focus:ring-amber-100 transition-all duration-200 shadow-sm hover:border-gray-300 min-h-[52px]"
-        >
-          <option value="">選択してください</option>
-          {WEIGHTS.map((w) => (
-            <option key={w} value={w}>
-              {w}g
-            </option>
-          ))}
-        </select>
-      </div>
+    <div className="space-y-5">
+      <Select
+        label="重さ"
+        value={String(weight)}
+        onChange={(e) =>
+          onWeightChange(e.target.value ? (parseInt(e.target.value, 10) as Weight) : '')
+        }
+        options={[{ value: '', label: '選択してください' }, ...weightOptions]}
+        required
+        isChristmasMode={isChristmasMode}
+      />
 
       {weight !== '' && (
-        <div className="bg-gradient-to-br from-amber-50 to-amber-100 border-2 border-amber-200 rounded-xl p-4 shadow-sm">
-          <p className="text-sm sm:text-base text-gray-700">
+        <div className={`rounded-xl p-4 shadow-sm border-2 ${isChristmasMode ? 'bg-[#0f3a1f]/50 border-[#d4af37]/30' : 'bg-gradient-to-br from-amber-50 to-amber-100 border-amber-200'}`}>
+          <p className={`text-sm sm:text-base ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
             重さに応じたおすすめ時間は{' '}
-            <span className="font-bold text-amber-800">
+            <span className={`font-bold ${isChristmasMode ? 'text-[#d4af37]' : 'text-amber-800'}`}>
               {weight === 200 ? '8分' : weight === 300 ? '9分' : '10分'}
             </span>{' '}
             です
           </p>
         </div>
       )}
-    </>
+    </div>
   );
 }
 
@@ -178,6 +168,7 @@ function HistoryModeSection({
   onBeanNameChange,
   onWeightChange,
   onRoastLevelChange,
+  isChristmasMode,
 }: {
   beanName: BeanName | '';
   weight: Weight | '';
@@ -189,98 +180,63 @@ function HistoryModeSection({
   onBeanNameChange: (value: BeanName | '') => void;
   onWeightChange: (value: Weight | '') => void;
   onRoastLevelChange: (value: RoastLevel | '') => void;
+  isChristmasMode: boolean;
 }) {
+  // オプションの生成
+  const beanOptions: SelectOption[] = availableBeans.map((bean) => ({ value: bean, label: bean }));
+  const roastLevelOptions: SelectOption[] = availableRoastLevels.map((level) => ({ value: level, label: level }));
+  const weightOptions: SelectOption[] = availableWeights.map((w) => ({ value: String(w), label: `${w}g` }));
   return (
-    <>
-      <div>
-        <label className="block text-sm font-semibold text-gray-700 uppercase tracking-wide mb-2">
-          豆の名前 <span className="text-red-500">*</span>
-        </label>
-        <select
-          value={beanName}
-          onChange={(e) => {
-            onBeanNameChange(e.target.value as BeanName);
-          }}
-          className="w-full rounded-xl border-2 border-gray-200 px-4 py-3.5 text-base sm:text-lg text-gray-900 bg-gray-50 focus:border-amber-500 focus:bg-white focus:outline-none focus:ring-4 focus:ring-amber-100 transition-all duration-200 shadow-sm hover:border-gray-300 min-h-[52px]"
-        >
-          <option value="">選択してください</option>
-          {availableBeans.length > 0 ? (
-            availableBeans.map((bean) => (
-              <option key={bean} value={bean}>
-                {bean}
-              </option>
-            ))
-          ) : (
-            <option value="" disabled>
-              記録がありません（2件以上の記録が必要です）
-            </option>
-          )}
-        </select>
-      </div>
+    <div className="space-y-5">
+      <Select
+        label="豆の名前"
+        value={beanName}
+        onChange={(e) => onBeanNameChange(e.target.value as BeanName)}
+        options={[
+          { value: '', label: availableBeans.length > 0 ? '選択してください' : '記録がありません（2件以上の記録が必要です）' },
+          ...beanOptions
+        ]}
+        required
+        isChristmasMode={isChristmasMode}
+      />
 
-      <div>
-        <label className="block text-sm font-semibold text-gray-700 uppercase tracking-wide mb-2">
-          焙煎度合い <span className="text-red-500">*</span>
-        </label>
-        <select
-          value={roastLevel}
-          onChange={(e) => onRoastLevelChange(e.target.value as RoastLevel | '')}
-          disabled={!beanName}
-          className="w-full rounded-xl border-2 border-gray-200 px-4 py-3.5 text-base sm:text-lg text-gray-900 bg-gray-50 focus:border-amber-500 focus:bg-white focus:outline-none focus:ring-4 focus:ring-amber-100 transition-all duration-200 shadow-sm hover:border-gray-300 min-h-[52px] disabled:bg-gray-100 disabled:cursor-not-allowed disabled:text-gray-400"
-        >
-          <option value="">選択してください</option>
-          {availableRoastLevels.length > 0 ? (
-            availableRoastLevels.map((level) => (
-              <option key={level} value={level}>
-                {level}
-              </option>
-            ))
-          ) : beanName ? (
-            <option value="" disabled>
-              記録がありません（2件以上の記録が必要です）
-            </option>
-          ) : (
-            <option value="" disabled>
-              豆を選択してください
-            </option>
-          )}
-        </select>
-      </div>
+      <Select
+        label="焙煎度合い"
+        value={roastLevel}
+        onChange={(e) => onRoastLevelChange(e.target.value as RoastLevel | '')}
+        disabled={!beanName}
+        options={[
+          {
+            value: '',
+            label: !beanName ? '豆を選択してください' : availableRoastLevels.length > 0 ? '選択してください' : '記録がありません（2件以上の記録が必要です）'
+          },
+          ...roastLevelOptions
+        ]}
+        required
+        isChristmasMode={isChristmasMode}
+      />
 
-      <div>
-        <label className="block text-sm font-semibold text-gray-700 uppercase tracking-wide mb-2">
-          重さ <span className="text-red-500">*</span>
-        </label>
-        <select
-          value={weight}
-          onChange={(e) =>
-            onWeightChange(e.target.value ? (parseInt(e.target.value, 10) as Weight) : '')
-          }
-          disabled={!beanName}
-          className="w-full rounded-xl border-2 border-gray-200 px-4 py-3.5 text-base sm:text-lg text-gray-900 bg-gray-50 focus:border-amber-500 focus:bg-white focus:outline-none focus:ring-4 focus:ring-amber-100 transition-all duration-200 shadow-sm hover:border-gray-300 min-h-[52px] disabled:bg-gray-100 disabled:cursor-not-allowed disabled:text-gray-400"
-        >
-          <option value="">選択してください</option>
-          {availableWeights.length > 0 ? (
-            availableWeights.map((w) => (
-              <option key={w} value={w}>
-                {w}g
-              </option>
-            ))
-          ) : beanName ? (
-            <option value="" disabled>
-              記録がありません（2件以上の記録が必要です）
-            </option>
-          ) : (
-            <option value="" disabled>
-              豆を選択してください
-            </option>
-          )}
-        </select>
-      </div>
+      <Select
+        label="重さ"
+        value={String(weight)}
+        onChange={(e) =>
+          onWeightChange(e.target.value ? (parseInt(e.target.value, 10) as Weight) : '')
+        }
+        disabled={!beanName}
+        options={[
+          {
+            value: '',
+            label: !beanName ? '豆を選択してください' : availableWeights.length > 0 ? '選択してください' : '記録がありません（2件以上の記録が必要です）'
+          },
+          ...weightOptions
+        ]}
+        required
+        isChristmasMode={isChristmasMode}
+      />
 
       {!recommendedTimeInfo && beanName && weight !== '' && roastLevel && (
-        <div className="bg-yellow-50 border-2 border-yellow-200 rounded-xl p-4 shadow-sm">
-          <p className="text-sm sm:text-base text-yellow-800">
+        <div className={`rounded-xl p-4 shadow-sm border-2 ${isChristmasMode ? 'bg-[#3d2a11]/50 border-[#d4af37]/30' : 'bg-yellow-50 border-yellow-200'}`}>
+          <p className={`text-sm sm:text-base ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-yellow-800'}`}>
             この組み合わせの記録が2件未満のため、平均焙煎時間を計算できません。重さに応じたデフォルト時間（
             {weight === 200 ? '8分' : weight === 300 ? '9分' : '10分'}）でタイマーを開始します。
           </p>
@@ -288,20 +244,20 @@ function HistoryModeSection({
       )}
 
       {recommendedTimeInfo && (
-        <div className="bg-gradient-to-br from-amber-50 to-amber-100 border-2 border-amber-200 rounded-xl p-4 shadow-sm">
-          <p className="text-sm sm:text-base text-gray-700">
+        <div className={`rounded-xl p-4 shadow-sm border-2 ${isChristmasMode ? 'bg-[#0f3a1f]/50 border-[#d4af37]/30' : 'bg-gradient-to-br from-amber-50 to-amber-100 border-amber-200'}`}>
+          <p className={`text-sm sm:text-base ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
             過去の記録から、平均焙煎時間は{' '}
-            <span className="font-bold text-amber-800">
+            <span className={`font-bold ${isChristmasMode ? 'text-[#d4af37]' : 'text-amber-800'}`}>
               {formatTimeAsMinutesAndSeconds(recommendedTimeInfo.averageDuration)}
             </span>
             、おすすめタイマー時間は{' '}
-            <span className="font-bold text-amber-800">
+            <span className={`font-bold ${isChristmasMode ? 'text-[#d4af37]' : 'text-amber-800'}`}>
               {formatTimeAsMinutesAndSeconds(recommendedTimeInfo.recommendedDuration)}
             </span>{' '}
             です
           </p>
         </div>
       )}
-    </>
+    </div>
   );
 }

--- a/components/roast-timer/SetupPanel.tsx
+++ b/components/roast-timer/SetupPanel.tsx
@@ -14,6 +14,7 @@ import { ROAST_LEVELS, WEIGHTS, DEFAULT_DURATIONS as DEFAULT_DURATION_BY_WEIGHT,
 import { convertToHalfWidth, removeNonNumeric } from '@/lib/utils';
 import { ModeSelectView } from './ModeSelectView';
 import { RecommendedModeView } from './RecommendedModeView';
+import { Input, Button } from '@/components/ui';
 
 interface SetupPanelProps {
   onStart: (
@@ -23,6 +24,7 @@ interface SetupPanelProps {
     roastLevel?: RoastLevel
   ) => Promise<void>;
   isLoading: boolean;
+  isChristmasMode: boolean;
 }
 
 /**
@@ -31,7 +33,7 @@ interface SetupPanelProps {
  * - 手動入力モード
  * - おすすめモード
  */
-export function SetupPanel({ onStart, isLoading }: SetupPanelProps) {
+export function SetupPanel({ onStart, isLoading, isChristmasMode }: SetupPanelProps) {
   const { user } = useAuth();
   const { data } = useAppData();
   const { showToast } = useToastContext();
@@ -350,6 +352,7 @@ export function SetupPanel({ onStart, isLoading }: SetupPanelProps) {
           !user ||
           isLoading
         }
+        isChristmasMode={isChristmasMode}
       />
     );
   }
@@ -359,7 +362,7 @@ export function SetupPanel({ onStart, isLoading }: SetupPanelProps) {
     return (
       <div className="flex-1 flex flex-col pt-16 px-4 sm:px-6">
         <div className="flex items-center justify-between mb-6 flex-shrink-0">
-          <h3 className="text-xl sm:text-2xl font-bold text-gray-900 flex items-center gap-2">
+          <h3 className={`text-xl sm:text-2xl font-bold flex items-center gap-2 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-900'}`}>
             <div className="w-8 h-8 rounded-full bg-gradient-to-br from-amber-400 to-amber-600 flex items-center justify-center">
               <MdTimer className="text-white text-lg" />
             </div>
@@ -369,39 +372,43 @@ export function SetupPanel({ onStart, isLoading }: SetupPanelProps) {
 
         <div className="space-y-6 flex-1">
           <div>
-            <label className="block text-sm font-semibold text-gray-700 uppercase tracking-wide mb-3">
+            <label className={`block text-sm font-semibold uppercase tracking-wide mb-3 ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-700'}`}>
               時間設定
             </label>
             <div className="flex gap-4">
               <div className="flex-1">
-                <input
+                <Input
                   type="text"
                   inputMode="numeric"
                   value={durationMinutes}
                   onChange={(e) => handleDurationMinutesChange(e.target.value)}
                   placeholder="分"
-                  className="w-full rounded-xl border-2 border-gray-200 px-4 py-3.5 text-lg sm:text-xl text-gray-900 bg-gray-50 focus:border-amber-500 focus:bg-white focus:outline-none focus:ring-4 focus:ring-amber-100 transition-all duration-200 font-semibold text-center min-h-[52px] shadow-sm hover:border-gray-300"
+                  className="text-center font-semibold text-lg sm:text-xl"
+                  isChristmasMode={isChristmasMode}
                 />
               </div>
               <div className="flex items-end pb-2">
-                <span className="text-2xl font-bold text-gray-400">:</span>
+                <span className={`text-2xl font-bold ${isChristmasMode ? 'text-[#f8f1e7]/40' : 'text-gray-400'}`}>:</span>
               </div>
               <div className="flex-1">
-                <input
+                <Input
                   type="text"
                   inputMode="numeric"
                   value={durationSeconds}
                   onChange={(e) => handleDurationSecondsChange(e.target.value)}
                   placeholder="秒"
                   maxLength={2}
-                  className="w-full rounded-xl border-2 border-gray-200 px-4 py-3.5 text-lg sm:text-xl text-gray-900 bg-gray-50 focus:border-amber-500 focus:bg-white focus:outline-none focus:ring-4 focus:ring-amber-100 transition-all duration-200 font-semibold text-center min-h-[52px] shadow-sm hover:border-gray-300"
+                  className="text-center font-semibold text-lg sm:text-xl"
+                  isChristmasMode={isChristmasMode}
                 />
               </div>
             </div>
           </div>
 
           <div className="pt-2 flex-shrink-0">
-            <button
+            <Button
+              variant="primary"
+              size="lg"
               onClick={handleStart}
               disabled={
                 ((!durationMinutes || durationMinutes.trim() === '') &&
@@ -409,11 +416,12 @@ export function SetupPanel({ onStart, isLoading }: SetupPanelProps) {
                 !user ||
                 isLoading
               }
-              className="w-full flex items-center justify-center gap-3 px-6 py-4 bg-gradient-to-r from-amber-500 to-amber-600 text-white rounded-xl font-bold shadow-lg hover:shadow-xl hover:from-amber-600 hover:to-amber-700 active:scale-[0.98] transition-all duration-200 text-base sm:text-lg min-h-[56px] disabled:from-gray-300 disabled:to-gray-400 disabled:cursor-not-allowed disabled:hover:shadow-lg disabled:active:scale-100 disabled:hover:from-gray-300 disabled:hover:to-gray-400"
+              className="w-full flex items-center justify-center gap-3"
+              isChristmasMode={isChristmasMode}
             >
               <HiPlay className="text-2xl" />
               <span>スタート</span>
-            </button>
+            </Button>
           </div>
         </div>
       </div>
@@ -437,6 +445,7 @@ export function SetupPanel({ onStart, isLoading }: SetupPanelProps) {
       onRoastLevelChange={setRoastLevel}
       onStart={handleStart}
       isStartDisabled={!weight || (recommendedMode === 'history' && (!beanName || !roastLevel))}
+      isChristmasMode={isChristmasMode}
     />
   );
 }

--- a/components/roast-timer/TimerControls.tsx
+++ b/components/roast-timer/TimerControls.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { HiPlay, HiPause, HiRefresh, HiFastForward } from 'react-icons/hi';
+import { Button } from '@/components/ui';
 
 interface TimerControlsProps {
   isRunning: boolean;
@@ -10,6 +11,7 @@ interface TimerControlsProps {
   onResume: () => void;
   onSkip: () => void;
   onReset: () => void;
+  isChristmasMode: boolean;
 }
 
 /**
@@ -26,24 +28,31 @@ export function TimerControls({
   onResume,
   onSkip,
   onReset,
+  isChristmasMode,
 }: TimerControlsProps) {
   if (isRunning) {
     return (
       <div className="flex items-center justify-center gap-2 sm:gap-4 w-full max-w-md flex-shrink-0">
-        <button
+        <Button
+          variant="secondary"
+          size="md"
           onClick={onPause}
-          className="flex items-center justify-center gap-1 px-2.5 py-2.5 sm:px-5 sm:py-3 bg-gradient-to-r from-yellow-500 to-yellow-600 text-white rounded-lg font-semibold shadow-md hover:shadow-lg hover:from-yellow-600 hover:to-yellow-700 active:scale-[0.98] transition-all duration-200 text-xs sm:text-base min-h-[44px] flex-1 max-w-[200px]"
+          className="flex items-center justify-center gap-1 flex-1 max-w-[200px] !bg-yellow-500 hover:!bg-yellow-600"
+          isChristmasMode={isChristmasMode}
         >
           <HiPause className="text-xl sm:text-2xl flex-shrink-0" />
           <span>一時停止</span>
-        </button>
-        <button
+        </Button>
+        <Button
+          variant="secondary"
+          size="md"
           onClick={onSkip}
-          className="flex items-center justify-center gap-1 px-2.5 py-2.5 sm:px-5 sm:py-3 bg-gradient-to-r from-gray-500 to-gray-600 text-white rounded-lg font-semibold shadow-md hover:shadow-lg hover:from-gray-600 hover:to-gray-700 active:scale-[0.98] transition-all duration-200 text-xs sm:text-base min-h-[44px] flex-1 max-w-[200px]"
+          className="flex items-center justify-center gap-1 flex-1 max-w-[200px]"
+          isChristmasMode={isChristmasMode}
         >
           <HiFastForward className="text-xl sm:text-2xl flex-shrink-0" />
           <span>スキップ</span>
-        </button>
+        </Button>
       </div>
     );
   }
@@ -51,20 +60,26 @@ export function TimerControls({
   if (isPaused) {
     return (
       <div className="flex items-center justify-center gap-2 sm:gap-4 w-full max-w-md flex-shrink-0">
-        <button
+        <Button
+          variant="primary"
+          size="md"
           onClick={onResume}
-          className="flex items-center justify-center gap-1 px-2.5 py-2.5 sm:px-5 sm:py-3 bg-gradient-to-r from-amber-500 to-amber-600 text-white rounded-lg font-semibold shadow-md hover:shadow-lg hover:from-amber-600 hover:to-amber-700 active:scale-[0.98] transition-all duration-200 text-xs sm:text-base min-h-[44px] flex-1 max-w-[200px]"
+          className="flex items-center justify-center gap-1 flex-1 max-w-[200px]"
+          isChristmasMode={isChristmasMode}
         >
           <HiPlay className="text-xl sm:text-2xl flex-shrink-0" />
           <span>再開</span>
-        </button>
-        <button
+        </Button>
+        <Button
+          variant="secondary"
+          size="md"
           onClick={onSkip}
-          className="flex items-center justify-center gap-1 px-2.5 py-2.5 sm:px-5 sm:py-3 bg-gradient-to-r from-gray-500 to-gray-600 text-white rounded-lg font-semibold shadow-md hover:shadow-lg hover:from-gray-600 hover:to-gray-700 active:scale-[0.98] transition-all duration-200 text-xs sm:text-base min-h-[44px] flex-1 max-w-[200px]"
+          className="flex items-center justify-center gap-1 flex-1 max-w-[200px]"
+          isChristmasMode={isChristmasMode}
         >
           <HiFastForward className="text-xl sm:text-2xl flex-shrink-0" />
           <span>スキップ</span>
-        </button>
+        </Button>
       </div>
     );
   }
@@ -73,13 +88,16 @@ export function TimerControls({
     return (
       <div className="grid grid-cols-3 gap-2 sm:gap-4 w-full max-w-md flex-shrink-0">
         <div></div>
-        <button
+        <Button
+          variant="secondary"
+          size="md"
           onClick={onReset}
-          className="flex items-center justify-center gap-1 px-2.5 py-2.5 sm:px-5 sm:py-3 bg-gradient-to-r from-gray-500 to-gray-600 text-white rounded-lg font-semibold shadow-md hover:shadow-lg hover:from-gray-600 hover:to-gray-700 active:scale-[0.98] transition-all duration-200 text-xs sm:text-base min-h-[44px] min-w-[44px]"
+          className="flex items-center justify-center gap-1"
+          isChristmasMode={isChristmasMode}
         >
           <HiRefresh className="text-xl sm:text-2xl flex-shrink-0" />
           <span>リセット</span>
-        </button>
+        </Button>
         <div></div>
       </div>
     );

--- a/components/roast-timer/TimerDisplay.tsx
+++ b/components/roast-timer/TimerDisplay.tsx
@@ -12,6 +12,7 @@ interface TimerDisplayProps {
   isRunning: boolean;
   isPaused: boolean;
   isCompleted: boolean;
+  isChristmasMode?: boolean;
 }
 
 /**
@@ -21,7 +22,7 @@ interface TimerDisplayProps {
  * - 残り時間/経過時間
  * - 実行中の情報（豆、重さ、焙煎度合い）
  */
-export function TimerDisplay({ state, isRunning, isPaused, isCompleted }: TimerDisplayProps) {
+export function TimerDisplay({ state, isRunning, isPaused, isCompleted, isChristmasMode = false }: TimerDisplayProps) {
   // 円形プログレスバーの設定（レスポンシブ対応）
   const [circleSize, setCircleSize] = useState(340);
   const strokeWidth = 16;
@@ -141,8 +142,15 @@ export function TimerDisplay({ state, isRunning, isPaused, isCompleted }: TimerD
   const remaining = state ? Math.max(0, state.remaining) : 0;
   const offset = circumference - (progress / 100) * circumference;
 
-  // 色の決定
+  // 色の決定（クリスマスモード対応）
   const getProgressColor = () => {
+    if (isChristmasMode) {
+      if (isCompleted) return '#0f5132'; // 深緑
+      if (isPaused) return '#c41e3a'; // クリスマスレッド
+      if (isRunning) return '#d4af37'; // ゴールド
+      return '#d1d5db';
+    }
+    // 通常モード
     if (isCompleted) return '#10b981';
     if (isPaused) return '#f59e0b';
     if (isRunning) return '#d97706';
@@ -156,20 +164,28 @@ export function TimerDisplay({ state, isRunning, isPaused, isCompleted }: TimerD
       {/* タイトル */}
       {(isRunning || isPaused) && (
         <div className="text-center space-y-2 flex-shrink-0 mb-4 sm:mb-6">
-          <div className="inline-flex items-center justify-center w-14 h-14 sm:w-16 sm:h-16 md:w-20 md:h-20 rounded-full bg-gradient-to-br from-orange-400 to-red-500 shadow-lg mb-2">
+          <div className={`inline-flex items-center justify-center w-14 h-14 sm:w-16 sm:h-16 md:w-20 md:h-20 rounded-full shadow-lg mb-2 ${
+            isChristmasMode
+              ? 'bg-gradient-to-br from-red-600 to-red-400'
+              : 'bg-gradient-to-br from-orange-400 to-red-500'
+          }`}>
             <MdLocalFireDepartment className="text-3xl sm:text-4xl md:text-5xl text-white" />
           </div>
-          <h2 className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-bold text-gray-900 tracking-tight">
+          <h2 className={`text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-bold tracking-tight ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-900'}`}>
             焙煎中
           </h2>
         </div>
       )}
       {isCompleted && (
         <div className="text-center space-y-2 flex-shrink-0 mb-4 sm:mb-6">
-          <div className="inline-flex items-center justify-center w-14 h-14 sm:w-16 sm:h-16 md:w-20 md:h-20 rounded-full bg-gradient-to-br from-green-400 to-green-600 shadow-lg mb-2">
+          <div className={`inline-flex items-center justify-center w-14 h-14 sm:w-16 sm:h-16 md:w-20 md:h-20 rounded-full shadow-lg mb-2 ${
+            isChristmasMode
+              ? 'bg-gradient-to-br from-green-600 to-green-800'
+              : 'bg-gradient-to-br from-green-400 to-green-600'
+          }`}>
             <HiCheckCircle className="text-3xl sm:text-4xl md:text-5xl text-white" />
           </div>
-          <h2 className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-bold text-gray-900 tracking-tight">
+          <h2 className={`text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-bold tracking-tight ${isChristmasMode ? 'text-[#f8f1e7]' : 'text-gray-900'}`}>
             焙煎完了
           </h2>
         </div>
@@ -215,22 +231,24 @@ export function TimerDisplay({ state, isRunning, isPaused, isCompleted }: TimerD
         <div className="absolute inset-0 flex flex-col items-center justify-center">
           <div
             ref={remainingTextRef}
-            className="text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-bold text-amber-600 font-sans"
+            className={`text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-bold font-sans ${
+              isChristmasMode ? 'text-[#d4af37]' : 'text-amber-600'
+            }`}
           >
             {formatTime(Math.floor(remaining))}
           </div>
           {state && (
-            <div className="text-base sm:text-lg md:text-xl text-gray-500 mt-2 sm:mt-3">
+            <div className={`text-base sm:text-lg md:text-xl mt-2 sm:mt-3 ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-500'}`}>
               <span ref={elapsedTextRef}>{formatTime(Math.floor(state.elapsed))}</span> / {formatTime(state.duration)}
             </div>
           )}
           {isCompleted && (
-            <div className="text-sm sm:text-base md:text-lg font-semibold text-green-600 mt-2 sm:mt-3">
+            <div className={`text-sm sm:text-base md:text-lg font-semibold mt-2 sm:mt-3 ${isChristmasMode ? 'text-[#d4af37]' : 'text-green-600'}`}>
               ロースト完了！
             </div>
           )}
           {isPaused && (
-            <div className="text-xs sm:text-sm md:text-base text-amber-600 mt-2 sm:mt-3 font-medium">
+            <div className={`text-xs sm:text-sm md:text-base mt-2 sm:mt-3 font-medium ${isChristmasMode ? 'text-[#d4af37]' : 'text-amber-600'}`}>
               一時停止中
             </div>
           )}
@@ -239,7 +257,7 @@ export function TimerDisplay({ state, isRunning, isPaused, isCompleted }: TimerD
 
       {/* 実行中の情報表示 */}
       {state && (isRunning || isPaused || isCompleted) && (
-        <div className="text-center space-y-0.5 text-sm sm:text-base text-gray-600 flex-shrink-0 mb-4 sm:mb-6">
+        <div className={`text-center space-y-0.5 text-sm sm:text-base flex-shrink-0 mb-4 sm:mb-6 ${isChristmasMode ? 'text-[#f8f1e7]/70' : 'text-gray-600'}`}>
           {state.beanName && <div>豆の名前: {state.beanName}</div>}
           {state.weight && <div>重さ: {state.weight}g</div>}
           {state.roastLevel && <div>焙煎度合い: {state.roastLevel}</div>}

--- a/components/roast-timer/TimerHeader.tsx
+++ b/components/roast-timer/TimerHeader.tsx
@@ -3,11 +3,13 @@
 import Link from 'next/link';
 import { HiArrowLeft, HiClipboardList } from 'react-icons/hi';
 import { IoSettings } from 'react-icons/io5';
+import { IconButton, Button } from '@/components/ui';
 
 interface TimerHeaderProps {
   onBack: () => void;
   onSettingsClick: () => void;
   isOverlay?: boolean;
+  isChristmasMode?: boolean;
 }
 
 /**
@@ -16,39 +18,48 @@ interface TimerHeaderProps {
  * - 設定ボタン
  * - 記録一覧リンク
  */
-export function TimerHeader({ onBack, onSettingsClick, isOverlay = false }: TimerHeaderProps) {
+export function TimerHeader({ onBack, onSettingsClick, isOverlay = false, isChristmasMode = false }: TimerHeaderProps) {
   const containerClass = isOverlay
     ? 'absolute top-4 left-4 right-4 z-10 flex justify-between items-start'
     : 'absolute top-4 left-4 right-4 z-10 flex justify-between items-start pointer-events-none';
 
   return (
     <div className={containerClass}>
-      <button
+      <IconButton
         onClick={onBack}
-        className={`px-3 py-2 text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded transition-colors flex items-center justify-center min-h-[44px] min-w-[44px] ${!isOverlay ? 'pointer-events-auto' : ''}`}
+        size="lg"
         title="戻る"
         aria-label="戻る"
+        className={`${!isOverlay ? 'pointer-events-auto' : ''}`}
+        isChristmasMode={isChristmasMode}
       >
         <HiArrowLeft className="h-6 w-6 flex-shrink-0" />
-      </button>
+      </IconButton>
       <div className={`flex items-center gap-2 ${!isOverlay ? 'pointer-events-auto' : ''}`}>
-        <button
+        <Button
+          variant="secondary"
+          size="md"
           onClick={onSettingsClick}
-          className="px-4 py-2.5 bg-white text-gray-800 rounded-lg shadow-md hover:bg-gray-50 hover:shadow-lg transition-all duration-200 flex items-center gap-2 min-h-[44px] border border-gray-200"
+          className="flex items-center gap-2"
           title="ローストタイマー設定"
           aria-label="ローストタイマー設定"
+          isChristmasMode={isChristmasMode}
         >
           <IoSettings className="h-5 w-5 flex-shrink-0" />
           <span className="text-sm font-semibold hidden sm:inline">タイマー設定</span>
-        </button>
-        <Link
-          href="/roast-record"
-          className="px-4 py-2.5 bg-primary text-white rounded-lg shadow-md hover:bg-primary-dark hover:shadow-lg transition-all duration-200 flex items-center gap-2 min-h-[44px]"
-          title="ロースト記録一覧"
-          aria-label="ロースト記録一覧"
-        >
-          <HiClipboardList className="h-5 w-5 flex-shrink-0" />
-          <span className="text-sm font-semibold hidden sm:inline">記録一覧</span>
+        </Button>
+        <Link href="/roast-record" className="inline-block">
+          <Button
+            variant="primary"
+            size="md"
+            className="flex items-center gap-2"
+            title="ロースト記録一覧"
+            aria-label="ロースト記録一覧"
+            isChristmasMode={isChristmasMode}
+          >
+            <HiClipboardList className="h-5 w-5 flex-shrink-0" />
+            <span className="text-sm font-semibold hidden sm:inline">記録一覧</span>
+          </Button>
         </Link>
       </div>
     </div>


### PR DESCRIPTION
## 概要
Issue #135 を解決。ローストタイマーページの全UI要素を共通UIコンポーネントに置換し、クリスマスモード対応を実装しました。

## 変更内容

### UI共通化
- **ボタン**: 独自button → `Button`/`IconButton` (約30箇所)
- **入力フィールド**: 独自input → `Input`/`NumberInput` (約10箇所)
- **セレクトボックス**: 独自select → `Select` (5箇所)
- **チェックボックス**: 独自checkbox → `Checkbox` (1箇所)
- **タブ**: 独自ボタン群 → `Tabs` (1箇所)
- **モーダル/ダイアログ**: 独自実装 → `Modal` (4箇所)

### クリスマスモード対応
- `useChristmasMode`フックを全コンポーネントに導入
- 背景色、テキスト色、カード色などをクリスマスモードに対応
- 既存のButtonコンポーネントに`isChristmasMode` propを追加

### 影響範囲
```
app/roast-timer/page.tsx
components/RoastTimer.tsx
components/RoastTimerDialogs.tsx
components/RoastTimerSettings.tsx
components/roast-timer/
  ├─ ModeSelectView.tsx
  ├─ RecommendedModeView.tsx
  ├─ SetupPanel.tsx
  ├─ TimerControls.tsx
  └─ TimerHeader.tsx
```

## 技術的詳細

### 独自スタイル維持部分
以下は共通コンポーネントが未実装のため、独自実装を維持:
- `input[type="range"]` (音量スライダー) - Sliderコンポーネント未実装
- 円形プログレスバー (TimerDisplay.tsx) - 特殊なSVGアニメーション

### Tabsコンポーネントの活用
おすすめモード選択で独自ボタン実装からTabsコンポーネントに移行:
```tsx
<Tabs value={recommendedMode} onValueChange={onRecommendedModeChange} isChristmasMode={isChristmasMode}>
  <TabsList>
    <TabsTrigger value="weight">重さで設定</TabsTrigger>
    <TabsTrigger value="history">過去の記録から設定</TabsTrigger>
  </TabsList>
  <TabsContent value="weight">...</TabsContent>
  <TabsContent value="history">...</TabsContent>
</Tabs>
```

## テスト
- [x] lint通過
- [x] build通過
- [x] 通常モードでの動作確認
- [x] クリスマスモードでの動作確認
- [ ] 手動タイマー起動
- [ ] おすすめタイマー起動(重さ・過去記録)
- [ ] タイマー操作(一時停止・再開・スキップ・リセット)
- [ ] 設定画面の動作

## スクリーンショット
(ユーザーが手動確認後に追加予定)

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
