### PR TITLE
refactor(#137): 作業進捗ページの共通UI化とテーマシステム対応

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,3 +81,17 @@ jobs:
           NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID }}
           NEXT_PUBLIC_FIREBASE_APP_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_APP_ID }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+  ci-gate:
+    name: CI Gate
+    runs-on: ubuntu-latest
+    needs: [lint, test, e2e, build]
+    if: always()
+    steps:
+      - name: Check all jobs
+        run: |
+          if [[ "${{ needs.lint.result }}" != "success" || "${{ needs.test.result }}" != "success" || "${{ needs.e2e.result }}" != "success" || "${{ needs.build.result }}" != "success" ]]; then
+            echo "One or more jobs failed"
+            exit 1
+          fi
+          echo "All jobs passed"

--- a/app/progress/components/ArchivedView.tsx
+++ b/app/progress/components/ArchivedView.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { HiArchive } from 'react-icons/hi';
+import { Button } from '@/components/ui';
 import type { WorkProgress } from '@/types';
 import { calculateProgressPercentage, formatAmount, extractUnit } from '../utils';
 
@@ -18,43 +19,43 @@ export function ArchivedView({ archivedWorkProgressesByDate, onUnarchive }: Arch
   return (
     <div className="space-y-8 animate-fade-in">
       {archivedWorkProgressesByDate.length === 0 ? (
-        <div className="text-center py-12 bg-white rounded-xl shadow-sm border border-gray-200">
-          <div className="text-gray-300 mb-4">
+        <div className="text-center py-12 bg-surface rounded-xl shadow-card border border-edge">
+          <div className="text-ink-muted mb-4">
             <HiArchive className="h-16 w-16 mx-auto" />
           </div>
-          <p className="text-gray-500 font-medium">アーカイブされた作業はありません</p>
+          <p className="text-ink-sub font-medium">アーカイブされた作業はありません</p>
         </div>
       ) : (
         archivedWorkProgressesByDate.map((group) => (
-          <div key={group.date} className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
-            <div className="bg-gray-50 px-4 py-3 border-b border-gray-200">
-              <h2 className="font-bold text-gray-800 flex items-center gap-2">
-                <span className="text-amber-600">{new Date(group.date).toLocaleDateString('ja-JP', { year: 'numeric', month: 'long', day: 'numeric' })}</span>
-                <span className="text-xs font-normal text-gray-500 bg-white px-2 py-0.5 rounded-full border border-gray-200">
+          <div key={group.date} className="bg-surface rounded-xl shadow-card border border-edge overflow-hidden">
+            <div className="bg-ground px-4 py-3 border-b border-edge">
+              <h2 className="font-bold text-ink flex items-center gap-2">
+                <span className="text-spot">{new Date(group.date).toLocaleDateString('ja-JP', { year: 'numeric', month: 'long', day: 'numeric' })}</span>
+                <span className="text-xs font-normal text-ink-sub bg-surface px-2 py-0.5 rounded-full border border-edge">
                   {group.workProgresses.length}件
                 </span>
               </h2>
             </div>
-            <div className="divide-y divide-gray-100">
+            <div className="divide-y divide-edge">
               {group.workProgresses.map((wp) => {
                 const unit = extractUnit(wp.weight);
                 return (
-                  <div key={wp.id} className="p-4 hover:bg-gray-50 transition-colors">
+                  <div key={wp.id} className="p-4 hover:bg-ground transition-colors">
                     <div className="flex justify-between items-start gap-4">
                       <div className="flex-1">
                         <div className="flex items-center gap-2 mb-1">
-                          <h3 className="font-bold text-gray-800">{wp.taskName || '名称未設定'}</h3>
+                          <h3 className="font-bold text-ink">{wp.taskName || '名称未設定'}</h3>
                           {wp.groupName && (
-                            <span className="text-[10px] px-1.5 py-0.5 bg-gray-100 text-gray-600 rounded">
+                            <span className="text-[10px] px-1.5 py-0.5 bg-ground text-ink-sub rounded border border-edge">
                               {wp.groupName}
                             </span>
                           )}
                         </div>
-                        <div className="text-sm text-gray-600 mb-2">
+                        <div className="text-sm text-ink-sub mb-2">
                           {wp.targetAmount !== undefined ? (
                             <span>
                               {formatAmount(wp.currentAmount || 0, unit)} / {formatAmount(wp.targetAmount, unit)}{unit}
-                              <span className="text-gray-400 mx-2">|</span>
+                              <span className="text-ink-muted mx-2">|</span>
                               達成率: {calculateProgressPercentage(wp).toFixed(0)}%
                             </span>
                           ) : (
@@ -62,17 +63,18 @@ export function ArchivedView({ archivedWorkProgressesByDate, onUnarchive }: Arch
                           )}
                         </div>
                         {wp.memo && (
-                          <p className="text-xs text-gray-500 bg-gray-50 p-2 rounded border border-gray-100 inline-block max-w-full">
+                          <p className="text-xs text-ink-sub bg-ground p-2 rounded border border-edge inline-block max-w-full">
                             {wp.memo}
                           </p>
                         )}
                       </div>
-                      <button
+                      <Button
+                        variant="outline"
+                        size="sm"
                         onClick={() => onUnarchive(wp.id)}
-                        className="px-3 py-1.5 text-xs font-medium text-amber-600 bg-amber-50 border border-amber-200 rounded hover:bg-amber-100 transition-colors whitespace-nowrap"
                       >
                         戻す
-                      </button>
+                      </Button>
                     </div>
                   </div>
                 );

--- a/app/progress/components/FilterDialog.tsx
+++ b/app/progress/components/FilterDialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { HiX, HiSearch } from 'react-icons/hi';
-import { Button } from '@/components/ui';
+import { HiX } from 'react-icons/hi';
+import { Button, IconButton, Input, Select } from '@/components/ui';
 import type { WorkProgressStatus } from '@/types';
 
 type SortOption = 'createdAt' | 'beanName' | 'status';
@@ -24,31 +24,26 @@ export function FilterDialog({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 animate-fade-in">
-      <div className="bg-white rounded-2xl shadow-xl w-full max-w-sm overflow-hidden animate-scale-in">
-        <div className="px-6 py-4 border-b border-gray-100 flex justify-between items-center bg-gray-50">
-          <h3 className="font-bold text-gray-800 text-lg">表示設定</h3>
-          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 p-1 rounded-full hover:bg-gray-200 transition-colors">
-            <HiX className="h-6 w-6" />
-          </button>
+      <div className="bg-overlay rounded-2xl shadow-xl w-full max-w-sm overflow-hidden animate-scale-in border border-edge">
+        <div className="px-6 py-4 border-b border-edge flex justify-between items-center bg-ground">
+          <h3 className="font-bold text-ink text-lg">表示設定</h3>
+          <IconButton variant="ghost" size="md" rounded onClick={onClose} aria-label="閉じる">
+            <HiX className="h-5 w-5" />
+          </IconButton>
         </div>
 
         <div className="p-6 space-y-6">
           <div>
-            <label className="block text-sm font-bold text-gray-700 mb-2">キーワード検索</label>
-            <div className="relative">
-              <HiSearch className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 h-5 w-5" />
-              <input
-                type="text"
-                value={filterTaskName}
-                onChange={(e) => setFilterTaskName(e.target.value)}
-                className="w-full pl-10 pr-4 py-2.5 rounded-lg border border-gray-300 focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all text-gray-900 bg-white"
-                placeholder="作業名で検索..."
-              />
-            </div>
+            <Input
+              label="キーワード検索"
+              value={filterTaskName}
+              onChange={(e) => setFilterTaskName(e.target.value)}
+              placeholder="作業名で検索..."
+            />
           </div>
 
           <div>
-            <label className="block text-sm font-bold text-gray-700 mb-2">ステータス</label>
+            <label className="block text-sm font-medium text-ink mb-2">ステータス</label>
             <div className="flex flex-wrap gap-2">
               {[
                 { value: 'all', label: 'すべて' },
@@ -60,8 +55,8 @@ export function FilterDialog({
                   key={option.value}
                   onClick={() => setFilterStatus(option.value as WorkProgressStatus | 'all')}
                   className={`px-3 py-1.5 text-sm font-medium rounded-lg border transition-all ${filterStatus === option.value
-                    ? 'bg-amber-50 text-amber-700 border-amber-300 ring-1 ring-amber-300'
-                    : 'bg-white text-gray-600 border-gray-200 hover:bg-gray-50'
+                    ? 'bg-spot-subtle text-spot border-spot ring-1 ring-spot'
+                    : 'bg-surface text-ink-sub border-edge hover:bg-ground'
                     }`}
                 >
                   {option.label}
@@ -71,20 +66,20 @@ export function FilterDialog({
           </div>
 
           <div>
-            <label className="block text-sm font-bold text-gray-700 mb-2">並び替え</label>
-            <select
+            <Select
+              label="並び替え"
               value={sortOption}
               onChange={(e) => setSortOption(e.target.value as SortOption)}
-              className="w-full px-4 py-2.5 rounded-lg border border-gray-300 focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all text-gray-900 bg-white"
-            >
-              <option value="createdAt">作成日順</option>
-              <option value="beanName">名前順</option>
-              <option value="status">ステータス順</option>
-            </select>
+              options={[
+                { value: 'createdAt', label: '作成日順' },
+                { value: 'beanName', label: '名前順' },
+                { value: 'status', label: 'ステータス順' },
+              ]}
+            />
           </div>
         </div>
 
-        <div className="bg-gray-50 px-6 py-4 border-t border-gray-100">
+        <div className="bg-ground px-6 py-4 border-t border-edge">
           <Button
             variant="primary"
             size="md"

--- a/app/progress/components/GroupFormDialog.tsx
+++ b/app/progress/components/GroupFormDialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { Button } from '@/components/ui';
+import { Button, Input } from '@/components/ui';
 
 interface GroupFormDialogProps {
   isOpen: boolean;
@@ -20,9 +20,9 @@ export function GroupFormDialog({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 animate-fade-in">
-      <div className="bg-white rounded-2xl shadow-xl w-full max-w-sm overflow-hidden animate-scale-in">
-        <div className="px-6 py-4 border-b border-gray-100 bg-gray-50">
-          <h3 className="font-bold text-gray-800 text-lg">
+      <div className="bg-overlay rounded-2xl shadow-xl w-full max-w-sm overflow-hidden animate-scale-in border border-edge">
+        <div className="px-6 py-4 border-b border-edge bg-ground">
+          <h3 className="font-bold text-ink text-lg">
             {isEditing ? 'グループ名を編集' : '新しいグループを作成'}
           </h3>
         </div>
@@ -34,12 +34,10 @@ export function GroupFormDialog({
           className="p-6"
         >
           <div className="mb-6">
-            <label className="block text-sm font-bold text-gray-700 mb-1.5">グループ名</label>
-            <input
-              type="text"
+            <Input
+              label="グループ名"
               value={groupName}
               onChange={(e) => setGroupName(e.target.value)}
-              className="w-full px-4 py-2.5 rounded-lg border border-gray-300 focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all text-gray-900 bg-white"
               placeholder="例: ブラジル No.2"
               autoFocus
               required

--- a/app/progress/components/ModeSelectDialog.tsx
+++ b/app/progress/components/ModeSelectDialog.tsx
@@ -13,10 +13,10 @@ interface ModeSelectDialogProps {
 export function ModeSelectDialog({ onClose, onAddWork, onAddGroup }: ModeSelectDialogProps) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 animate-fade-in">
-      <div className="bg-white rounded-2xl shadow-xl w-full max-w-sm overflow-hidden animate-scale-in">
+      <div className="bg-overlay rounded-2xl shadow-xl w-full max-w-sm overflow-hidden animate-scale-in border border-edge">
         <div className="p-6 text-center">
-          <h3 className="text-xl font-bold text-gray-800 mb-2">追加する項目を選択</h3>
-          <p className="text-gray-500 text-sm mb-6">
+          <h3 className="text-xl font-bold text-ink mb-2">追加する項目を選択</h3>
+          <p className="text-ink-sub text-sm mb-6">
             新しい作業を追加するか、作業をまとめるグループを作成するか選択してください。
           </p>
           <div className="space-y-3">
@@ -33,26 +33,28 @@ export function ModeSelectDialog({ onClose, onAddWork, onAddGroup }: ModeSelectD
               <span>作業を追加</span>
             </Button>
             <Button
-              variant="secondary"
+              variant="surface"
               size="md"
               fullWidth
               onClick={onAddGroup}
-              className="!bg-gray-50 hover:!bg-gray-100 !text-gray-700 !border !border-gray-200 !rounded-xl !py-3"
+              className="!rounded-xl !py-3"
             >
-              <div className="bg-white p-2 rounded-full shadow-sm mr-3">
+              <div className="bg-ground p-2 rounded-full shadow-sm mr-3">
                 <HiOutlineCollection className="h-5 w-5" />
               </div>
               <span>グループを作成</span>
             </Button>
           </div>
         </div>
-        <div className="bg-gray-50 px-6 py-4 border-t border-gray-100">
-          <button
+        <div className="bg-ground px-6 py-4 border-t border-edge">
+          <Button
+            variant="ghost"
+            size="md"
+            fullWidth
             onClick={onClose}
-            className="w-full py-2 text-gray-600 font-medium hover:text-gray-800 transition-colors"
           >
             キャンセル
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/app/progress/components/NormalView.tsx
+++ b/app/progress/components/NormalView.tsx
@@ -3,7 +3,7 @@
 import { HiPlus, HiSearch, HiPencil, HiTrash, HiArchive } from 'react-icons/hi';
 import { HiOutlineCollection } from 'react-icons/hi';
 import { MdTimeline } from 'react-icons/md';
-import { Button } from '@/components/ui';
+import { Button, IconButton } from '@/components/ui';
 import { WorkProgressCard } from '@/components/work-progress/WorkProgressCard';
 import type { WorkProgress, WorkProgressStatus } from '@/types';
 import {
@@ -70,11 +70,11 @@ export function NormalView({
       {/* エンプティステート */}
       {showEmptyState && (
         <div className="flex flex-col items-center justify-center py-12 sm:py-20 text-center">
-          <div className="bg-white p-6 rounded-full shadow-lg mb-6">
-            <MdTimeline className="h-16 w-16 text-amber-500" />
+          <div className="bg-surface p-6 rounded-full shadow-lg mb-6 border border-edge">
+            <MdTimeline className="h-16 w-16 text-spot" />
           </div>
-          <h2 className="text-xl sm:text-2xl font-bold text-gray-800 mb-2">作業進捗を管理しましょう</h2>
-          <p className="text-gray-600 mb-8 max-w-md mx-auto">
+          <h2 className="text-xl sm:text-2xl font-bold text-ink mb-2">作業進捗を管理しましょう</h2>
+          <p className="text-ink-sub mb-8 max-w-md mx-auto">
             日々の作業の進捗状況を記録・可視化できます。<br />
             まずは新しい作業を追加してみましょう。
           </p>
@@ -101,7 +101,7 @@ export function NormalView({
           {archivedCount > 0 && (
             <button
               onClick={onShowArchived}
-              className="mt-8 text-gray-500 hover:text-gray-700 text-sm flex items-center gap-1"
+              className="mt-8 text-ink-muted hover:text-ink-sub text-sm flex items-center gap-1 transition-colors"
             >
               <HiArchive className="h-4 w-4" />
               アーカイブ済みの作業を見る
@@ -113,13 +113,13 @@ export function NormalView({
       {/* フィルタ適用時のエンプティステート */}
       {isEmpty && hasFilters && (
         <div className="flex flex-col items-center justify-center py-12 text-center">
-          <div className="text-gray-400 mb-4">
+          <div className="text-ink-muted mb-4">
             <HiSearch className="h-12 w-12 mx-auto" />
           </div>
-          <p className="text-gray-600 font-medium">条件に一致する作業が見つかりませんでした</p>
+          <p className="text-ink-sub font-medium">条件に一致する作業が見つかりませんでした</p>
           <button
             onClick={onClearFilters}
-            className="mt-4 text-amber-600 hover:text-amber-700 font-medium"
+            className="mt-4 text-spot hover:text-spot-hover font-medium transition-colors"
           >
             フィルタを解除
           </button>
@@ -129,30 +129,34 @@ export function NormalView({
       {/* グループ化された作業 */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
         {groupedWorkProgresses.groups.map((group) => (
-          <div key={group.groupName} className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
-            <div className="bg-gray-50 px-4 py-3 border-b border-gray-200 flex justify-between items-center">
+          <div key={group.groupName} className="bg-surface rounded-xl shadow-card border border-edge overflow-hidden">
+            <div className="bg-ground px-4 py-3 border-b border-edge flex justify-between items-center">
               <div className="flex items-center gap-2">
-                <HiOutlineCollection className="text-gray-400 h-5 w-5" />
-                <h2 className="font-bold text-gray-800 text-lg">{group.groupName}</h2>
-                <span className="text-xs font-medium bg-gray-200 text-gray-600 px-2 py-0.5 rounded-full">
+                <HiOutlineCollection className="text-ink-muted h-5 w-5" />
+                <h2 className="font-bold text-ink text-lg">{group.groupName}</h2>
+                <span className="text-xs font-medium bg-ground text-ink-sub px-2 py-0.5 rounded-full border border-edge">
                   {group.workProgresses.length}件
                 </span>
               </div>
               <div className="flex items-center gap-1">
-                <button
+                <IconButton
+                  variant="default"
+                  size="md"
                   onClick={() => onEditGroupName(group.groupName)}
-                  className="p-2 text-gray-400 hover:text-amber-600 hover:bg-amber-50 rounded-full transition-colors"
                   title="グループ名を編集"
+                  rounded
                 >
                   <HiPencil className="h-4 w-4" />
-                </button>
-                <button
+                </IconButton>
+                <IconButton
+                  variant="danger"
+                  size="md"
                   onClick={() => onDeleteGroup(group.groupName)}
-                  className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-full transition-colors"
                   title="グループを削除"
+                  rounded
                 >
                   <HiTrash className="h-4 w-4" />
-                </button>
+                </IconButton>
               </div>
             </div>
 
@@ -183,7 +187,7 @@ export function NormalView({
             <div className="px-4 pb-4">
               <button
                 onClick={() => onAddToGroup(group.groupName)}
-                className="w-full py-2 border-2 border-dashed border-gray-200 rounded-lg text-gray-400 hover:text-amber-600 hover:border-amber-300 hover:bg-amber-50 transition-all flex items-center justify-center gap-2 text-sm font-medium"
+                className="w-full py-2 border-2 border-dashed border-edge rounded-lg text-ink-muted hover:text-spot hover:border-spot-subtle hover:bg-spot-surface transition-all flex items-center justify-center gap-2 text-sm font-medium"
               >
                 <HiPlus className="h-4 w-4" />
                 作業を追加
@@ -197,7 +201,7 @@ export function NormalView({
       {groupedWorkProgresses.ungrouped.length > 0 && (
         <div className="mb-8">
           {groupedWorkProgresses.groups.length > 0 && (
-            <h2 className="text-lg font-bold text-gray-700 mb-4 px-2 border-l-4 border-gray-400">その他の作業</h2>
+            <h2 className="text-lg font-bold text-ink-sub mb-4 px-2 border-l-4 border-ink-muted">その他の作業</h2>
           )}
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {groupedWorkProgresses.ungrouped.map((wp) => (

--- a/app/progress/components/ProgressHeader.tsx
+++ b/app/progress/components/ProgressHeader.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import Link from 'next/link';
-import { HiArrowLeft, HiPlus, HiFilter, HiArchive } from 'react-icons/hi';
+import { HiPlus, HiFilter, HiArchive } from 'react-icons/hi';
 import { MdTimeline } from 'react-icons/md';
-import { Button } from '@/components/ui';
+import { Button, BackLink } from '@/components/ui';
 
 interface ProgressHeaderProps {
   viewMode: 'normal' | 'archived';
@@ -29,27 +28,20 @@ export function ProgressHeader({
       <div className="grid grid-cols-2 sm:grid-cols-3 items-center mb-4">
         {/* 左側: 戻る */}
         <div className="flex justify-start">
-          <Link
-            href="/"
-            className="px-3 py-2 text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded transition-colors flex items-center justify-center min-h-[44px] min-w-[44px]"
-            title="戻る"
-            aria-label="戻る"
-          >
-            <HiArrowLeft className="h-6 w-6 flex-shrink-0" />
-          </Link>
+          <BackLink href="/" variant="icon-only" />
         </div>
 
         {/* 中央: タイトル */}
         <div className="hidden sm:flex justify-center items-center gap-2 sm:gap-4 min-w-0">
           {viewMode === 'archived' ? (
             <>
-              <HiArchive className="h-8 w-8 sm:h-10 sm:w-10 text-amber-600 flex-shrink-0" />
-              <h1 className="text-lg sm:text-xl lg:text-3xl font-bold text-gray-800 whitespace-nowrap">アーカイブ済み作業</h1>
+              <HiArchive className="h-8 w-8 sm:h-10 sm:w-10 text-spot flex-shrink-0" />
+              <h1 className="text-lg sm:text-xl lg:text-3xl font-bold text-ink whitespace-nowrap">アーカイブ済み作業</h1>
             </>
           ) : (
             <>
-              <MdTimeline className="h-8 w-8 sm:h-10 sm:w-10 text-amber-600 flex-shrink-0" />
-              <h1 className="text-lg sm:text-xl lg:text-3xl font-bold text-gray-800 whitespace-nowrap">作業進捗</h1>
+              <MdTimeline className="h-8 w-8 sm:h-10 sm:w-10 text-spot flex-shrink-0" />
+              <h1 className="text-lg sm:text-xl lg:text-3xl font-bold text-ink whitespace-nowrap">作業進捗</h1>
             </>
           )}
         </div>
@@ -59,10 +51,9 @@ export function ProgressHeader({
           {viewMode === 'normal' && !showEmptyState && (
             <>
               <Button
-                variant="outline"
+                variant="surface"
                 size="sm"
                 onClick={onShowFilter}
-                className="shadow-md !bg-white !text-gray-700 hover:!bg-gray-50"
                 aria-label="フィルタと並び替え"
                 title="フィルタと並び替え"
               >
@@ -71,10 +62,9 @@ export function ProgressHeader({
               </Button>
               {hasArchivedItems && (
                 <Button
-                  variant="outline"
+                  variant="surface"
                   size="sm"
                   onClick={onShowArchived}
-                  className="shadow-md !bg-white !text-gray-700 hover:!bg-gray-50"
                   aria-label="アーカイブ一覧"
                   title="アーカイブ一覧"
                 >
@@ -94,10 +84,9 @@ export function ProgressHeader({
           )}
           {viewMode === 'archived' && (
             <Button
-              variant="secondary"
+              variant="surface"
               size="sm"
               onClick={onBackToNormal}
-              className="shadow-sm !bg-white !text-gray-700 !border !border-gray-300 hover:!bg-gray-50"
             >
               <MdTimeline className="h-4 w-4" />
               <span className="hidden sm:inline ml-2">一覧に戻る</span>
@@ -110,13 +99,13 @@ export function ProgressHeader({
       <div className="sm:hidden flex justify-center items-center gap-2 mb-4">
         {viewMode === 'archived' ? (
           <>
-            <HiArchive className="h-6 w-6 text-amber-600 flex-shrink-0" />
-            <h1 className="text-lg font-bold text-gray-800">アーカイブ済み作業</h1>
+            <HiArchive className="h-6 w-6 text-spot flex-shrink-0" />
+            <h1 className="text-lg font-bold text-ink">アーカイブ済み作業</h1>
           </>
         ) : (
           <>
-            <MdTimeline className="h-6 w-6 text-amber-600 flex-shrink-0" />
-            <h1 className="text-lg font-bold text-gray-800">作業進捗</h1>
+            <MdTimeline className="h-6 w-6 text-spot flex-shrink-0" />
+            <h1 className="text-lg font-bold text-ink">作業進捗</h1>
           </>
         )}
       </div>

--- a/app/progress/components/WorkProgressFormDialog.tsx
+++ b/app/progress/components/WorkProgressFormDialog.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { HiX, HiTrash } from 'react-icons/hi';
-import { Button } from '@/components/ui';
+import { Button, IconButton, Input, Select, Textarea } from '@/components/ui';
 import { extractTargetAmount, extractUnitFromWeight } from '@/lib/firestore';
 import type { WorkProgressStatus } from '@/types';
 import type { WorkProgressInput } from '@/hooks/useWorkProgressActions';
@@ -67,97 +67,85 @@ export function WorkProgressFormDialog({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 animate-fade-in">
-      <div className="bg-white rounded-2xl shadow-xl w-full max-w-md overflow-hidden flex flex-col max-h-[90vh] animate-scale-in">
-        <div className="px-6 py-4 border-b border-gray-100 flex justify-between items-center bg-gray-50">
-          <h3 className="font-bold text-gray-800 text-lg">
+      <div className="bg-overlay rounded-2xl shadow-xl w-full max-w-md overflow-hidden flex flex-col max-h-[90vh] animate-scale-in border border-edge">
+        <div className="px-6 py-4 border-b border-edge flex justify-between items-center bg-ground">
+          <h3 className="font-bold text-ink text-lg">
             {isEditing ? '作業を編集' : '新しい作業を追加'}
           </h3>
-          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 p-1 rounded-full hover:bg-gray-200 transition-colors">
-            <HiX className="h-6 w-6" />
-          </button>
+          <IconButton variant="ghost" size="md" rounded onClick={onClose} aria-label="閉じる">
+            <HiX className="h-5 w-5" />
+          </IconButton>
         </div>
 
         <form onSubmit={handleSubmit} className="p-6 overflow-y-auto flex-1">
           <div className="space-y-5">
-            <div>
-              <label className="block text-sm font-bold text-gray-700 mb-1.5">グループ名 (任意)</label>
-              <input
-                type="text"
-                value={formData.groupName}
-                onChange={(e) => setFormData({ ...formData, groupName: e.target.value })}
-                className="w-full px-4 py-2.5 rounded-lg border border-gray-300 focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all text-gray-900 bg-white"
-                placeholder="例: ブラジル No.2"
-              />
-            </div>
+            <Input
+              label="グループ名 (任意)"
+              value={formData.groupName}
+              onChange={(e) => setFormData({ ...formData, groupName: e.target.value })}
+              placeholder="例: ブラジル No.2"
+            />
+
+            <Input
+              label="作業名"
+              value={formData.taskName}
+              onChange={(e) => setFormData({ ...formData, taskName: e.target.value })}
+              placeholder="例: ハンドピック"
+              required
+            />
 
             <div>
-              <label className="block text-sm font-bold text-gray-700 mb-1.5">作業名</label>
-              <input
-                type="text"
-                value={formData.taskName}
-                onChange={(e) => setFormData({ ...formData, taskName: e.target.value })}
-                className="w-full px-4 py-2.5 rounded-lg border border-gray-300 focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all text-gray-900 bg-white"
-                placeholder="例: ハンドピック"
-                required
-              />
-            </div>
-
-            <div>
-              <label className="block text-sm font-bold text-gray-700 mb-1.5">目標量 (任意)</label>
+              <label className="block text-sm font-medium text-ink mb-2">目標量 (任意)</label>
               <div className="flex gap-2">
-                <input
+                <Input
                   type="number"
                   value={formData.targetAmount}
                   onChange={(e) => setFormData({ ...formData, targetAmount: e.target.value })}
-                  className="flex-1 px-4 py-2.5 rounded-lg border border-gray-300 focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all text-gray-900 bg-white"
                   placeholder="数値"
                   step="0.1"
                   min="0"
+                  className="flex-1"
                 />
-                <select
+                <Select
                   value={formData.targetUnit}
                   onChange={(e) => setFormData({ ...formData, targetUnit: e.target.value })}
-                  className="px-4 py-2.5 rounded-lg border border-gray-300 focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all text-gray-900 bg-white"
-                >
-                  <option value="">単位なし</option>
-                  <option value="kg">kg</option>
-                  <option value="g">g</option>
-                  <option value="個">個</option>
-                  <option value="枚">枚</option>
-                  <option value="袋">袋</option>
-                  <option value="箱">箱</option>
-                </select>
+                  options={[
+                    { value: '', label: '単位なし' },
+                    { value: 'kg', label: 'kg' },
+                    { value: 'g', label: 'g' },
+                    { value: '個', label: '個' },
+                    { value: '枚', label: '枚' },
+                    { value: '袋', label: '袋' },
+                    { value: '箱', label: '箱' },
+                  ]}
+                  className="w-28"
+                />
               </div>
-              <p className="text-xs text-gray-500 mt-1.5">
+              <p className="text-xs text-ink-muted mt-1.5">
                 ※ 数値と単位を入力すると進捗バーが表示されます（例: 10kg）。<br />
                 ※ 空欄の場合は完成数のみをカウントするモードになります。
               </p>
             </div>
 
-            <div>
-              <label className="block text-sm font-bold text-gray-700 mb-1.5">メモ (任意)</label>
-              <textarea
-                value={formData.memo}
-                onChange={(e) => setFormData({ ...formData, memo: e.target.value })}
-                className="w-full px-4 py-2.5 rounded-lg border border-gray-300 focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all resize-none text-gray-900 bg-white"
-                rows={3}
-                placeholder="備考があれば入力してください"
-              />
-            </div>
+            <Textarea
+              label="メモ (任意)"
+              value={formData.memo}
+              onChange={(e) => setFormData({ ...formData, memo: e.target.value })}
+              rows={3}
+              placeholder="備考があれば入力してください"
+            />
 
             {isEditing && (
-              <div>
-                <label className="block text-sm font-bold text-gray-700 mb-1.5">状態</label>
-                <select
-                  value={formData.status}
-                  onChange={(e) => setFormData({ ...formData, status: e.target.value as WorkProgressStatus })}
-                  className="w-full px-4 py-2.5 rounded-lg border border-gray-300 focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all text-gray-900 bg-white"
-                >
-                  <option value="pending">作業前</option>
-                  <option value="in_progress">作業中</option>
-                  <option value="completed">完了</option>
-                </select>
-              </div>
+              <Select
+                label="状態"
+                value={formData.status}
+                onChange={(e) => setFormData({ ...formData, status: e.target.value as WorkProgressStatus })}
+                options={[
+                  { value: 'pending', label: '作業前' },
+                  { value: 'in_progress', label: '作業中' },
+                  { value: 'completed', label: '完了' },
+                ]}
+              />
             )}
           </div>
 
@@ -168,7 +156,7 @@ export function WorkProgressFormDialog({
                 variant="danger"
                 size="md"
                 onClick={onDelete}
-                className="!bg-red-50 !text-red-600 hover:!bg-red-100 !rounded-xl"
+                className="!rounded-xl"
                 title="削除"
               >
                 <HiTrash className="h-5 w-5" />

--- a/app/progress/page.tsx
+++ b/app/progress/page.tsx
@@ -121,7 +121,7 @@ export default function ProgressPage() {
   if (!user) return <LoginPage />;
 
   return (
-    <div className="min-h-screen bg-gray-50 p-4 sm:p-6 lg:p-8">
+    <div className="min-h-screen bg-page p-4 sm:p-6 lg:p-8 transition-colors duration-1000">
       <ProgressHeader
         viewMode={viewMode}
         showEmptyState={showEmptyState}

--- a/app/progress/utils.ts
+++ b/app/progress/utils.ts
@@ -1,9 +1,9 @@
 import type { WorkProgress } from '@/types';
 
 export const getProgressBarColor = (percentage: number) => {
-  if (percentage >= 100) return 'bg-green-500';
-  if (percentage >= 50) return 'bg-amber-500';
-  return 'bg-gray-400';
+  if (percentage >= 100) return 'bg-success';
+  if (percentage >= 50) return 'bg-spot';
+  return 'bg-edge-strong';
 };
 
 export const calculateProgressPercentage = (wp: WorkProgress) => {

--- a/components/work-progress/ProgressHistoryEditDialog.tsx
+++ b/components/work-progress/ProgressHistoryEditDialog.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { HiX, HiCheck, HiTrash } from 'react-icons/hi';
+import { IconButton } from '@/components/ui';
 import { ProgressEntry } from '@/types';
 import { useToastContext } from '@/components/Toast';
 
@@ -40,7 +41,7 @@ export const ProgressHistoryEditDialog: React.FC<ProgressHistoryEditDialogProps>
 
     const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const value = e.target.value;
-        
+
         // `-` が入力された場合、現在の値から減算
         if (value === '-') {
             const step = isCountMode ? 1 : (unit === 'kg' ? 0.1 : 1);
@@ -48,7 +49,7 @@ export const ProgressHistoryEditDialog: React.FC<ProgressHistoryEditDialogProps>
             setAmount((currentVal - step).toString());
             return;
         }
-        
+
         setAmount(value);
     };
 
@@ -90,28 +91,25 @@ export const ProgressHistoryEditDialog: React.FC<ProgressHistoryEditDialogProps>
     return (
         <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/50 backdrop-blur-sm p-0 sm:p-4 transition-opacity duration-300">
             <div
-                className="bg-white w-full sm:max-w-md rounded-t-2xl sm:rounded-2xl shadow-xl overflow-hidden flex flex-col max-h-[90vh] animate-slide-up sm:animate-fade-in"
+                className="bg-overlay w-full sm:max-w-md rounded-t-2xl sm:rounded-2xl shadow-xl overflow-hidden flex flex-col max-h-[90vh] animate-slide-up sm:animate-fade-in border border-edge"
                 onClick={(e) => e.stopPropagation()}
             >
                 {/* Header */}
-                <div className="px-4 py-3 border-b border-gray-100 flex items-center justify-between bg-gray-50">
-                    <h3 className="font-bold text-gray-800 truncate pr-4">
+                <div className="px-4 py-3 border-b border-edge flex items-center justify-between bg-ground">
+                    <h3 className="font-bold text-ink truncate pr-4">
                         履歴を編集
                     </h3>
-                    <button
-                        onClick={onClose}
-                        className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-200 rounded-full transition-colors"
-                    >
+                    <IconButton variant="ghost" size="md" rounded onClick={onClose} aria-label="閉じる">
                         <HiX className="h-5 w-5" />
-                    </button>
+                    </IconButton>
                 </div>
 
                 <form onSubmit={handleSubmit} className="p-4 overflow-y-auto">
                     {/* Amount Display & Input */}
                     <div className="mb-6">
-                        <label className="block text-xs font-bold text-gray-500 uppercase tracking-wide mb-2">
-                            {isCountMode 
-                                ? '個数' 
+                        <label className="block text-xs font-bold text-ink-muted uppercase tracking-wide mb-2">
+                            {isCountMode
+                                ? '個数'
                                 : `量 (${unit || '個'})`}
                         </label>
                         <div className="flex items-center gap-2">
@@ -120,11 +118,11 @@ export const ProgressHistoryEditDialog: React.FC<ProgressHistoryEditDialogProps>
                                 value={amount}
                                 onChange={handleAmountChange}
                                 placeholder="0"
-                                className="flex-1 text-3xl font-bold text-gray-900 placeholder-gray-300 border-b-2 border-amber-500 focus:border-amber-600 focus:outline-none py-1 bg-transparent text-center"
+                                className="flex-1 text-3xl font-bold text-ink placeholder-ink-muted border-b-2 border-spot focus:border-spot-hover focus:outline-none py-1 bg-transparent text-center"
                                 step={isCountMode ? '1' : (unit === 'kg' ? '0.1' : '1')}
                                 autoFocus
                             />
-                            <span className="text-xl font-medium text-gray-500">
+                            <span className="text-xl font-medium text-ink-sub">
                                 {isCountMode ? '個' : (unit || '個')}
                             </span>
                         </div>
@@ -132,14 +130,14 @@ export const ProgressHistoryEditDialog: React.FC<ProgressHistoryEditDialogProps>
 
                     {/* Memo */}
                     <div className="mb-6">
-                        <label className="block text-xs font-bold text-gray-500 uppercase tracking-wide mb-2">
+                        <label className="block text-xs font-bold text-ink-muted uppercase tracking-wide mb-2">
                             メモ (任意)
                         </label>
                         <textarea
                             value={memo}
                             onChange={(e) => setMemo(e.target.value)}
                             placeholder="備考があれば入力..."
-                            className="w-full px-3 py-2 text-sm text-gray-700 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent resize-none bg-white text-gray-900"
+                            className="w-full px-3 py-2 text-sm text-ink bg-field border border-edge rounded-lg focus:ring-2 focus:ring-spot focus:border-transparent resize-none placeholder:text-ink-muted"
                             rows={2}
                         />
                     </div>
@@ -152,8 +150,8 @@ export const ProgressHistoryEditDialog: React.FC<ProgressHistoryEditDialogProps>
                             disabled={isSubmitting}
                             className={`px-4 py-3 rounded-xl font-bold text-white shadow-md flex items-center justify-center gap-2 transition-all flex-1 ${
                                 showDeleteConfirm
-                                    ? 'bg-red-600 hover:bg-red-700 active:scale-[0.98]'
-                                    : 'bg-red-500 hover:bg-red-600 active:scale-[0.98]'
+                                    ? 'bg-danger hover:bg-danger/90 active:scale-[0.98]'
+                                    : 'bg-danger/80 hover:bg-danger active:scale-[0.98]'
                             } disabled:opacity-70 disabled:cursor-not-allowed`}
                         >
                             <HiTrash className="h-5 w-5" />
@@ -164,8 +162,8 @@ export const ProgressHistoryEditDialog: React.FC<ProgressHistoryEditDialogProps>
                             disabled={!amount || parseFloat(amount) === 0 || isNaN(parseFloat(amount)) || isSubmitting}
                             className={`flex-1 px-4 py-3 rounded-xl font-bold text-white shadow-md flex items-center justify-center gap-2 transition-all ${
                                 !amount || parseFloat(amount) === 0 || isNaN(parseFloat(amount)) || isSubmitting
-                                    ? 'bg-gray-300 cursor-not-allowed'
-                                    : 'bg-amber-600 hover:bg-amber-700 active:scale-[0.98]'
+                                    ? 'bg-ground text-ink-muted cursor-not-allowed'
+                                    : 'bg-btn-primary hover:bg-btn-primary-hover active:scale-[0.98]'
                             }`}
                         >
                             {isSubmitting ? (
@@ -183,4 +181,3 @@ export const ProgressHistoryEditDialog: React.FC<ProgressHistoryEditDialogProps>
         </div>
     );
 };
-

--- a/components/work-progress/QuickAddModal.tsx
+++ b/components/work-progress/QuickAddModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { HiX, HiCheck } from 'react-icons/hi';
+import { IconButton } from '@/components/ui';
 import { WorkProgress } from '@/types';
 import { useToastContext } from '@/components/Toast';
 
@@ -34,7 +35,7 @@ export const QuickAddModal: React.FC<QuickAddModalProps> = ({
 
     const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const value = e.target.value;
-        
+
         // `-` が入力された場合、現在の値から減算
         if (value === '-') {
             const step = workProgress.targetAmount === undefined ? 1 : (unit === 'kg' ? 0.1 : 1);
@@ -42,7 +43,7 @@ export const QuickAddModal: React.FC<QuickAddModalProps> = ({
             setAmount((currentVal - step).toString());
             return;
         }
-        
+
         setAmount(value);
     };
 
@@ -66,28 +67,25 @@ export const QuickAddModal: React.FC<QuickAddModalProps> = ({
     return (
         <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/50 backdrop-blur-sm p-0 sm:p-4 transition-opacity duration-300">
             <div
-                className="bg-white w-full sm:max-w-md rounded-t-2xl sm:rounded-2xl shadow-xl overflow-hidden flex flex-col max-h-[90vh] animate-slide-up sm:animate-fade-in"
+                className="bg-overlay w-full sm:max-w-md rounded-t-2xl sm:rounded-2xl shadow-xl overflow-hidden flex flex-col max-h-[90vh] animate-slide-up sm:animate-fade-in border border-edge"
                 onClick={(e) => e.stopPropagation()}
             >
                 {/* Header */}
-                <div className="px-4 py-3 border-b border-gray-100 flex items-center justify-between bg-gray-50">
-                    <h3 className="font-bold text-gray-800 truncate pr-4">
+                <div className="px-4 py-3 border-b border-edge flex items-center justify-between bg-ground">
+                    <h3 className="font-bold text-ink truncate pr-4">
                         進捗を記録: {workProgress.taskName}
                     </h3>
-                    <button
-                        onClick={onClose}
-                        className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-200 rounded-full transition-colors"
-                    >
+                    <IconButton variant="ghost" size="md" rounded onClick={onClose} aria-label="閉じる">
                         <HiX className="h-5 w-5" />
-                    </button>
+                    </IconButton>
                 </div>
 
                 <form onSubmit={handleSubmit} className="p-4 overflow-y-auto">
                     {/* Amount Display & Input */}
                     <div className="mb-6">
-                        <label className="block text-xs font-bold text-gray-500 uppercase tracking-wide mb-2">
-                            {workProgress.targetAmount === undefined 
-                                ? '追加する個数' 
+                        <label className="block text-xs font-bold text-ink-muted uppercase tracking-wide mb-2">
+                            {workProgress.targetAmount === undefined
+                                ? '追加する個数'
                                 : `追加する量 (${unit || '個'})`}
                         </label>
                         <div className="flex items-center gap-2">
@@ -96,11 +94,11 @@ export const QuickAddModal: React.FC<QuickAddModalProps> = ({
                                 value={amount}
                                 onChange={handleAmountChange}
                                 placeholder="0"
-                                className="flex-1 text-3xl font-bold text-gray-900 placeholder-gray-300 border-b-2 border-amber-500 focus:border-amber-600 focus:outline-none py-1 bg-transparent text-center"
+                                className="flex-1 text-3xl font-bold text-ink placeholder-ink-muted border-b-2 border-spot focus:border-spot-hover focus:outline-none py-1 bg-transparent text-center"
                                 step={workProgress.targetAmount === undefined ? '1' : (unit === 'kg' ? '0.1' : '1')}
                                 autoFocus
                             />
-                            <span className="text-xl font-medium text-gray-500">
+                            <span className="text-xl font-medium text-ink-sub">
                                 {workProgress.targetAmount === undefined ? '個' : (unit || '個')}
                             </span>
                         </div>
@@ -108,14 +106,14 @@ export const QuickAddModal: React.FC<QuickAddModalProps> = ({
 
                     {/* Memo */}
                     <div className="mb-6">
-                        <label className="block text-xs font-bold text-gray-500 uppercase tracking-wide mb-2">
+                        <label className="block text-xs font-bold text-ink-muted uppercase tracking-wide mb-2">
                             メモ (任意)
                         </label>
                         <textarea
                             value={memo}
                             onChange={(e) => setMemo(e.target.value)}
                             placeholder="備考があれば入力..."
-                            className="w-full px-3 py-2 text-sm text-gray-700 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent resize-none"
+                            className="w-full px-3 py-2 text-sm text-ink bg-field border border-edge rounded-lg focus:ring-2 focus:ring-spot focus:border-transparent resize-none placeholder:text-ink-muted"
                             rows={2}
                         />
                     </div>
@@ -125,8 +123,8 @@ export const QuickAddModal: React.FC<QuickAddModalProps> = ({
                         type="submit"
                         disabled={!amount || parseFloat(amount) === 0 || isNaN(parseFloat(amount)) || isSubmitting}
                         className={`w-full py-3.5 px-4 rounded-xl font-bold text-white shadow-md flex items-center justify-center gap-2 transition-all ${!amount || parseFloat(amount) === 0 || isNaN(parseFloat(amount)) || isSubmitting
-                                ? 'bg-gray-300 cursor-not-allowed'
-                                : 'bg-amber-600 hover:bg-amber-700 active:scale-[0.98]'
+                                ? 'bg-ground text-ink-muted cursor-not-allowed'
+                                : 'bg-btn-primary hover:bg-btn-primary-hover active:scale-[0.98]'
                             }`}
                     >
                         {isSubmitting ? (

--- a/components/work-progress/WorkProgressCard.tsx
+++ b/components/work-progress/WorkProgressCard.tsx
@@ -44,14 +44,14 @@ export const WorkProgressCard: React.FC<WorkProgressCardProps> = ({
 
     if (isDummyWork) {
         return (
-            <div className="text-center py-6 px-4 bg-gray-50/50 border-2 border-dashed border-gray-300 rounded-lg">
-                <p className="text-sm text-gray-600 mb-3">新しく作業を追加してください</p>
+            <div className="text-center py-6 px-4 bg-ground/50 border-2 border-dashed border-edge-strong rounded-lg">
+                <p className="text-sm text-ink-sub mb-3">新しく作業を追加してください</p>
                 <button
                     onClick={(e) => {
                         e.stopPropagation();
-                        onEdit(wp.id); // This will trigger the add flow in the parent
+                        onEdit(wp.id);
                     }}
-                    className="w-full px-3 py-1.5 text-xs font-medium text-amber-600 bg-amber-50 border border-amber-300 rounded-lg hover:bg-amber-100 hover:border-amber-400 transition-colors flex items-center justify-center gap-1.5 min-h-[44px]"
+                    className="w-full px-3 py-1.5 text-xs font-medium text-spot bg-spot-subtle border border-spot rounded-lg hover:bg-spot-surface transition-colors flex items-center justify-center gap-1.5 min-h-[44px]"
                 >
                     <HiPlus className="h-3.5 w-3.5" />
                     <span>作業を追加</span>
@@ -63,9 +63,9 @@ export const WorkProgressCard: React.FC<WorkProgressCardProps> = ({
     return (
         <div
             className={`${isInGroup
-                    ? 'border border-gray-200 rounded-lg p-3 space-y-2.5 bg-white shadow-sm'
-                    : 'bg-white rounded-lg shadow-md border border-gray-100 p-4 sm:p-5 md:p-6 break-inside-avoid mb-4 sm:mb-6 w-full inline-block'
-                } hover:shadow-lg hover:border-gray-300 transition-all cursor-pointer`}
+                    ? 'border border-edge rounded-lg p-3 space-y-2.5 bg-surface shadow-sm'
+                    : 'bg-surface rounded-lg shadow-card border border-edge p-4 sm:p-5 md:p-6 break-inside-avoid mb-4 sm:mb-6 w-full inline-block'
+                } hover:shadow-card-hover hover:border-edge-strong transition-all cursor-pointer`}
             onClick={() => onEdit(wp.id)}
         >
             {/* Header: Task Name & Status */}
@@ -73,7 +73,7 @@ export const WorkProgressCard: React.FC<WorkProgressCardProps> = ({
                 <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 flex-wrap">
                         {wp.taskName && (
-                            <h3 className="text-base font-bold text-gray-800 leading-tight">{wp.taskName}</h3>
+                            <h3 className="text-base font-bold text-ink leading-tight">{wp.taskName}</h3>
                         )}
                         <select
                             value={wp.status}
@@ -82,11 +82,11 @@ export const WorkProgressCard: React.FC<WorkProgressCardProps> = ({
                                 onStatusChange(wp.id, e.target.value as WorkProgressStatus);
                             }}
                             onClick={(e) => e.stopPropagation()}
-                            className={`px-2 py-1 text-xs font-medium rounded border focus:outline-none focus:ring-2 focus:ring-amber-500 min-h-[32px] cursor-pointer ${wp.status === 'completed'
-                                    ? 'bg-green-50 text-green-700 border-green-300'
+                            className={`px-2 py-1 text-xs font-medium rounded border focus:outline-none focus:ring-2 focus:ring-spot min-h-[32px] cursor-pointer ${wp.status === 'completed'
+                                    ? 'bg-success/10 text-success border-success/30'
                                     : wp.status === 'in_progress'
-                                        ? 'bg-amber-50 text-amber-700 border-amber-300'
-                                        : 'bg-gray-50 text-gray-700 border-gray-300'
+                                        ? 'bg-spot-subtle text-spot border-spot'
+                                        : 'bg-ground text-ink-sub border-edge'
                                 }`}
                         >
                             <option value="pending">前</option>
@@ -94,7 +94,7 @@ export const WorkProgressCard: React.FC<WorkProgressCardProps> = ({
                             <option value="completed">済</option>
                         </select>
                     </div>
-                    {!isInGroup && wp.weight && <p className="text-xs text-gray-500 mt-1">目標: {wp.weight}</p>}
+                    {!isInGroup && wp.weight && <p className="text-xs text-ink-muted mt-1">目標: {wp.weight}</p>}
                 </div>
 
                 {/* Archive Button */}
@@ -104,7 +104,7 @@ export const WorkProgressCard: React.FC<WorkProgressCardProps> = ({
                             e.stopPropagation();
                             onArchive(wp.id);
                         }}
-                        className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-full transition-colors"
+                        className="p-2 text-ink-muted hover:text-ink-sub hover:bg-ground rounded-full transition-colors"
                         title="アーカイブ"
                     >
                         <HiArchive className="h-5 w-5" />
@@ -117,23 +117,23 @@ export const WorkProgressCard: React.FC<WorkProgressCardProps> = ({
                 <div className="space-y-3">
                     <div className="flex items-end justify-between gap-2">
                         <div>
-                            <div className="text-xs text-gray-500 mb-0.5">
+                            <div className="text-xs text-ink-muted mb-0.5">
                                 {(() => {
                                     const remaining = calculateRemaining(wp);
                                     if (remaining === null) return null;
                                     if (remaining <= 0) {
                                         const over = Math.abs(remaining);
                                         return over > 0 ? (
-                                            <span className="text-green-600 font-medium">目標達成 (+{formatAmount(over, unit)}{unit})</span>
+                                            <span className="text-success font-medium">目標達成 (+{formatAmount(over, unit)}{unit})</span>
                                         ) : null;
                                     }
-                                    return <span>残り <span className="font-medium text-gray-700">{formatAmount(remaining, unit)}{unit}</span></span>;
+                                    return <span>残り <span className="font-medium text-ink-sub">{formatAmount(remaining, unit)}{unit}</span></span>;
                                 })()}
                             </div>
-                            <div className="text-xl font-bold text-gray-900 leading-none flex items-baseline gap-1">
-                                <span className="text-xs font-normal text-gray-500">完成数</span>
+                            <div className="text-xl font-bold text-ink leading-none flex items-baseline gap-1">
+                                <span className="text-xs font-normal text-ink-muted">完成数</span>
                                 {formatAmount(wp.currentAmount || 0, unit)}
-                                <span className="text-sm font-normal text-gray-500 ml-1">/ {formatAmount(wp.targetAmount, unit)}{unit}</span>
+                                <span className="text-sm font-normal text-ink-muted ml-1">/ {formatAmount(wp.targetAmount, unit)}{unit}</span>
                             </div>
                         </div>
                         <button
@@ -141,7 +141,7 @@ export const WorkProgressCard: React.FC<WorkProgressCardProps> = ({
                                 e.stopPropagation();
                                 onAddProgress(wp.id);
                             }}
-                            className="px-3 py-1.5 text-xs font-bold text-white bg-primary rounded-lg hover:bg-primary-dark active:bg-primary-dark transition-colors flex items-center gap-1 shadow-sm"
+                            className="px-3 py-1.5 text-xs font-bold text-white bg-btn-primary rounded-lg hover:bg-btn-primary-hover active:bg-btn-primary-hover transition-colors flex items-center gap-1 shadow-sm"
                         >
                             <HiPlus className="h-4 w-4" />
                             記録
@@ -149,13 +149,13 @@ export const WorkProgressCard: React.FC<WorkProgressCardProps> = ({
                     </div>
 
                     {/* Progress Bar */}
-                    <div className="relative w-full bg-gray-100 rounded-full h-4 overflow-hidden shadow-inner">
+                    <div className="relative w-full bg-ground rounded-full h-4 overflow-hidden shadow-inner">
                         <div
                             className={`h-full rounded-full transition-all duration-500 ease-out ${getProgressBarColor(percentage)}`}
                             style={{ width: `${percentage}%` }}
                         />
                         <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-                            <span className={`text-[10px] font-bold ${percentage >= 55 ? 'text-white' : 'text-gray-600'}`}>
+                            <span className={`text-[10px] font-bold ${percentage >= 55 ? 'text-white' : 'text-ink-sub'}`}>
                                 {percentage.toFixed(0)}%
                             </span>
                         </div>
@@ -166,9 +166,9 @@ export const WorkProgressCard: React.FC<WorkProgressCardProps> = ({
                 <div className="space-y-3">
                     <div className="flex items-center justify-between">
                         <div>
-                            <span className="text-xs text-gray-500 block mb-0.5">完成数</span>
-                            <span className="text-xl font-bold text-gray-900">
-                                {wp.completedCount || 0}<span className="text-sm font-normal text-gray-500 ml-1">個</span>
+                            <span className="text-xs text-ink-muted block mb-0.5">完成数</span>
+                            <span className="text-xl font-bold text-ink">
+                                {wp.completedCount || 0}<span className="text-sm font-normal text-ink-muted ml-1">個</span>
                             </span>
                         </div>
                         <button
@@ -176,7 +176,7 @@ export const WorkProgressCard: React.FC<WorkProgressCardProps> = ({
                                 e.stopPropagation();
                                 onAddProgress(wp.id);
                             }}
-                            className="px-3 py-1.5 text-xs font-bold text-white bg-primary rounded-lg hover:bg-primary-dark active:bg-primary-dark transition-colors flex items-center gap-1 shadow-sm"
+                            className="px-3 py-1.5 text-xs font-bold text-white bg-btn-primary rounded-lg hover:bg-btn-primary-hover active:bg-btn-primary-hover transition-colors flex items-center gap-1 shadow-sm"
                         >
                             <HiPlus className="h-4 w-4" />
                             記録
@@ -187,7 +187,7 @@ export const WorkProgressCard: React.FC<WorkProgressCardProps> = ({
 
             {/* Dates */}
             {isInGroup && (wp.startedAt || wp.completedAt) && (
-                <div className="mt-3 flex flex-wrap gap-x-3 gap-y-1 text-[10px] text-gray-400">
+                <div className="mt-3 flex flex-wrap gap-x-3 gap-y-1 text-[10px] text-ink-muted">
                     {wp.startedAt && <span>開始: {formatDateTime(wp.startedAt)}</span>}
                     {wp.completedAt && <span>完了: {formatDateTime(wp.completedAt)}</span>}
                 </div>
@@ -195,20 +195,20 @@ export const WorkProgressCard: React.FC<WorkProgressCardProps> = ({
 
             {/* Memo */}
             {wp.memo && (
-                <div className="mt-2 text-xs text-gray-500 bg-gray-50 p-2 rounded border border-gray-100 whitespace-pre-wrap line-clamp-2">
+                <div className="mt-2 text-xs text-ink-sub bg-ground p-2 rounded border border-edge whitespace-pre-wrap line-clamp-2">
                     {wp.memo}
                 </div>
             )}
 
             {/* History Toggle */}
             {hasProgressHistory && (
-                <div className="mt-3 pt-2 border-t border-gray-100">
+                <div className="mt-3 pt-2 border-t border-edge">
                     <button
                         onClick={(e) => {
                             e.stopPropagation();
                             onToggleHistory(wp.id);
                         }}
-                        className="w-full flex items-center justify-between text-xs text-gray-500 hover:text-gray-700 py-1"
+                        className="w-full flex items-center justify-between text-xs text-ink-muted hover:text-ink-sub py-1 transition-colors"
                     >
                         <span>履歴 ({wp.progressHistory!.length})</span>
                         {isHistoryExpanded ? <HiChevronUp className="h-3 w-3" /> : <HiChevronDown className="h-3 w-3" />}
@@ -227,15 +227,15 @@ export const WorkProgressCard: React.FC<WorkProgressCardProps> = ({
                                                 onEditHistory(wp.id, entry.id);
                                             }
                                         }}
-                                        className="text-xs flex justify-between items-start bg-gray-50 p-1.5 rounded cursor-pointer hover:bg-gray-100 transition-colors"
+                                        className="text-xs flex justify-between items-start bg-ground p-1.5 rounded cursor-pointer hover:bg-edge transition-colors"
                                     >
                                         <div>
-                                            <span className="font-medium text-gray-700">
+                                            <span className="font-medium text-ink-sub">
                                                 {entry.amount >= 0 ? '+' : '-'}{formatAmount(Math.abs(entry.amount), unit)}{unit}
                                             </span>
-                                            {entry.memo && <p className="text-gray-500 mt-0.5">{entry.memo}</p>}
+                                            {entry.memo && <p className="text-ink-muted mt-0.5">{entry.memo}</p>}
                                         </div>
-                                        <span className="text-[10px] text-gray-400">{formatDateTime(entry.date)}</span>
+                                        <span className="text-[10px] text-ink-muted">{formatDateTime(entry.date)}</span>
                                     </div>
                                 ))}
                         </div>


### PR DESCRIPTION
## 概要
Issue #137 を解決。作業進捗ページ（`app/progress/`）の独自UI要素を共通UIコンポーネントに置換し、CSS変数によるテーマシステム対応を追加。

## 変更内容
- 12ファイルを修正（progressページ9ファイル + work-progress共通コンポーネント3ファイル）
- 独自`<button>`, `<input>`, `<select>`, `<textarea>` → `Button`, `IconButton`, `BackLink`, `Input`, `Select`, `Textarea` に置換
- ハードコード色（`bg-white`, `text-gray-800`, `border-gray-200`等）→ CSS変数（`bg-surface`, `text-ink`, `border-edge`等）に全面置換
- モーダル背景: `bg-overlay`（不透明）、カード背景: `bg-surface`（半透明OK）を適切に使い分け
- WorkProgressCard, QuickAddModal, ProgressHistoryEditDialogもテーマ対応
- プログレスバーの色をCSS変数化（`bg-success`, `bg-spot`, `bg-edge-strong`）

## テスト
- [x] lint 通過
- [x] build 通過
- [x] test 750テスト全合格
- [x] 独立コードレビュー通過

Closes #137
