### PR TITLE
feat(theme): CSS変数ベースのテーマシステム基盤を構築 (#170)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -12,6 +12,55 @@
   --gold: #FFC107;
 }
 
+/*
+ * テーマシステム: セマンティックトークン
+ * data-theme 属性で切り替わるCSS変数
+ * 新テーマ追加時はここにブロックを追加するだけ
+ */
+@layer theme {
+  :root {
+    /* 背景 */
+    --page: #F7F7F5;
+    --surface: #FFFFFF;
+    --overlay: #FFFFFF;
+    --ground: #F5F5F5;
+    --field: #FFFFFF;
+    /* テキスト */
+    --ink: #1f2937;
+    --ink-sub: #4b5563;
+    --ink-muted: #9ca3af;
+    /* ボーダー */
+    --edge: #e5e7eb;
+    --edge-strong: #d1d5db;
+    /* アクセント */
+    --spot: #d97706;
+    --spot-hover: #b45309;
+    --spot-subtle: #fef3c7;
+    --spot-surface: #fffbeb;
+  }
+
+  [data-theme="christmas"] {
+    /* 背景 */
+    --page: #051a0e;
+    --surface: rgba(255, 255, 255, 0.05);
+    --overlay: #0a2f1a;
+    --ground: rgba(255, 255, 255, 0.03);
+    --field: rgba(255, 255, 255, 0.08);
+    /* テキスト */
+    --ink: #f8f1e7;
+    --ink-sub: rgba(248, 241, 231, 0.7);
+    --ink-muted: rgba(248, 241, 231, 0.5);
+    /* ボーダー */
+    --edge: rgba(212, 175, 55, 0.2);
+    --edge-strong: rgba(212, 175, 55, 0.3);
+    /* アクセント */
+    --spot: #d4af37;
+    --spot-hover: #e8c65f;
+    --spot-subtle: rgba(212, 175, 55, 0.15);
+    --spot-surface: rgba(212, 175, 55, 0.05);
+  }
+}
+
 /* stylelint-disable-next-line at-rule-no-unknown */
 @theme inline {
   --color-background: var(--background);
@@ -22,10 +71,26 @@
   --color-dark: var(--dark);
   --color-dark-light: var(--dark-light);
   --color-gold: var(--gold);
-  /* 背景色トークン */
-  --color-bg-global: #F7F7F5;
-  --color-bg-card: #FFFFFF;
-  --color-bg-section: #F5F5F5;
+  /* 背景色トークン（テーマ対応） */
+  --color-bg-global: var(--page);
+  --color-bg-card: var(--surface);
+  --color-bg-section: var(--ground);
+  /* セマンティックテーマトークン */
+  --color-page: var(--page);
+  --color-surface: var(--surface);
+  --color-overlay: var(--overlay);
+  --color-ground: var(--ground);
+  --color-field: var(--field);
+  --color-ink: var(--ink);
+  --color-ink-sub: var(--ink-sub);
+  --color-ink-muted: var(--ink-muted);
+  --color-edge: var(--edge);
+  --color-edge-strong: var(--edge-strong);
+  --color-spot: var(--spot);
+  --color-spot-hover: var(--spot-hover);
+  --color-spot-subtle: var(--spot-subtle);
+  --color-spot-surface: var(--spot-surface);
+  /* フォント */
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
   --font-nunito: var(--font-nunito);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import "./globals.css";
 import { ServiceWorkerRegistration } from "@/components/ServiceWorkerRegistration";
 import { ToastProvider } from "@/components/Toast";
 import { SplashScreenWrapper } from "@/components/SplashScreenWrapper";
+import { ThemeProvider } from "@/components/ThemeProvider";
 
 import { Zen_Old_Mincho, Inter, Roboto_Mono, Oswald, Orbitron, Noto_Sans_JP } from "next/font/google";
 
@@ -88,9 +89,11 @@ export default function RootLayout({
         />
         <ServiceWorkerRegistration />
         <SplashScreenWrapper />
-        <ToastProvider>
-          {children}
-        </ToastProvider>
+        <ThemeProvider>
+          <ToastProvider>
+            {children}
+          </ToastProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/components/ThemeProvider.test.tsx
+++ b/components/ThemeProvider.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from './ThemeProvider';
+
+// next-themes のモック
+const mockSetTheme = vi.fn();
+
+vi.mock('next-themes', () => ({
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="next-themes-provider">{children}</div>
+  ),
+  useTheme: () => ({
+    resolvedTheme: 'default',
+    setTheme: mockSetTheme,
+    theme: 'default',
+  }),
+}));
+
+// localStorageのモック
+const createLocalStorageMock = () => {
+  const store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => { store[key] = value; }),
+    removeItem: vi.fn((key: string) => { delete store[key]; }),
+    clear: vi.fn(),
+  };
+};
+
+describe('ThemeProvider', () => {
+  let localStorageMock: ReturnType<typeof createLocalStorageMock>;
+
+  beforeEach(() => {
+    localStorageMock = createLocalStorageMock();
+    vi.stubGlobal('localStorage', localStorageMock);
+    mockSetTheme.mockClear();
+  });
+
+  it('子要素を正しくレンダリングする', () => {
+    render(
+      <ThemeProvider>
+        <div data-testid="child">Hello</div>
+      </ThemeProvider>
+    );
+
+    expect(screen.getByTestId('child')).toBeDefined();
+    expect(screen.getByText('Hello')).toBeDefined();
+  });
+
+  it('NextThemesProvider でラップされる', () => {
+    render(
+      <ThemeProvider>
+        <span>Content</span>
+      </ThemeProvider>
+    );
+
+    expect(screen.getByTestId('next-themes-provider')).toBeDefined();
+  });
+
+  it('旧localStorage キーからマイグレーションする（christmas=true）', async () => {
+    localStorageMock.setItem('roastplus_christmas_mode', 'true');
+
+    render(
+      <ThemeProvider>
+        <span>Content</span>
+      </ThemeProvider>
+    );
+
+    // useEffectが実行されるまで待つ
+    await vi.waitFor(() => {
+      expect(mockSetTheme).toHaveBeenCalledWith('christmas');
+    });
+
+    // 旧キーがクリーンアップされている
+    expect(localStorageMock.removeItem).toHaveBeenCalledWith('roastplus_christmas_mode');
+    expect(localStorageMock.removeItem).toHaveBeenCalledWith('roastplus_christmas_mode_migrated');
+  });
+
+  it('マイグレーション済みの場合は再実行しない', async () => {
+    localStorageMock.setItem('roastplus_theme_migrated_v2', 'true');
+    localStorageMock.setItem('roastplus_christmas_mode', 'true');
+
+    render(
+      <ThemeProvider>
+        <span>Content</span>
+      </ThemeProvider>
+    );
+
+    // setTheme が呼ばれないことを確認（少し待ってから）
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(mockSetTheme).not.toHaveBeenCalled();
+  });
+
+  it('旧キーが false の場合はテーマ変更しない', async () => {
+    localStorageMock.setItem('roastplus_christmas_mode', 'false');
+
+    render(
+      <ThemeProvider>
+        <span>Content</span>
+      </ThemeProvider>
+    );
+
+    // マイグレーション完了を待つ
+    await vi.waitFor(() => {
+      expect(localStorageMock.setItem).toHaveBeenCalledWith('roastplus_theme_migrated_v2', 'true');
+    });
+
+    // christmas テーマには切り替えない
+    expect(mockSetTheme).not.toHaveBeenCalledWith('christmas');
+  });
+});

--- a/components/ThemeProvider.tsx
+++ b/components/ThemeProvider.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect } from 'react';
+import { ThemeProvider as NextThemesProvider, useTheme } from 'next-themes';
+
+const OLD_STORAGE_KEY = 'roastplus_christmas_mode';
+const OLD_MIGRATION_FLAG = 'roastplus_christmas_mode_migrated';
+const MIGRATION_V2_FLAG = 'roastplus_theme_migrated_v2';
+
+/**
+ * 旧localStorage (roastplus_christmas_mode) から next-themes への
+ * 一回限りのマイグレーションを行うコンポーネント
+ */
+function ThemeMigration({ children }: { children: React.ReactNode }) {
+  const { setTheme } = useTheme();
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const migrated = localStorage.getItem(MIGRATION_V2_FLAG);
+    if (migrated) return;
+
+    // 旧キーの値を読み取り、next-themes に引き継ぐ
+    const oldValue = localStorage.getItem(OLD_STORAGE_KEY);
+    if (oldValue === 'true') {
+      setTheme('christmas');
+    }
+
+    // 旧キーをクリーンアップ
+    localStorage.removeItem(OLD_STORAGE_KEY);
+    localStorage.removeItem(OLD_MIGRATION_FLAG);
+    localStorage.setItem(MIGRATION_V2_FLAG, 'true');
+  }, [setTheme]);
+
+  return <>{children}</>;
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <NextThemesProvider
+      attribute="data-theme"
+      defaultTheme="default"
+      themes={['default', 'christmas']}
+      storageKey="roastplus_theme"
+      enableSystem={false}
+      disableTransitionOnChange
+    >
+      <ThemeMigration>{children}</ThemeMigration>
+    </NextThemesProvider>
+  );
+}

--- a/hooks/useChristmasMode.ts
+++ b/hooks/useChristmasMode.ts
@@ -1,43 +1,29 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useCallback } from 'react';
+import { useTheme } from 'next-themes';
 
-const STORAGE_KEY = 'roastplus_christmas_mode';
-const MIGRATION_FLAG_KEY = 'roastplus_christmas_mode_migrated';
-
+/**
+ * クリスマスモードの切り替えフック（後方互換性ラッパー）
+ *
+ * 内部で next-themes の useTheme を使用し、
+ * data-theme 属性の切り替え + CSS変数によるテーマ適用を行う。
+ *
+ * 既存の isChristmasMode API はそのまま維持するため、
+ * 既存コードを修正せずにテーマシステムに移行可能。
+ */
 export function useChristmasMode() {
-    const [isChristmasMode, setIsChristmasMode] = useState<boolean>(() => {
-        if (typeof window === 'undefined') return false;
+    const { resolvedTheme, setTheme } = useTheme();
 
-        // マイグレーション処理（一度だけ実行）
-        const migrationDone = localStorage.getItem(MIGRATION_FLAG_KEY) === 'true';
+    const isChristmasMode = resolvedTheme === 'christmas';
 
-        if (!migrationDone) {
-            // 既存のlocalStorageキーを削除して、新しいデフォルト（オフ）を適用
-            // これにより、デプロイ後に既存端末でもオフになる
-            if (localStorage.getItem(STORAGE_KEY) !== null) {
-                localStorage.removeItem(STORAGE_KEY);
-            }
-            localStorage.setItem(MIGRATION_FLAG_KEY, 'true');
-            return false;
-        }
-
-        // マイグレーション済みの場合は、localStorageから読み込む
-        const stored = localStorage.getItem(STORAGE_KEY);
-        return stored === null ? false : stored === 'true';
-    });
-
-    // 切り替え
     const setChristmasMode = useCallback((enabled: boolean) => {
-        if (typeof window !== 'undefined') {
-            localStorage.setItem(STORAGE_KEY, String(enabled));
-            setIsChristmasMode(enabled);
-        }
-    }, []);
+        setTheme(enabled ? 'christmas' : 'default');
+    }, [setTheme]);
 
     const toggleChristmasMode = useCallback(() => {
-        setChristmasMode(!isChristmasMode);
-    }, [isChristmasMode, setChristmasMode]);
+        setTheme(isChristmasMode ? 'default' : 'christmas');
+    }, [isChristmasMode, setTheme]);
 
     return {
         isChristmasMode,

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "framer-motion": "^12.23.24",
         "lottie-react": "^2.4.1",
         "next": "^16.0.8",
+        "next-themes": "^0.4.6",
         "openai": "^6.16.0",
         "phosphor-react": "^1.4.1",
         "react": "19.2.0",
@@ -9652,6 +9653,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "framer-motion": "^12.23.24",
     "lottie-react": "^2.4.1",
     "next": "^16.0.8",
+    "next-themes": "^0.4.6",
     "openai": "^6.16.0",
     "phosphor-react": "^1.4.1",
     "react": "19.2.0",


### PR DESCRIPTION
## 概要

`next-themes` + Tailwind CSS v4 CSS変数によるスケーラブルなテーマシステム基盤を構築。

現在の `isChristmasMode: boolean` パターン（1,150+箇所のハードコード色）を段階的にCSS変数に置き換えるためのインフラを整備。

## 変更内容

### 新規ファイル
- `components/ThemeProvider.tsx` - next-themes ラッパー + 旧localStorage マイグレーション
- `components/ThemeProvider.test.tsx` - ThemeProvider テスト（5テスト）

### 変更ファイル
- `app/globals.css` - `@layer theme` でセマンティックCSS変数トークン定義、`@theme inline` をCSS変数参照に更新
- `app/layout.tsx` - `<ThemeProvider>` でアプリ全体をラップ
- `hooks/useChristmasMode.ts` - 内部を next-themes `useTheme` に委譲（API変更なし）
- `hooks/useChristmasMode.test.ts` - next-themes モックに書き換え（7テスト）
- `package.json` / `package-lock.json` - `next-themes` 追加

### 利用可能な新Tailwindユーティリティ

| カテゴリ | ユーティリティ | 用途 |
|---------|---------------|------|
| 背景 | `bg-page`, `bg-surface`, `bg-overlay`, `bg-ground`, `bg-field` | ページ/カード/モーダル/セクション/入力 |
| テキスト | `text-ink`, `text-ink-sub`, `text-ink-muted` | 本文/補足/ヒント |
| ボーダー | `border-edge`, `border-edge-strong` | 通常/強調 |
| アクセント | `text-spot`, `bg-spot`, `bg-spot-subtle` | ハイライト |

これらは `data-theme` 属性に応じて自動で色が切り替わります。

### 後方互換性
- `useChristmasMode()` のAPIは完全に同一（`isChristmasMode`, `setChristmasMode`, `toggleChristmasMode`）
- 既存の `bg-bg-global`, `bg-bg-card`, `bg-bg-section` もCSS変数参照に更新 → 自動テーマ対応

## テスト
- [x] lint 通過（0 errors）
- [x] build 成功（52ページ）
- [x] 全811テスト合格（新規12テスト含む）

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)
