### PR TITLE
feat: スプラッシュ画面リデザイン＆ランダムアニメーション

### DIFF
--- a/app/dev/splash-preview/page.tsx
+++ b/app/dev/splash-preview/page.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { HiArrowLeft, HiPlay, HiArrowsPointingOut } from 'react-icons/hi2';
+import { useRouter } from 'next/navigation';
+import { splashPatterns } from '@/components/splash/patterns';
+
+// ─── プレビューカード ───
+
+function PreviewCard({
+  pattern,
+  onFullscreen,
+}: {
+  pattern: (typeof splashPatterns)[number];
+  onFullscreen: () => void;
+}) {
+  const [phase, setPhase] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  const play = useCallback(() => {
+    setPhase(0);
+    setIsPlaying(true);
+
+    const timers = [
+      setTimeout(() => setPhase(1), 100),
+      setTimeout(() => setPhase(2), 600),
+      setTimeout(() => setPhase(3), 1000),
+      setTimeout(() => setIsPlaying(false), 3000),
+    ];
+
+    return () => timers.forEach(clearTimeout);
+  }, []);
+
+  // 初回自動再生
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      play();
+    }, pattern.id * 400);
+    return () => clearTimeout(timer);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const { Component } = pattern;
+
+  return (
+    <div className="rounded-xl border border-white/10 overflow-hidden bg-white/5">
+      {/* プレビューエリア */}
+      <div
+        className="relative flex items-center justify-center h-48"
+        style={{ backgroundColor: '#261a14' }}
+      >
+        <Component phase={phase} compact />
+      </div>
+
+      {/* 情報エリア */}
+      <div className="p-4 flex items-center justify-between bg-[#1a1210]">
+        <div>
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-mono text-[#EF8A00]">#{pattern.id}</span>
+            <h3 className="text-sm font-bold text-white">{pattern.name}</h3>
+          </div>
+          <p className="text-xs text-white/50 mt-0.5">{pattern.description}</p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={play}
+            disabled={isPlaying}
+            className="flex h-9 w-9 items-center justify-center rounded-lg bg-[#EF8A00]/20 text-[#EF8A00] hover:bg-[#EF8A00]/30 transition-colors disabled:opacity-30"
+            aria-label="リプレイ"
+            title="リプレイ"
+          >
+            <HiPlay className="h-4 w-4" />
+          </button>
+          <button
+            onClick={onFullscreen}
+            className="flex h-9 w-9 items-center justify-center rounded-lg bg-white/10 text-white/70 hover:bg-white/20 transition-colors"
+            aria-label="フルスクリーン"
+            title="フルスクリーン"
+          >
+            <HiArrowsPointingOut className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── フルスクリーンプレビュー ───
+
+function FullscreenPreview({
+  pattern,
+  onClose,
+}: {
+  pattern: (typeof splashPatterns)[number];
+  onClose: () => void;
+}) {
+  const [phase, setPhase] = useState(0);
+
+  const startAnimation = useCallback(() => {
+    setPhase(0);
+    setTimeout(() => setPhase(1), 100);
+    setTimeout(() => setPhase(2), 600);
+    setTimeout(() => setPhase(3), 1000);
+  }, []);
+
+  useEffect(() => {
+    queueMicrotask(() => startAnimation());
+  }, [startAnimation]);
+
+  const { Component } = pattern;
+
+  return (
+    <>
+      <style jsx global>{`
+        @keyframes breathe {
+          0%, 100% { transform: scale(1); }
+          50% { transform: scale(1.03); }
+        }
+      `}</style>
+      <div
+        className="fixed inset-0 z-[9999] flex flex-col items-center justify-center"
+        style={{ backgroundColor: '#261a14' }}
+      >
+        <Component phase={phase} />
+
+        {/* コントロール */}
+        <div className="absolute bottom-8 flex gap-3">
+          <button
+            onClick={startAnimation}
+            className="flex items-center gap-2 px-4 py-2 rounded-full bg-[#EF8A00]/20 text-[#EF8A00] text-sm hover:bg-[#EF8A00]/30 transition-colors"
+          >
+            <HiPlay className="h-4 w-4" />
+            リプレイ
+          </button>
+          <button
+            onClick={onClose}
+            className="flex items-center gap-2 px-4 py-2 rounded-full bg-white/10 text-white/70 text-sm hover:bg-white/20 transition-colors"
+          >
+            閉じる
+          </button>
+        </div>
+
+        {/* パターン名表示 */}
+        <div className="absolute top-6 left-6 flex items-center gap-2">
+          <span className="text-xs font-mono text-[#EF8A00]">#{pattern.id}</span>
+          <span className="text-sm text-white/60">{pattern.name}</span>
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ─── メインページ ───
+
+export default function SplashPreviewPage() {
+  const router = useRouter();
+  const [fullscreenPattern, setFullscreenPattern] = useState<(typeof splashPatterns)[number] | null>(null);
+
+  return (
+    <>
+      <style jsx global>{`
+        @keyframes breathe {
+          0%, 100% { transform: scale(1); }
+          50% { transform: scale(1.03); }
+        }
+      `}</style>
+
+      <div className="min-h-screen" style={{ backgroundColor: '#1a1210' }}>
+        {/* ヘッダー */}
+        <header className="sticky top-0 z-40 border-b border-white/10 backdrop-blur-xl" style={{ backgroundColor: '#261a14ee' }}>
+          <div className="mx-auto max-w-5xl flex items-center justify-between px-4 py-3">
+            <div className="flex items-center gap-3">
+              <button
+                onClick={() => router.push('/')}
+                className="flex h-9 w-9 items-center justify-center rounded-lg bg-white/10 text-white/70 hover:bg-white/20 transition-colors"
+                aria-label="ホームに戻る"
+              >
+                <HiArrowLeft className="h-4 w-4" />
+              </button>
+              <div>
+                <h1 className="text-sm font-bold text-white">Splash Animation Preview</h1>
+                <p className="text-xs text-white/40">アニメーションパターンを比較（本番はランダム再生）</p>
+              </div>
+            </div>
+            <span className="text-xs font-mono text-[#EF8A00]/60">DEV ONLY</span>
+          </div>
+        </header>
+
+        {/* グリッド */}
+        <main className="mx-auto max-w-5xl px-4 py-6">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {splashPatterns.map((pattern) => (
+              <PreviewCard
+                key={pattern.id}
+                pattern={pattern}
+                onFullscreen={() => setFullscreenPattern(pattern)}
+              />
+            ))}
+          </div>
+
+          <p className="mt-6 text-center text-xs text-white/30">
+            各カードの ▶ でリプレイ、⛶ でフルスクリーンプレビュー
+          </p>
+        </main>
+      </div>
+
+      {/* フルスクリーンモーダル */}
+      {fullscreenPattern && (
+        <FullscreenPreview
+          pattern={fullscreenPattern}
+          onClose={() => setFullscreenPattern(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,6 +25,8 @@ import { FaTree, FaGift, FaSnowflake, FaStar } from 'react-icons/fa';
 import { PiBellFill } from 'react-icons/pi';
 import { GiCandyCanes, GiGingerbreadMan } from 'react-icons/gi';
 import { HiClock } from 'react-icons/hi';
+import { HiSparkles } from 'react-icons/hi2';
+import { REPLAY_SPLASH_EVENT } from '@/components/SplashScreen';
 import { BsStars } from 'react-icons/bs';
 
 const SPLASH_DISPLAY_TIME = 3000; // スプラッシュ画面の表示時間 (ms)
@@ -357,14 +359,25 @@ export default function HomePage(_props: HomePageProps = {}) {
             </button>
 
             {isDeveloperMode && (
-              <button
-                onClick={handleShowLoadingDebugModal}
-                className={`flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full p-2 transition-all ${isChristmasMode ? 'text-[#d4af37] bg-white/5 hover:bg-[#d4af37]/20 border border-[#d4af37]/20 shadow-inner' : 'text-white hover:bg-white/10'
-                  }`}
-                aria-label="Lottieアニメーション確認モーダルを開く"
-              >
-                <PiCoffeeBeanFill className="h-6 w-6" />
-              </button>
+              <>
+                <button
+                  onClick={() => window.dispatchEvent(new Event(REPLAY_SPLASH_EVENT))}
+                  className={`flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full p-2 transition-all ${isChristmasMode ? 'text-[#d4af37] bg-white/5 hover:bg-[#d4af37]/20 border border-[#d4af37]/20 shadow-inner' : 'text-white hover:bg-white/10'
+                    }`}
+                  aria-label="スプラッシュ画面を再生"
+                  title="スプラッシュ再生"
+                >
+                  <HiSparkles className="h-6 w-6" />
+                </button>
+                <button
+                  onClick={handleShowLoadingDebugModal}
+                  className={`flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full p-2 transition-all ${isChristmasMode ? 'text-[#d4af37] bg-white/5 hover:bg-[#d4af37]/20 border border-[#d4af37]/20 shadow-inner' : 'text-white hover:bg-white/10'
+                    }`}
+                  aria-label="Lottieアニメーション確認モーダルを開く"
+                >
+                  <PiCoffeeBeanFill className="h-6 w-6" />
+                </button>
+              </>
             )}
 
           </div>

--- a/components/SplashScreen.tsx
+++ b/components/SplashScreen.tsx
@@ -1,51 +1,56 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import Lottie from 'lottie-react';
+import { useCallback, useEffect, useState } from 'react';
+import { splashPatterns } from '@/components/splash/patterns';
 
-const SPLASH_DISPLAY_TIME = 3000; // 3秒
-const SPLASH_SHOWN_KEY = 'roastplus_splash_shown'; // セッション開始時のフラグ
+const SPLASH_DISPLAY_TIME = 2800;
+const SPLASH_SHOWN_KEY = 'roastplus_splash_shown';
+export const REPLAY_SPLASH_EVENT = 'replay-splash';
+
+function pickRandomIndex() {
+  return Math.floor(Math.random() * splashPatterns.length);
+}
 
 export function SplashScreen() {
   const [isVisible, setIsVisible] = useState(false);
   const [isFadingOut, setIsFadingOut] = useState(false);
+  const [phase, setPhase] = useState(0);
+  const [patternIndex, setPatternIndex] = useState(0);
 
-  // クライアントマウント時にsessionStorageをチェックし、初回訪問時のみスプラッシュを表示
-  // サーバー/クライアント共にisVisible=falseで開始することでHydrationミスマッチを回避
+  const startSplash = useCallback(() => {
+    setPatternIndex(pickRandomIndex());
+    setPhase(0);
+    setIsFadingOut(false);
+    setIsVisible(true);
+  }, []);
+
   useEffect(() => {
+    const index = pickRandomIndex();
     const splashShown = sessionStorage.getItem(SPLASH_SHOWN_KEY);
     if (splashShown !== 'true') {
       sessionStorage.setItem(SPLASH_SHOWN_KEY, 'true');
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- sessionStorageとの初期同期のため必要
-      setIsVisible(true);
+      queueMicrotask(() => {
+        setPatternIndex(index);
+        setIsVisible(true);
+      });
+    } else {
+      queueMicrotask(() => setPatternIndex(index));
     }
   }, []);
-  const [animationData, setAnimationData] = useState<object | null>(null);
-  const [isTextVisible, setIsTextVisible] = useState(false);
+
+  // カスタムイベントでスプラッシュを再生
+  useEffect(() => {
+    const handleReplay = () => startSplash();
+    window.addEventListener(REPLAY_SPLASH_EVENT, handleReplay);
+    return () => window.removeEventListener(REPLAY_SPLASH_EVENT, handleReplay);
+  }, [startSplash]);
 
   useEffect(() => {
     if (!isVisible) return;
 
-    let isMounted = true;
-    const loadAnimation = async () => {
-      try {
-        const response = await fetch('/animations/Loading coffee bean.json');
-        if (response.ok) {
-          const data = await response.json();
-          if (isMounted) {
-            setAnimationData(data);
-          }
-        }
-      } catch (error) {
-        console.error('Error loading Lottie animation:', error);
-      }
-    };
-
-    loadAnimation();
-
-    const textFadeInTimer = setTimeout(() => {
-      setIsTextVisible(true);
-    }, 200);
+    const phase1 = setTimeout(() => setPhase(1), 100);
+    const phase2 = setTimeout(() => setPhase(2), 600);
+    const phase3 = setTimeout(() => setPhase(3), 1000);
 
     const fadeOutTimer = setTimeout(() => {
       setIsFadingOut(true);
@@ -53,11 +58,12 @@ export function SplashScreen() {
 
     const hideTimer = setTimeout(() => {
       setIsVisible(false);
-    }, SPLASH_DISPLAY_TIME + 300);
+    }, SPLASH_DISPLAY_TIME + 500);
 
     return () => {
-      isMounted = false;
-      clearTimeout(textFadeInTimer);
+      clearTimeout(phase1);
+      clearTimeout(phase2);
+      clearTimeout(phase3);
       clearTimeout(fadeOutTimer);
       clearTimeout(hideTimer);
     };
@@ -67,36 +73,24 @@ export function SplashScreen() {
     return null;
   }
 
+  const { Component } = splashPatterns[patternIndex];
+
   return (
-    <div
-      className={`fixed inset-0 z-[9999] flex items-center justify-center transition-opacity duration-300 ${isFadingOut ? 'opacity-0' : 'opacity-100'
+    <>
+      <style jsx global>{`
+        @keyframes breathe {
+          0%, 100% { transform: scale(1); }
+          50% { transform: scale(1.03); }
+        }
+      `}</style>
+      <div
+        className={`fixed inset-0 z-[9999] flex items-center justify-center transition-opacity duration-500 ${
+          isFadingOut ? 'opacity-0' : 'opacity-100'
         }`}
-      style={{ backgroundColor: '#1a1412' }}
-    >
-      <div className="text-center space-y-8">
-        {/* タイトルを上に */}
-        <div
-          className={`transition-opacity duration-500 ${isTextVisible ? 'opacity-100' : 'opacity-0'
-            }`}
-        >
-          <div className="space-y-4">
-            <h1 className="text-5xl font-bold text-white tracking-[0.05em] leading-tight font-[var(--font-playfair)]">
-              Roast<span className="text-[#EF8A00]">Plus</span>
-            </h1>
-          </div>
-        </div>
-        {/* アニメーションを下に */}
-        <div className="flex justify-center">
-          {animationData && (
-            <Lottie
-              animationData={animationData}
-              loop={true}
-              style={{ width: 200, height: 200 }}
-            />
-          )}
-        </div>
+        style={{ backgroundColor: '#261a14' }}
+      >
+        <Component phase={phase} />
       </div>
-    </div>
+    </>
   );
 }
-

--- a/components/splash/patterns.tsx
+++ b/components/splash/patterns.tsx
@@ -1,0 +1,280 @@
+'use client';
+
+// ─── スプラッシュアニメーションパターン ───
+
+export interface PatternProps {
+  phase: number;
+  compact?: boolean; // プレビューカード用の小さいサイズ
+}
+
+const textSize = (compact?: boolean) =>
+  compact
+    ? 'text-[2rem]'
+    : 'text-[3rem] sm:text-[3.8rem]';
+
+const subTextSize = (compact?: boolean) =>
+  compact
+    ? 'text-[0.55rem]'
+    : 'text-[0.65rem] sm:text-[0.72rem]';
+
+const lineWidth = (compact?: boolean) =>
+  compact ? 'w-12' : 'w-16';
+
+const spacing = (compact?: boolean) =>
+  compact ? 'mt-3' : 'mt-4';
+
+// パターン1: Fade Up（現行）
+// ロゴが下から浮き上がりフェードイン → ライン展開 → サブテキスト表示
+function PatternFadeUp({ phase, compact }: PatternProps) {
+  return (
+    <div className="flex flex-col items-center">
+      <h1
+        className={`${textSize(compact)} font-bold tracking-[0.04em] leading-none font-[var(--font-playfair)] transition-all duration-700 ease-out ${
+          phase >= 1 ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-3'
+        }`}
+      >
+        <span className="text-white">Roast</span>
+        <span className="text-[#EF8A00] ml-0.5">Plus</span>
+      </h1>
+      <div className={`${spacing(compact)} flex justify-center`}>
+        <div
+          className={`h-[2px] rounded-full transition-all duration-700 ease-out ${
+            phase >= 2 ? `${lineWidth(compact)} opacity-100` : 'w-0 opacity-0'
+          }`}
+          style={{
+            background: 'linear-gradient(90deg, transparent, #D67A00 30%, #EF8A00, #D67A00 70%, transparent)',
+          }}
+        />
+      </div>
+      <p
+        className={`${spacing(compact)} ${subTextSize(compact)} tracking-[0.3em] uppercase transition-all duration-600 ease-out ${
+          phase >= 3 ? 'opacity-40 translate-y-0' : 'opacity-0 translate-y-2'
+        }`}
+        style={{ color: '#FFFFFF', fontWeight: 300 }}
+      >
+        Coffee Roasting
+      </p>
+    </div>
+  );
+}
+
+// パターン2: Scale Breathe
+// ロゴが中央から拡大しながら出現 → 微妙なスケールパルス → サブテキスト
+function PatternScaleBreathe({ phase, compact }: PatternProps) {
+  return (
+    <div className="flex flex-col items-center">
+      <h1
+        className={`${textSize(compact)} font-bold tracking-[0.04em] leading-none font-[var(--font-playfair)] transition-all duration-800 ease-out ${
+          phase >= 1 ? 'opacity-100 scale-100' : 'opacity-0 scale-75'
+        } ${phase >= 2 ? 'animate-[breathe_2s_ease-in-out_infinite]' : ''}`}
+      >
+        <span className="text-white">Roast</span>
+        <span className="text-[#EF8A00] ml-0.5">Plus</span>
+      </h1>
+      <p
+        className={`mt-4 ${subTextSize(compact)} tracking-[0.3em] uppercase transition-all duration-600 ease-out ${
+          phase >= 3 ? 'opacity-40 translate-y-0' : 'opacity-0 translate-y-2'
+        }`}
+        style={{ color: '#FFFFFF', fontWeight: 300 }}
+      >
+        Coffee Roasting
+      </p>
+    </div>
+  );
+}
+
+// パターン3: Letter Stagger
+// 文字が1文字ずつ順番にフェードインで出現
+function PatternLetterStagger({ phase, compact }: PatternProps) {
+  const letters = [
+    { char: 'R', color: '#FFFFFF' },
+    { char: 'o', color: '#FFFFFF' },
+    { char: 'a', color: '#FFFFFF' },
+    { char: 's', color: '#FFFFFF' },
+    { char: 't', color: '#FFFFFF' },
+    { char: 'P', color: '#EF8A00' },
+    { char: 'l', color: '#EF8A00' },
+    { char: 'u', color: '#EF8A00' },
+    { char: 's', color: '#EF8A00' },
+  ];
+
+  return (
+    <div className="flex flex-col items-center">
+      <h1 className={`${textSize(compact)} font-bold tracking-[0.04em] leading-none font-[var(--font-playfair)] flex`}>
+        {letters.map((letter, i) => (
+          <span
+            key={i}
+            className="transition-all duration-500 ease-out inline-block"
+            style={{
+              color: letter.color,
+              opacity: phase >= 1 ? 1 : 0,
+              transform: phase >= 1 ? 'translateY(0)' : 'translateY(12px)',
+              transitionDelay: phase >= 1 ? `${i * 80}ms` : '0ms',
+              marginLeft: i === 5 ? '4px' : '0',
+            }}
+          >
+            {letter.char}
+          </span>
+        ))}
+      </h1>
+      <div className={`${spacing(compact)} flex justify-center`}>
+        <div
+          className={`h-[2px] rounded-full transition-all duration-700 ease-out ${
+            phase >= 2 ? `${lineWidth(compact)} opacity-100` : 'w-0 opacity-0'
+          }`}
+          style={{
+            background: 'linear-gradient(90deg, transparent, #D67A00 30%, #EF8A00, #D67A00 70%, transparent)',
+            transitionDelay: phase >= 2 ? '400ms' : '0ms',
+          }}
+        />
+      </div>
+      <p
+        className={`${spacing(compact)} ${subTextSize(compact)} tracking-[0.3em] uppercase transition-all duration-600 ease-out ${
+          phase >= 3 ? 'opacity-40' : 'opacity-0'
+        }`}
+        style={{ color: '#FFFFFF', fontWeight: 300, transitionDelay: phase >= 3 ? '200ms' : '0ms' }}
+      >
+        Coffee Roasting
+      </p>
+    </div>
+  );
+}
+
+// パターン4: Slide Reveal
+// 「Roast」が左から、「Plus」が右からスライドインして中央で合流
+function PatternSlideReveal({ phase, compact }: PatternProps) {
+  return (
+    <div className="flex flex-col items-center">
+      <h1 className={`${textSize(compact)} font-bold tracking-[0.04em] leading-none font-[var(--font-playfair)] flex overflow-hidden`}>
+        <span
+          className={`text-white transition-all duration-700 ease-out ${
+            phase >= 1 ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-8'
+          }`}
+        >
+          Roast
+        </span>
+        <span
+          className={`text-[#EF8A00] ml-0.5 transition-all duration-700 ease-out ${
+            phase >= 1 ? 'opacity-100 translate-x-0' : 'opacity-0 translate-x-8'
+          }`}
+          style={{ transitionDelay: phase >= 1 ? '150ms' : '0ms' }}
+        >
+          Plus
+        </span>
+      </h1>
+      <div className={`${spacing(compact)} flex justify-center`}>
+        <div
+          className={`h-[2px] rounded-full transition-all duration-700 ease-out ${
+            phase >= 2 ? `${lineWidth(compact)} opacity-100` : 'w-0 opacity-0'
+          }`}
+          style={{
+            background: 'linear-gradient(90deg, transparent, #D67A00 30%, #EF8A00, #D67A00 70%, transparent)',
+          }}
+        />
+      </div>
+      <p
+        className={`${spacing(compact)} ${subTextSize(compact)} tracking-[0.3em] uppercase transition-all duration-600 ease-out ${
+          phase >= 3 ? 'opacity-40 translate-y-0' : 'opacity-0 translate-y-2'
+        }`}
+        style={{ color: '#FFFFFF', fontWeight: 300 }}
+      >
+        Coffee Roasting
+      </p>
+    </div>
+  );
+}
+
+// パターン5: Glow Pulse
+// ロゴが暖かいグロー効果と共に出現、オレンジの発光が脈動
+function PatternGlowPulse({ phase, compact }: PatternProps) {
+  return (
+    <div className="flex flex-col items-center">
+      <h1
+        className={`${textSize(compact)} font-bold tracking-[0.04em] leading-none font-[var(--font-playfair)] transition-all duration-800 ease-out ${
+          phase >= 1 ? 'opacity-100' : 'opacity-0'
+        }`}
+        style={{
+          filter: phase >= 1 ? 'blur(0px)' : 'blur(8px)',
+          transition: 'all 0.8s ease-out',
+        }}
+      >
+        <span
+          className="text-white"
+          style={{
+            textShadow: phase >= 2 ? '0 0 20px rgba(255,255,255,0.3)' : 'none',
+            transition: 'text-shadow 0.6s ease-out',
+          }}
+        >
+          Roast
+        </span>
+        <span
+          className="ml-0.5"
+          style={{
+            color: '#EF8A00',
+            textShadow:
+              phase >= 2
+                ? '0 0 20px rgba(239,138,0,0.5), 0 0 40px rgba(239,138,0,0.2)'
+                : 'none',
+            transition: 'text-shadow 0.6s ease-out',
+          }}
+        >
+          Plus
+        </span>
+      </h1>
+      <div className={`${spacing(compact)} flex justify-center`}>
+        <div
+          className={`h-[2px] rounded-full transition-all duration-700 ease-out ${
+            phase >= 2 ? `${lineWidth(compact)} opacity-100` : 'w-0 opacity-0'
+          }`}
+          style={{
+            background: 'linear-gradient(90deg, transparent, #D67A00 30%, #EF8A00, #D67A00 70%, transparent)',
+            boxShadow: phase >= 2 ? '0 0 8px rgba(239,138,0,0.4)' : 'none',
+          }}
+        />
+      </div>
+      <p
+        className={`${spacing(compact)} ${subTextSize(compact)} tracking-[0.3em] uppercase transition-all duration-600 ease-out ${
+          phase >= 3 ? 'opacity-40' : 'opacity-0'
+        }`}
+        style={{ color: '#FFFFFF', fontWeight: 300 }}
+      >
+        Coffee Roasting
+      </p>
+    </div>
+  );
+}
+
+// ─── パターン定義配列（エクスポート） ───
+
+export const splashPatterns = [
+  {
+    id: 1,
+    name: 'Fade Up',
+    description: '下から浮き上がりフェードイン（現行）',
+    Component: PatternFadeUp,
+  },
+  {
+    id: 2,
+    name: 'Scale Breathe',
+    description: '中央から拡大 → 微呼吸パルス',
+    Component: PatternScaleBreathe,
+  },
+  {
+    id: 3,
+    name: 'Letter Stagger',
+    description: '文字が1つずつ順番にフェードイン',
+    Component: PatternLetterStagger,
+  },
+  {
+    id: 4,
+    name: 'Slide Reveal',
+    description: '左右からスライドして中央で合流',
+    Component: PatternSlideReveal,
+  },
+  {
+    id: 5,
+    name: 'Glow Pulse',
+    description: 'ブラーから出現 + オレンジグロー',
+    Component: PatternGlowPulse,
+  },
+];


### PR DESCRIPTION
## Summary
- スプラッシュ画面をダークブラウン背景（#261a14）にリデザインし、ヘッダーと配色を統一
- Lottie依存を排除し、CSSアニメーションのみで5パターンのアニメーションを実装（毎回ランダム再生）
- 開発モード時にヘッダーからスプラッシュを再生できるデバッグボタンと、`/dev/splash-preview` 比較プレビューページを追加

## Test plan
- [ ] セッション初回アクセス時にスプラッシュ画面が表示されること
- [ ] スプラッシュのアニメーションが5パターンからランダムに選ばれること
- [ ] 開発モードON時、ヘッダーの✦ボタンでスプラッシュが再生されること
- [ ] `/dev/splash-preview` で5パターンのリプレイ・フルスクリーンプレビューが動作すること
- [ ] モバイル・デスクトップ両方で正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)