### PR TITLE
refactor(#138): ドリップガイドページの共通UI化とテーマシステム対応

### DIFF
--- a/app/drip-guide/edit/page.tsx
+++ b/app/drip-guide/edit/page.tsx
@@ -13,13 +13,13 @@ function EditRecipeContent() {
     const { recipes, updateRecipe, isLoaded } = useRecipes();
 
     if (!isLoaded) {
-        return <div className="p-8 text-center text-gray-500">Loading...</div>;
+        return <div className="p-8 text-center text-ink-muted">Loading...</div>;
     }
 
     const recipe = recipes.find((r) => r.id === recipeId);
 
     if (!recipe) {
-        return <div className="p-8 text-center text-gray-500">レシピが見つかりません</div>;
+        return <div className="p-8 text-center text-ink-muted">レシピが見つかりません</div>;
     }
 
     const handleSubmit = (updatedRecipe: DripRecipe) => {
@@ -36,8 +36,8 @@ function EditRecipeContent() {
 
 export default function EditRecipePage() {
     return (
-        <div className="min-h-screen text-gray-900" style={{ backgroundColor: '#F7F7F5' }}>
-            <Suspense fallback={<div className="p-8 text-center text-gray-500">Loading...</div>}>
+        <div className="min-h-screen text-ink bg-page transition-colors duration-1000">
+            <Suspense fallback={<div className="p-8 text-center text-ink-muted">Loading...</div>}>
                 <EditRecipeContent />
             </Suspense>
         </div>

--- a/app/drip-guide/new/page.tsx
+++ b/app/drip-guide/new/page.tsx
@@ -16,7 +16,7 @@ export default function NewRecipePage() {
     };
 
     return (
-        <div className="min-h-screen text-gray-900" style={{ backgroundColor: '#F7F7F5' }}>
+        <div className="min-h-screen text-ink bg-page transition-colors duration-1000">
             <div className="max-w-5xl mx-auto p-4 sm:p-6">
                 <RecipeForm onSubmit={handleSubmit} />
             </div>

--- a/app/drip-guide/page.tsx
+++ b/app/drip-guide/page.tsx
@@ -5,39 +5,32 @@ import Link from 'next/link';
 import { RecipeList } from '@/components/drip-guide/RecipeList';
 import { useRecipes } from '@/lib/drip-guide/useRecipes';
 import { Plus } from 'phosphor-react';
-import { HiArrowLeft } from 'react-icons/hi';
+import { BackLink } from '@/components/ui';
 
 export default function DripGuidePage() {
     const { recipes, isLoaded, deleteRecipe } = useRecipes();
 
     if (!isLoaded) {
-        return <div className="p-8 text-center text-gray-500">Loading...</div>;
+        return <div className="p-8 text-center text-ink-muted">Loading...</div>;
     }
 
     return (
-        <div className="h-screen overflow-y-hidden flex flex-col px-3 sm:px-6 lg:px-8 pt-3 sm:pt-6 lg:pt-8 pb-2 sm:pb-3 lg:pb-4" style={{ backgroundColor: '#F7F7F5' }}>
+        <div className="h-screen overflow-y-hidden flex flex-col px-3 sm:px-6 lg:px-8 pt-3 sm:pt-6 lg:pt-8 pb-2 sm:pb-3 lg:pb-4 bg-page transition-colors duration-1000">
             <div className="max-w-7xl mx-auto w-full flex flex-col flex-1 min-h-0">
                 <header className="mb-4 sm:mb-6 flex-shrink-0">
                     <div className="flex items-center justify-between">
                         <div className="flex items-center gap-4">
-                            <Link
-                                href="/"
-                                className="px-3 py-2 text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded transition-colors flex items-center justify-center min-h-[44px] min-w-[44px]"
-                                title="戻る"
-                                aria-label="戻る"
-                            >
-                                <HiArrowLeft className="h-6 w-6 flex-shrink-0" />
-                            </Link>
+                            <BackLink href="/" variant="icon-only" aria-label="戻る" />
                             <div>
-                                <h1 className="text-2xl font-bold text-gray-800">ドリップガイド</h1>
-                                <p className="text-gray-500 text-sm mt-1 hidden sm:block">
+                                <h1 className="text-2xl font-bold text-ink">ドリップガイド</h1>
+                                <p className="text-ink-sub text-sm mt-1 hidden sm:block">
                                     レシピを選んで、一貫性のあるドリップを。
                                 </p>
                             </div>
                         </div>
                         <Link
                             href="/drip-guide/new"
-                            className="flex items-center gap-2 bg-primary text-white px-4 py-2 rounded-lg font-bold hover:bg-primary-dark transition-colors shadow-sm min-h-[44px]"
+                            className="flex items-center gap-2 bg-btn-primary text-white px-4 py-2 rounded-lg font-bold hover:bg-btn-primary-hover transition-colors shadow-sm min-h-[44px]"
                         >
                             <Plus size={20} />
                             <span className="hidden sm:inline">新規レシピ</span>

--- a/app/drip-guide/run/page.tsx
+++ b/app/drip-guide/run/page.tsx
@@ -38,7 +38,7 @@ function RunRecipeContent() {
         const calculatedRecipe = generateRecipe46(validServings, taste, strength);
 
         return (
-            <div className="min-h-screen bg-white">
+            <div className="min-h-screen bg-page transition-colors duration-1000">
                 <DripGuideRunner recipe={calculatedRecipe} />
             </div>
         );
@@ -46,7 +46,7 @@ function RunRecipeContent() {
 
     // 既存レシピの処理
     if (!isLoaded) {
-        return <div className="p-8 text-center text-gray-500">Loading...</div>;
+        return <div className="p-8 text-center text-ink-muted">Loading...</div>;
     }
 
     const recipe = recipes.find((r) => r.id === recipeId);
@@ -54,8 +54,8 @@ function RunRecipeContent() {
     if (!recipe) {
         return (
             <div className="p-8 text-center">
-                <p className="text-gray-500 mb-4">レシピが見つかりません</p>
-                <Link href="/drip-guide" className="text-amber-600 hover:underline">
+                <p className="text-ink-muted mb-4">レシピが見つかりません</p>
+                <Link href="/drip-guide" className="text-spot hover:underline">
                     一覧に戻る
                 </Link>
             </div>
@@ -71,7 +71,7 @@ function RunRecipeContent() {
     const calculatedRecipe = calculateRecipeForServings(recipe, validServings);
 
     return (
-        <div className="min-h-screen bg-white">
+        <div className="min-h-screen bg-page transition-colors duration-1000">
             <DripGuideRunner recipe={calculatedRecipe} />
         </div>
     );
@@ -79,7 +79,7 @@ function RunRecipeContent() {
 
 export default function RunRecipePage() {
     return (
-        <Suspense fallback={<div className="p-8 text-center text-gray-500">Loading...</div>}>
+        <Suspense fallback={<div className="p-8 text-center text-ink-muted">Loading...</div>}>
             <RunRecipeContent />
         </Suspense>
     );

--- a/components/drip-guide/DripGuideRunner.tsx
+++ b/components/drip-guide/DripGuideRunner.tsx
@@ -108,7 +108,7 @@ export const DripGuideRunner: React.FC<DripGuideRunnerProps> = ({ recipe }) => {
     }
 
     return (
-        <div className="flex flex-col h-[100dvh] bg-white relative overflow-hidden">
+        <div className="flex flex-col h-[100dvh] bg-surface relative overflow-hidden">
             <RunnerHeader recipeName={recipe.name} />
 
             <div className="flex-grow flex flex-col items-center py-2 px-4 overflow-hidden">

--- a/components/drip-guide/RecipeForm.tsx
+++ b/components/drip-guide/RecipeForm.tsx
@@ -3,10 +3,9 @@
 import React, { useState } from 'react';
 import { DripRecipe, DripStep } from '@/lib/drip-guide/types';
 import { StepEditor } from './StepEditor';
-import { FloppyDisk, ArrowLeft, ArrowClockwise } from 'phosphor-react';
-import Link from 'next/link';
+import { FloppyDisk, ArrowClockwise } from 'phosphor-react';
 import { MOCK_RECIPES } from '@/lib/drip-guide/mockData';
-import { Input, Textarea, Button } from '@/components/ui';
+import { Input, Textarea, Button, BackLink } from '@/components/ui';
 
 interface RecipeFormProps {
     initialRecipe?: DripRecipe;
@@ -90,22 +89,19 @@ export const RecipeForm: React.FC<RecipeFormProps> = ({ initialRecipe, onSubmit 
     return (
         <form onSubmit={handleSubmit} className="max-w-3xl mx-auto pb-20">
             <div className="mb-6 flex items-center justify-between">
-                <Link href="/drip-guide" className="flex items-center text-gray-500 hover:text-gray-800 transition-colors p-2 -ml-2 rounded-lg active:bg-gray-100">
-                    <ArrowLeft size={20} className="mr-1" />
-                    一覧に戻る
-                </Link>
-                <h1 className="text-2xl font-bold text-gray-800">
+                <BackLink href="/drip-guide">一覧に戻る</BackLink>
+                <h1 className="text-2xl font-bold text-ink">
                     {initialRecipe ? 'レシピを編集' : '新しいレシピを作成'}
                 </h1>
             </div>
 
-            <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6 mb-6 space-y-6">
+            <div className="bg-surface rounded-xl shadow-card border border-edge p-6 mb-6 space-y-6">
                 {/* Basic Info Section */}
                 <div>
-                    <h2 className="text-lg font-bold text-gray-700 mb-4 border-b pb-2">基本情報</h2>
+                    <h2 className="text-lg font-bold text-ink-sub mb-4 border-b border-edge pb-2">基本情報</h2>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                         <div className="col-span-2">
-                            <label className="block text-sm font-medium text-gray-700 mb-1">レシピ名 <span className="text-red-500">*</span></label>
+                            <label className="block text-sm font-medium text-ink-sub mb-1">レシピ名 <span className="text-danger">*</span></label>
                             <Input
                                 type="text"
                                 value={name}
@@ -116,7 +112,7 @@ export const RecipeForm: React.FC<RecipeFormProps> = ({ initialRecipe, onSubmit 
                         </div>
 
                         <div>
-                            <label className="block text-sm font-medium text-gray-700 mb-1">豆の名前 <span className="text-red-500">*</span></label>
+                            <label className="block text-sm font-medium text-ink-sub mb-1">豆の名前 <span className="text-danger">*</span></label>
                             <Input
                                 type="text"
                                 value={beanName}
@@ -127,7 +123,7 @@ export const RecipeForm: React.FC<RecipeFormProps> = ({ initialRecipe, onSubmit 
                         </div>
 
                         <div>
-                            <label className="block text-sm font-medium text-gray-700 mb-1">用途・タグ</label>
+                            <label className="block text-sm font-medium text-ink-sub mb-1">用途・タグ</label>
                             <Input
                                 type="text"
                                 value={purpose}
@@ -137,7 +133,7 @@ export const RecipeForm: React.FC<RecipeFormProps> = ({ initialRecipe, onSubmit 
                         </div>
 
                         <div>
-                            <label className="block text-sm font-medium text-gray-700 mb-1">豆の量 (g)</label>
+                            <label className="block text-sm font-medium text-ink-sub mb-1">豆の量 (g)</label>
                             <Input
                                 type="number"
                                 value={beanAmountGram}
@@ -147,7 +143,7 @@ export const RecipeForm: React.FC<RecipeFormProps> = ({ initialRecipe, onSubmit 
                         </div>
 
                         <div>
-                            <label className="block text-sm font-medium text-gray-700 mb-1">総湯量 (g)</label>
+                            <label className="block text-sm font-medium text-ink-sub mb-1">総湯量 (g)</label>
                             <Input
                                 type="number"
                                 value={totalWaterGram}
@@ -157,7 +153,7 @@ export const RecipeForm: React.FC<RecipeFormProps> = ({ initialRecipe, onSubmit 
                         </div>
 
                         <div>
-                            <label className="block text-sm font-medium text-gray-700 mb-1">総時間</label>
+                            <label className="block text-sm font-medium text-ink-sub mb-1">総時間</label>
                             <div className="flex gap-2 items-center">
                                 <div>
                                     <div className="flex items-center gap-2">
@@ -172,7 +168,7 @@ export const RecipeForm: React.FC<RecipeFormProps> = ({ initialRecipe, onSubmit 
                                             className="w-20 text-right"
                                             min={0}
                                         />
-                                        <span className="text-gray-600 text-sm whitespace-nowrap font-medium">分</span>
+                                        <span className="text-ink-sub text-sm whitespace-nowrap font-medium">分</span>
                                     </div>
                                 </div>
                                 <div>
@@ -189,14 +185,14 @@ export const RecipeForm: React.FC<RecipeFormProps> = ({ initialRecipe, onSubmit 
                                             min={0}
                                             max={59}
                                         />
-                                        <span className="text-gray-600 text-sm whitespace-nowrap font-medium">秒</span>
+                                        <span className="text-ink-sub text-sm whitespace-nowrap font-medium">秒</span>
                                     </div>
                                 </div>
                             </div>
                         </div>
 
                         <div className="col-span-2">
-                            <label className="block text-sm font-medium text-gray-700 mb-1">説明・メモ</label>
+                            <label className="block text-sm font-medium text-ink-sub mb-1">説明・メモ</label>
                             <Textarea
                                 value={description}
                                 onChange={(e) => setDescription(e.target.value)}
@@ -209,9 +205,9 @@ export const RecipeForm: React.FC<RecipeFormProps> = ({ initialRecipe, onSubmit 
 
                 {/* Guide Mode Settings Section */}
                 <div>
-                    <h2 className="text-lg font-bold text-gray-700 mb-4 border-b pb-2">ガイドモード設定</h2>
+                    <h2 className="text-lg font-bold text-ink-sub mb-4 border-b border-edge pb-2">ガイドモード設定</h2>
                     <div className="space-y-4">
-                        <div className="bg-gray-50 rounded-lg p-4 border border-gray-200">
+                        <div className="bg-ground rounded-lg p-4 border border-edge">
                             <div className="space-y-3">
                                 <label className="flex items-center gap-3 cursor-pointer">
                                     <input
@@ -219,11 +215,11 @@ export const RecipeForm: React.FC<RecipeFormProps> = ({ initialRecipe, onSubmit 
                                         name="guideMode"
                                         checked={!isManualMode}
                                         onChange={() => setIsManualMode(false)}
-                                        className="w-5 h-5 text-amber-600 focus:ring-2 focus:ring-amber-500"
+                                        className="w-5 h-5 text-spot focus:ring-2 focus:ring-spot"
                                     />
                                     <div className="flex-1">
-                                        <div className="font-semibold text-gray-800">自動モード</div>
-                                        <div className="text-sm text-gray-600">タイマーに基づいて自動的にステップが進行します。時間が確定しているレシピに適しています。</div>
+                                        <div className="font-semibold text-ink">自動モード</div>
+                                        <div className="text-sm text-ink-sub">タイマーに基づいて自動的にステップが進行します。時間が確定しているレシピに適しています。</div>
                                     </div>
                                 </label>
                                 <label className="flex items-center gap-3 cursor-pointer">
@@ -232,11 +228,11 @@ export const RecipeForm: React.FC<RecipeFormProps> = ({ initialRecipe, onSubmit 
                                         name="guideMode"
                                         checked={isManualMode}
                                         onChange={() => setIsManualMode(true)}
-                                        className="w-5 h-5 text-amber-600 focus:ring-2 focus:ring-amber-500"
+                                        className="w-5 h-5 text-spot focus:ring-2 focus:ring-spot"
                                     />
                                     <div className="flex-1">
-                                        <div className="font-semibold text-gray-800">手動モード</div>
-                                        <div className="text-sm text-gray-600">手動でステップを進めます。タイマーは参考として表示されます。時間が不確定なレシピ（BYSN Standard Dripなど）に適しています。</div>
+                                        <div className="font-semibold text-ink">手動モード</div>
+                                        <div className="text-sm text-ink-sub">手動でステップを進めます。タイマーは参考として表示されます。時間が不確定なレシピ（BYSN Standard Dripなど）に適しています。</div>
                                     </div>
                                 </label>
                             </div>
@@ -251,7 +247,7 @@ export const RecipeForm: React.FC<RecipeFormProps> = ({ initialRecipe, onSubmit 
             </div>
 
             {/* Submit Button */}
-            <div className="fixed bottom-0 left-0 right-0 p-4 bg-white border-t border-gray-200 z-10">
+            <div className="fixed bottom-0 left-0 right-0 p-4 bg-overlay border-t border-edge z-10">
                 <div className="max-w-3xl mx-auto flex flex-row gap-3 justify-center">
                     {initialRecipe?.isDefault && (
                         <Button

--- a/components/drip-guide/RecipeList.tsx
+++ b/components/drip-guide/RecipeList.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation';
 import { DripRecipe } from '@/lib/drip-guide/types';
 import { Timer, Coffee, Drop, Trash, Pencil, Play, CaretDown } from 'phosphor-react';
 import { clsx } from 'clsx';
-import { Dialog, Card } from '@/components/ui';
+import { Dialog, Card, Button, IconButton } from '@/components/ui';
 import { StartHintDialog } from './StartHintDialog';
 import { Start46Dialog } from './Start46Dialog';
 import { StartHoffmannDialog } from './StartHoffmannDialog';
@@ -90,7 +90,7 @@ export const RecipeList: React.FC<RecipeListProps> = ({ recipes, onDelete }) => 
 
     if (recipes.length === 0) {
         return (
-            <div className="text-center py-10 text-gray-500">
+            <div className="text-center py-10 text-ink-muted">
                 <p>レシピがまだありません。</p>
                 <p className="text-sm mt-2">新しいレシピを作成して、ドリップガイドを始めましょう。</p>
             </div>
@@ -111,55 +111,56 @@ export const RecipeList: React.FC<RecipeListProps> = ({ recipes, onDelete }) => 
                             className="p-4 sm:p-5 flex flex-col"
                         >
                             <div className="flex justify-between items-start mb-3">
-                                <h3 className="font-bold text-lg text-gray-800 line-clamp-1" title={recipe.name}>
+                                <h3 className="font-bold text-lg text-ink line-clamp-1" title={recipe.name}>
                                     {recipe.name}
                                 </h3>
                                 <div className="flex gap-1">
                                     {recipe.id !== 'recipe-046' && recipe.id !== 'recipe-hoffmann' && (
                                         <Link
                                             href={`/drip-guide/edit?id=${recipe.id}`}
-                                            className="p-3 sm:p-2 text-gray-400 hover:text-blue-600 hover:bg-blue-50 rounded-full transition-colors"
+                                            className="p-3 sm:p-2 text-ink-muted hover:text-info hover:bg-info/10 rounded-full transition-colors"
                                             title="編集"
                                         >
                                             <Pencil size={18} />
                                         </Link>
                                     )}
                                     {!recipe.isDefault && (
-                                        <button
-                                            type="button"
+                                        <IconButton
+                                            variant="ghost"
+                                            size="sm"
                                             onClick={(e) => {
                                                 e.preventDefault();
                                                 e.stopPropagation();
                                                 handleDeleteClick(recipe.id);
                                             }}
-                                            className="p-3 sm:p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-full transition-colors"
+                                            className="text-ink-muted hover:text-danger hover:bg-danger-subtle"
                                             title="削除"
                                         >
                                             <Trash size={18} />
-                                        </button>
+                                        </IconButton>
                                     )}
                                 </div>
                             </div>
 
-                            <div className="space-y-2 text-sm text-gray-600 mb-4 flex-grow">
+                            <div className="space-y-2 text-sm text-ink-sub mb-4 flex-grow">
                                 <div className="flex items-center gap-2">
-                                    <Coffee size={16} className="text-amber-700" />
+                                    <Coffee size={16} className="text-spot" />
                                     <span className="font-medium">{calculatedRecipe.beanName}</span>
-                                    <span className="text-gray-400">({calculatedRecipe.beanAmountGram}g)</span>
+                                    <span className="text-ink-muted">({calculatedRecipe.beanAmountGram}g)</span>
                                 </div>
                                 <div className="flex items-center gap-2">
-                                    <Drop size={16} className="text-blue-500" />
+                                    <Drop size={16} className="text-info" />
                                     <span>{calculatedRecipe.totalWaterGram}g</span>
                                 </div>
                                 <div className="flex items-center gap-2">
-                                    <Timer size={16} className="text-gray-500" />
+                                    <Timer size={16} className="text-ink-muted" />
                                     <span>
                                         {Math.floor(calculatedRecipe.totalDurationSec / 60)}分
                                         {calculatedRecipe.totalDurationSec % 60}秒
                                     </span>
                                 </div>
                                 {recipe.purpose && (
-                                    <div className="mt-2 inline-block px-2 py-0.5 bg-gray-100 text-gray-600 text-xs rounded-md">
+                                    <div className="mt-2 inline-block px-2 py-0.5 bg-ground text-ink-sub text-xs rounded-md">
                                         {recipe.purpose}
                                     </div>
                                 )}
@@ -175,7 +176,7 @@ export const RecipeList: React.FC<RecipeListProps> = ({ recipes, onDelete }) => 
                                         id={`servings-${recipe.id}`}
                                         value={servings}
                                         onChange={(e) => handleServingsChange(recipe.id, parseInt(e.target.value, 10))}
-                                        className="w-full py-2 px-3 pr-10 rounded-lg text-sm font-medium transition-colors min-h-[44px] bg-white border border-gray-300 text-gray-700 hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500 appearance-none cursor-pointer"
+                                        className="w-full py-2 px-3 pr-10 rounded-lg text-sm font-medium transition-colors min-h-[44px] bg-field border border-edge text-ink hover:border-edge-strong focus:outline-none focus:ring-2 focus:ring-spot focus:border-spot appearance-none cursor-pointer"
                                         aria-label="人前を選択"
                                     >
                                         {[1, 2, 3, 4, 5, 6, 7, 8].map((serving) => (
@@ -185,22 +186,22 @@ export const RecipeList: React.FC<RecipeListProps> = ({ recipes, onDelete }) => 
                                         ))}
                                     </select>
                                     <div className="absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none">
-                                        <CaretDown size={16} className="text-gray-500" />
+                                        <CaretDown size={16} className="text-ink-muted" />
                                     </div>
                                 </div>
                             </div>
 
-                            <button
-                                type="button"
+                            <Button
+                                variant="primary"
+                                fullWidth
                                 onClick={() => handleOpenStart(recipe.id)}
                                 className={clsx(
-                                    "mt-auto flex items-center justify-center gap-2 w-full py-3 sm:py-2.5 rounded-lg font-bold transition-all",
-                                    "bg-primary text-white hover:bg-primary-dark active:scale-[0.98] touch-manipulation"
+                                    "mt-auto gap-2 !rounded-lg active:scale-[0.98] touch-manipulation"
                                 )}
                             >
                                 <Play size={20} weight="fill" />
                                 ガイド開始
-                            </button>
+                            </Button>
                         </Card>
                     );
                 })}

--- a/components/drip-guide/Start46Dialog.tsx
+++ b/components/drip-guide/Start46Dialog.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import { generateRecipe46, type Taste46, type Strength46 } from '@/lib/drip-guide/recipe46';
 import { getLast46Taste, getLast46Strength, setLast46Taste, setLast46Strength } from '@/lib/localStorage';
 import { useDialogKeyboard } from '@/hooks/drip-guide/useDialogKeyboard';
+import { Button } from '@/components/ui';
 import { DialogOverlay } from './dialogs/shared/DialogOverlay';
 import { Dialog46Header } from './dialogs/46/Dialog46Header';
 import { Dialog46Form } from './dialogs/46/Dialog46Form';
@@ -90,7 +91,7 @@ export const Start46Dialog: React.FC<Start46DialogProps> = ({
                         onClick={onClose}
                     >
                         <div
-                            className="w-full max-w-2xl rounded-2xl border border-amber-100 bg-white shadow-2xl my-8"
+                            className="w-full max-w-2xl rounded-2xl border border-edge bg-overlay shadow-2xl my-8"
                             onClick={(e) => e.stopPropagation()}
                         >
                             <Dialog46Header />
@@ -108,21 +109,22 @@ export const Start46Dialog: React.FC<Start46DialogProps> = ({
                             <Dialog46Preview recipe={previewRecipe} />
 
                             <div className="flex items-center justify-between px-5 pb-5 pt-1">
-                                <button
-                                    type="button"
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
                                     onClick={onClose}
-                                    className="inline-flex items-center gap-2 rounded-full px-3 py-2 text-gray-600 hover:bg-gray-100 hover:text-gray-800 transition-colors"
+                                    className="gap-2"
                                 >
                                     <span className="text-base">×</span>
-                                    <span className="text-sm font-medium">閉じる</span>
-                                </button>
-                                <button
-                                    type="button"
+                                    閉じる
+                                </Button>
+                                <Button
+                                    variant="primary"
                                     onClick={handleStartGuide}
-                                    className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-5 py-3 font-semibold text-white shadow-sm transition-all hover:bg-primary-dark active:scale-[0.99] touch-manipulation"
+                                    className="!rounded-full !px-5 !py-3 active:scale-[0.99] touch-manipulation"
                                 >
                                     ガイド開始
-                                </button>
+                                </Button>
                             </div>
                         </div>
                     </motion.div>

--- a/components/drip-guide/StartHintDialog.tsx
+++ b/components/drip-guide/StartHintDialog.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useCallback } from 'react';
 import { AnimatePresence, motion, type MotionProps } from 'framer-motion';
 import { Coffee, Timer } from 'phosphor-react';
 import { GiCoffeePot } from 'react-icons/gi';
+import { Button } from '@/components/ui';
 
 interface StartHintDialogProps {
     isOpen: boolean;
@@ -71,49 +72,49 @@ export const StartHintDialog: React.FC<StartHintDialogProps> = ({
                         onClick={onClose}
                     >
                         <div
-                            className="w-full max-w-md rounded-2xl border border-amber-100 bg-white shadow-2xl"
+                            className="w-full max-w-md rounded-2xl border border-edge bg-overlay shadow-2xl"
                             onClick={(e) => e.stopPropagation()}
                         >
                             <div className="flex items-start gap-3 px-5 pt-5">
-                                <div className="flex h-11 w-11 items-center justify-center rounded-full bg-amber-50 text-amber-700">
+                                <div className="flex h-11 w-11 items-center justify-center rounded-full bg-spot-subtle text-spot">
                                     <Coffee size={24} weight="duotone" />
                                 </div>
                                 <div className="flex-1">
-                                    <p className="text-xs font-semibold uppercase tracking-wide text-amber-700">
+                                    <p className="text-xs font-semibold uppercase tracking-wide text-spot">
                                         ドリップ前のヒント
                                     </p>
-                                    <h3 className="mt-1 text-lg font-bold text-gray-900">
+                                    <h3 className="mt-1 text-lg font-bold text-ink">
                                         一杯をおいしく淹れるために
                                     </h3>
                                     {recipeName && (
-                                        <p className="mt-1 text-sm text-gray-500">レシピ: {recipeName}</p>
+                                        <p className="mt-1 text-sm text-ink-muted">レシピ: {recipeName}</p>
                                     )}
                                 </div>
                             </div>
 
-                            <div className="px-5 py-4 space-y-3 text-sm text-gray-700">
+                            <div className="px-5 py-4 space-y-3 text-sm text-ink-sub">
                                 <div className="flex gap-3">
-                                    <div className="mt-1 flex h-9 w-9 items-center justify-center rounded-lg bg-amber-50 text-amber-700">
+                                    <div className="mt-1 flex h-9 w-9 items-center justify-center rounded-lg bg-spot-subtle text-spot">
                                         <GiCoffeePot size={18} />
                                     </div>
                                     <div className="flex-1">
-                                        <p className="font-semibold text-gray-900">湯量は総量表示です</p>
-                                        <p className="text-gray-700">
+                                        <p className="font-semibold text-ink">湯量は総量表示です</p>
+                                        <p className="text-ink-sub">
                                             表示される湯量は合計量です。スケールを毎回0に戻す必要はありません。
                                         </p>
                                         {waterInfo && (
-                                            <p className="mt-1 text-xs text-amber-700">今回の総湯量: {waterInfo}</p>
+                                            <p className="mt-1 text-xs text-spot">今回の総湯量: {waterInfo}</p>
                                         )}
                                     </div>
                                 </div>
 
                                 <div className="flex gap-3">
-                                    <div className="mt-1 flex h-9 w-9 items-center justify-center rounded-lg bg-amber-50 text-amber-700">
+                                    <div className="mt-1 flex h-9 w-9 items-center justify-center rounded-lg bg-spot-subtle text-spot">
                                         <Timer size={18} weight="duotone" />
                                     </div>
                                     <div className="flex-1">
-                                        <p className="font-semibold text-gray-900">蒸らし後にタイマー開始</p>
-                                        <p className="text-gray-700">
+                                        <p className="font-semibold text-ink">蒸らし後にタイマー開始</p>
+                                        <p className="text-ink-sub">
                                             蒸らしのお湯を入れたら、タイマーを開始してください。
                                         </p>
                                     </div>
@@ -122,21 +123,22 @@ export const StartHintDialog: React.FC<StartHintDialogProps> = ({
                             </div>
 
                             <div className="flex items-center justify-between px-5 pb-5 pt-1">
-                                <button
-                                    type="button"
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
                                     onClick={onClose}
-                                    className="inline-flex items-center gap-2 rounded-full px-3 py-2 text-gray-600 hover:bg-gray-100 hover:text-gray-800 transition-colors"
+                                    className="gap-2"
                                 >
                                     <span className="text-base">×</span>
-                                    <span className="text-sm font-medium">閉じる</span>
-                                </button>
-                                <button
-                                    type="button"
+                                    閉じる
+                                </Button>
+                                <Button
+                                    variant="primary"
                                     onClick={onStart}
-                                    className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-5 py-3 font-semibold text-white shadow-sm transition-all hover:bg-primary-dark active:scale-[0.99] touch-manipulation"
+                                    className="!rounded-full !px-5 !py-3 active:scale-[0.99] touch-manipulation"
                                 >
                                     ガイド開始
-                                </button>
+                                </Button>
                             </div>
                         </div>
                     </motion.div>
@@ -145,4 +147,3 @@ export const StartHintDialog: React.FC<StartHintDialogProps> = ({
         </AnimatePresence>
     );
 };
-

--- a/components/drip-guide/StartHoffmannDialog.tsx
+++ b/components/drip-guide/StartHoffmannDialog.tsx
@@ -7,6 +7,7 @@ import { calculateRecipeForServings } from '@/lib/drip-guide/recipeCalculator';
 import { MOCK_RECIPES } from '@/lib/drip-guide/mockData';
 import { RECIPE_HOFFMANN_STEP_DETAILS } from '@/lib/drip-guide/recipeHoffmannContent';
 import { useDialogKeyboard } from '@/hooks/drip-guide/useDialogKeyboard';
+import { Button } from '@/components/ui';
 import { DialogOverlay } from './dialogs/shared/DialogOverlay';
 import { HoffmannDialogHeader } from './dialogs/hoffmann/HoffmannDialogHeader';
 import { HoffmannDialogForm } from './dialogs/hoffmann/HoffmannDialogForm';
@@ -84,7 +85,7 @@ export const StartHoffmannDialog: React.FC<StartHoffmannDialogProps> = ({
                         onClick={onClose}
                     >
                         <div
-                            className="w-full max-w-2xl rounded-2xl border border-amber-100 bg-white shadow-2xl my-8"
+                            className="w-full max-w-2xl rounded-2xl border border-edge bg-overlay shadow-2xl my-8"
                             onClick={(e) => e.stopPropagation()}
                         >
                             <HoffmannDialogHeader />
@@ -101,21 +102,22 @@ export const StartHoffmannDialog: React.FC<StartHoffmannDialogProps> = ({
                             />
 
                             <div className="flex items-center justify-between px-5 pb-5 pt-1">
-                                <button
-                                    type="button"
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
                                     onClick={onClose}
-                                    className="inline-flex items-center gap-2 rounded-full px-3 py-2 text-gray-600 hover:bg-gray-100 hover:text-gray-800 transition-colors"
+                                    className="gap-2"
                                 >
                                     <span className="text-base">×</span>
-                                    <span className="text-sm font-medium">閉じる</span>
-                                </button>
-                                <button
-                                    type="button"
+                                    閉じる
+                                </Button>
+                                <Button
+                                    variant="primary"
                                     onClick={handleStartGuide}
-                                    className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-5 py-3 font-semibold text-white shadow-sm transition-all hover:bg-primary-dark active:scale-[0.99] touch-manipulation"
+                                    className="!rounded-full !px-5 !py-3 active:scale-[0.99] touch-manipulation"
                                 >
                                     ガイド開始
-                                </button>
+                                </Button>
                             </div>
                         </div>
                     </motion.div>

--- a/components/drip-guide/StepEditor.tsx
+++ b/components/drip-guide/StepEditor.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { DripStep } from '@/lib/drip-guide/types';
 import { Trash, Plus, ListNumbers } from 'phosphor-react';
+import { Button, IconButton } from '@/components/ui';
 
 interface StepEditorProps {
     steps: DripStep[];
@@ -27,8 +28,6 @@ export const StepEditor: React.FC<StepEditorProps> = ({ steps, onChange, isManua
     const updateStep = (index: number, field: keyof DripStep, value: DripStep[keyof DripStep]) => {
         const newSteps = [...steps];
         newSteps[index] = { ...newSteps[index], [field]: value };
-        // Sort by startTimeSec automatically? Maybe better to let user control or sort on save.
-        // For now, let's just update.
         onChange(newSteps);
     };
 
@@ -40,7 +39,7 @@ export const StepEditor: React.FC<StepEditorProps> = ({ steps, onChange, isManua
     return (
         <div className="space-y-4">
             <div className="flex items-center justify-between">
-                <h3 className="font-bold text-gray-700 flex items-center gap-2">
+                <h3 className="font-bold text-ink-sub flex items-center gap-2">
                     <ListNumbers size={20} />
                     手順ステップ
                 </h3>
@@ -48,17 +47,17 @@ export const StepEditor: React.FC<StepEditorProps> = ({ steps, onChange, isManua
 
             <div className="space-y-3">
                 {steps.map((step, index) => (
-                    <div key={step.id} className="bg-gray-50 p-4 rounded-lg border border-gray-200 relative group">
+                    <div key={step.id} className="bg-ground p-4 rounded-lg border border-edge relative group">
                         <div className="grid grid-cols-12 gap-3">
                             {/* Time Input */}
                             {!isManualMode && (
                                 <div className="col-span-3 sm:col-span-2">
-                                    <label className="block text-xs font-medium text-gray-500 mb-1">開始(秒)</label>
+                                    <label className="block text-xs font-medium text-ink-muted mb-1">開始(秒)</label>
                                     <input
                                         type="number"
                                         value={step.startTimeSec}
                                         onChange={(e) => updateStep(index, 'startTimeSec', parseInt(e.target.value) || 0)}
-                                        className="w-full p-3 sm:p-2 border rounded focus:ring-2 focus:ring-amber-500 outline-none text-base"
+                                        className="w-full p-3 sm:p-2 border border-edge rounded bg-field text-ink focus:ring-2 focus:ring-spot outline-none text-base"
                                         min={0}
                                     />
                                 </div>
@@ -66,60 +65,62 @@ export const StepEditor: React.FC<StepEditorProps> = ({ steps, onChange, isManua
 
                             {/* Title Input */}
                             <div className={isManualMode ? "col-span-6 sm:col-span-5" : "col-span-9 sm:col-span-4"}>
-                                <label className="block text-xs font-medium text-gray-500 mb-1">タイトル</label>
+                                <label className="block text-xs font-medium text-ink-muted mb-1">タイトル</label>
                                 <input
                                     type="text"
                                     value={step.title}
                                     onChange={(e) => updateStep(index, 'title', e.target.value)}
                                     placeholder="例: 蒸らし"
-                                    className="w-full p-3 sm:p-2 border rounded focus:ring-2 focus:ring-amber-500 outline-none text-base"
+                                    className="w-full p-3 sm:p-2 border border-edge rounded bg-field text-ink placeholder:text-ink-muted focus:ring-2 focus:ring-spot outline-none text-base"
                                 />
                             </div>
 
                             {/* Target Water Input */}
                             <div className="col-span-6 sm:col-span-3">
-                                <label className="block text-xs font-medium text-gray-500 mb-1">目標湯量(g)</label>
+                                <label className="block text-xs font-medium text-ink-muted mb-1">目標湯量(g)</label>
                                 <input
                                     type="number"
                                     value={step.targetTotalWater || ''}
                                     onChange={(e) => updateStep(index, 'targetTotalWater', e.target.value ? parseInt(e.target.value) : undefined)}
                                     placeholder="任意"
-                                    className="w-full p-3 sm:p-2 border rounded focus:ring-2 focus:ring-amber-500 outline-none text-base"
+                                    className="w-full p-3 sm:p-2 border border-edge rounded bg-field text-ink placeholder:text-ink-muted focus:ring-2 focus:ring-spot outline-none text-base"
                                 />
                             </div>
 
-                            {/* Delete Button (Desktop: right aligned, Mobile: absolute top-right) */}
+                            {/* Delete Button */}
                             <div className={isManualMode ? "col-span-6 sm:col-span-4 flex items-end justify-end" : "col-span-6 sm:col-span-3 flex items-end justify-end"}>
-                                <button
+                                <IconButton
+                                    variant="ghost"
+                                    size="sm"
                                     onClick={() => removeStep(index)}
-                                    className="text-gray-400 hover:text-red-500 p-3 sm:p-2 rounded-full hover:bg-red-50 transition-colors touch-manipulation"
+                                    className="text-ink-muted hover:text-danger hover:bg-danger-subtle"
                                     title="ステップを削除"
                                 >
                                     <Trash size={20} />
-                                </button>
+                                </IconButton>
                             </div>
 
                             {/* Description Input (Full width) */}
                             <div className="col-span-12">
-                                <label className="block text-xs font-medium text-gray-500 mb-1">説明・詳細</label>
+                                <label className="block text-xs font-medium text-ink-muted mb-1">説明・詳細</label>
                                 <textarea
                                     value={step.description}
                                     onChange={(e) => updateStep(index, 'description', e.target.value)}
                                     placeholder="例: 全体にお湯を行き渡らせます"
-                                    className="w-full p-3 sm:p-2 border rounded focus:ring-2 focus:ring-amber-500 outline-none text-base"
+                                    className="w-full p-3 sm:p-2 border border-edge rounded bg-field text-ink placeholder:text-ink-muted focus:ring-2 focus:ring-spot outline-none text-base"
                                     rows={2}
                                 />
                             </div>
 
                             {/* Note/Hint Input (Full width) */}
                             <div className="col-span-12">
-                                <label className="block text-xs font-medium text-gray-500 mb-1">ヒント</label>
+                                <label className="block text-xs font-medium text-ink-muted mb-1">ヒント</label>
                                 <input
                                     type="text"
                                     value={step.note || ''}
                                     onChange={(e) => updateStep(index, 'note', e.target.value || undefined)}
                                     placeholder="例: 粉全体が均一に膨らむのを確認"
-                                    className="w-full p-3 sm:p-2 border rounded focus:ring-2 focus:ring-amber-500 outline-none text-base"
+                                    className="w-full p-3 sm:p-2 border border-edge rounded bg-field text-ink placeholder:text-ink-muted focus:ring-2 focus:ring-spot outline-none text-base"
                                 />
                             </div>
                         </div>
@@ -127,14 +128,16 @@ export const StepEditor: React.FC<StepEditorProps> = ({ steps, onChange, isManua
                 ))}
             </div>
 
-            <button
-                type="button"
+            <Button
+                variant="outline"
+                fullWidth
                 onClick={addStep}
-                className="w-full py-3 border-2 border-dashed border-gray-300 rounded-lg text-gray-500 font-medium hover:border-amber-500 hover:text-amber-600 transition-colors flex items-center justify-center gap-2"
+                type="button"
+                className="!border-2 !border-dashed !border-edge gap-2"
             >
                 <Plus size={20} />
                 ステップを追加
-            </button>
+            </Button>
         </div>
     );
 };

--- a/components/drip-guide/dialogs/46/Dialog46DescriptionModal.tsx
+++ b/components/drip-guide/dialogs/46/Dialog46DescriptionModal.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { AnimatePresence, motion, type MotionProps } from 'framer-motion';
 import { Coffee, Timer, Drop } from 'phosphor-react';
 import { RECIPE46_DESCRIPTION_SECTIONS } from '@/lib/drip-guide/recipe46Content';
+import { Button } from '@/components/ui';
 
 const overlayMotion = {
     initial: { opacity: 0 },
@@ -42,18 +43,18 @@ export const Dialog46DescriptionModal: React.FC<Dialog46DescriptionModalProps> =
                         onClick={onClose}
                     >
                         <div
-                            className="w-full max-w-xl rounded-2xl bg-white shadow-xl relative overflow-hidden flex flex-col"
+                            className="w-full max-w-xl rounded-2xl bg-overlay shadow-xl relative overflow-hidden flex flex-col"
                             style={{ maxHeight: '90vh' }}
                             onClick={(e) => e.stopPropagation()}
                         >
-                            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
-                                <h3 className="text-xl font-bold text-gray-900">
+                            <div className="flex items-center justify-between px-6 py-4 border-b border-edge">
+                                <h3 className="text-xl font-bold text-ink">
                                     4:6メソッドのポイント
                                 </h3>
                                 <button
                                     type="button"
                                     onClick={onClose}
-                                    className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-full transition-colors"
+                                    className="p-2 text-ink-muted hover:text-ink hover:bg-ground rounded-full transition-colors"
                                 >
                                     <span className="text-2xl leading-none">×</span>
                                 </button>
@@ -62,7 +63,7 @@ export const Dialog46DescriptionModal: React.FC<Dialog46DescriptionModalProps> =
                             <div className="flex-1 overflow-y-auto px-6 py-6 space-y-6">
                                 {RECIPE46_DESCRIPTION_SECTIONS.map((section, idx) => (
                                     <div key={idx} className="flex gap-4">
-                                        <div className="flex-shrink-0 w-10 h-10 rounded-full bg-amber-50 text-amber-700 flex items-center justify-center">
+                                        <div className="flex-shrink-0 w-10 h-10 rounded-full bg-spot-subtle text-spot flex items-center justify-center">
                                             {section.icon === 'target' && <Drop size={20} weight="bold" />}
                                             {section.icon === 'rule' && <Coffee size={20} weight="bold" />}
                                             {section.icon === 'timer' && <Timer size={20} weight="bold" />}
@@ -70,11 +71,11 @@ export const Dialog46DescriptionModal: React.FC<Dialog46DescriptionModalProps> =
                                                 <Drop size={20} weight="duotone" />
                                             )}
                                         </div>
-                                        <div className="flex-1 border-b border-gray-50 pb-4">
-                                            <h4 className="font-bold text-gray-900 mb-1 text-base">
+                                        <div className="flex-1 border-b border-edge/30 pb-4">
+                                            <h4 className="font-bold text-ink mb-1 text-base">
                                                 {section.title}
                                             </h4>
-                                            <p className="text-[15px] leading-relaxed text-gray-600 whitespace-pre-wrap">
+                                            <p className="text-[15px] leading-relaxed text-ink-sub whitespace-pre-wrap">
                                                 {section.content}
                                             </p>
                                         </div>
@@ -82,14 +83,14 @@ export const Dialog46DescriptionModal: React.FC<Dialog46DescriptionModalProps> =
                                 ))}
                             </div>
 
-                            <div className="px-6 py-4 bg-gray-50 border-t border-gray-100 flex justify-end">
-                                <button
-                                    type="button"
+                            <div className="px-6 py-4 bg-ground border-t border-edge flex justify-end">
+                                <Button
+                                    variant="coffee"
+                                    size="sm"
                                     onClick={onClose}
-                                    className="bg-gray-900 text-white px-8 py-2.5 rounded-lg font-bold text-sm hover:bg-black transition-colors"
                                 >
                                     閉じる
-                                </button>
+                                </Button>
                             </div>
                         </div>
                     </motion.div>

--- a/components/drip-guide/dialogs/46/Dialog46Form.tsx
+++ b/components/drip-guide/dialogs/46/Dialog46Form.tsx
@@ -28,26 +28,26 @@ export const Dialog46Form: React.FC<Dialog46FormProps> = ({
             <button
                 type="button"
                 onClick={onDescriptionClick}
-                className="w-full rounded-lg bg-amber-50 border border-amber-100 p-3 text-left hover:bg-amber-100 transition-colors"
+                className="w-full rounded-lg bg-spot-subtle border border-spot/20 p-3 text-left hover:bg-spot-surface transition-colors"
             >
                 <div className="flex items-center justify-between">
-                    <span className="text-sm font-semibold text-amber-800">
+                    <span className="text-sm font-semibold text-spot-hover">
                         4:6メソッドのポイント（必読）
                     </span>
-                    <span className="text-amber-600 text-xs">クリックして開く</span>
+                    <span className="text-spot text-xs">クリックして開く</span>
                 </div>
             </button>
 
             {/* 人前選択 */}
             <div>
-                <label htmlFor="servings-46" className="block text-sm font-semibold text-gray-900 mb-2">
+                <label htmlFor="servings-46" className="block text-sm font-semibold text-ink mb-2">
                     人前
                 </label>
                 <select
                     id="servings-46"
                     value={servings}
                     onChange={(e) => onServingsChange(parseInt(e.target.value, 10))}
-                    className="w-full py-2 px-3 pr-10 rounded-lg text-sm font-medium transition-colors min-h-[44px] bg-white border border-gray-300 text-gray-700 hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500 appearance-none cursor-pointer"
+                    className="w-full py-2 px-3 pr-10 rounded-lg text-sm font-medium transition-colors min-h-[44px] bg-field border border-edge text-ink hover:border-edge-strong focus:outline-none focus:ring-2 focus:ring-spot focus:border-spot appearance-none cursor-pointer"
                     aria-label="人前を選択"
                 >
                     {[1, 2, 3, 4, 5, 6, 7, 8].map((s) => (
@@ -60,7 +60,7 @@ export const Dialog46Form: React.FC<Dialog46FormProps> = ({
 
             {/* 味わい選択 */}
             <div>
-                <label className="block text-sm font-semibold text-gray-900 mb-2">味わい</label>
+                <label className="block text-sm font-semibold text-ink mb-2">味わい</label>
                 <div className="grid grid-cols-3 gap-2">
                     {(['basic', 'sweet', 'bright'] as Taste46[]).map((t) => (
                         <button
@@ -69,8 +69,8 @@ export const Dialog46Form: React.FC<Dialog46FormProps> = ({
                             onClick={() => onTasteChange(t)}
                             className={`py-3 px-4 rounded-lg text-sm font-medium transition-all min-h-[44px] ${
                                 taste === t
-                                    ? 'bg-amber-500 text-white shadow-md'
-                                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                                    ? 'bg-spot text-white shadow-md'
+                                    : 'bg-ground text-ink-sub hover:bg-ground/80'
                             }`}
                         >
                             {TASTE_LABELS[t]}
@@ -81,7 +81,7 @@ export const Dialog46Form: React.FC<Dialog46FormProps> = ({
 
             {/* 濃度選択 */}
             <div>
-                <label className="block text-sm font-semibold text-gray-900 mb-2">濃度</label>
+                <label className="block text-sm font-semibold text-ink mb-2">濃度</label>
                 <div className="grid grid-cols-3 gap-2">
                     {(['light', 'strong2', 'strong3'] as Strength46[]).map((s) => (
                         <button
@@ -90,8 +90,8 @@ export const Dialog46Form: React.FC<Dialog46FormProps> = ({
                             onClick={() => onStrengthChange(s)}
                             className={`py-3 px-4 rounded-lg text-sm font-medium transition-all min-h-[44px] ${
                                 strength === s
-                                    ? 'bg-amber-500 text-white shadow-md'
-                                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                                    ? 'bg-spot text-white shadow-md'
+                                    : 'bg-ground text-ink-sub hover:bg-ground/80'
                             }`}
                         >
                             {STRENGTH_LABELS[s]}

--- a/components/drip-guide/dialogs/46/Dialog46Header.tsx
+++ b/components/drip-guide/dialogs/46/Dialog46Header.tsx
@@ -6,14 +6,14 @@ import { Coffee } from 'phosphor-react';
 export const Dialog46Header: React.FC = () => {
     return (
         <div className="flex items-start gap-3 px-5 pt-5">
-            <div className="flex h-11 w-11 items-center justify-center rounded-full bg-amber-50 text-amber-700">
+            <div className="flex h-11 w-11 items-center justify-center rounded-full bg-spot-subtle text-spot">
                 <Coffee size={24} weight="duotone" />
             </div>
             <div className="flex-1">
-                <p className="text-xs font-semibold uppercase tracking-wide text-amber-700">
+                <p className="text-xs font-semibold uppercase tracking-wide text-spot">
                     4:6メソッド（粕谷）
                 </p>
-                <h3 className="mt-1 text-lg font-bold text-gray-900">条件を選択してください</h3>
+                <h3 className="mt-1 text-lg font-bold text-ink">条件を選択してください</h3>
             </div>
         </div>
     );

--- a/components/drip-guide/dialogs/46/Dialog46Preview.tsx
+++ b/components/drip-guide/dialogs/46/Dialog46Preview.tsx
@@ -12,7 +12,7 @@ interface Dialog46PreviewProps {
 export const Dialog46Preview: React.FC<Dialog46PreviewProps> = ({ recipe }) => {
     return (
         <div className="px-5 pt-0 pb-4">
-            <div className="pt-4 border-t border-gray-200">
+            <div className="pt-4 border-t border-edge">
                 <RecipeSummary
                     beanAmountGram={recipe.beanAmountGram}
                     totalWaterGram={recipe.totalWaterGram}

--- a/components/drip-guide/dialogs/hoffmann/HoffmannDescriptionModal.tsx
+++ b/components/drip-guide/dialogs/hoffmann/HoffmannDescriptionModal.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { AnimatePresence, motion, type MotionProps } from 'framer-motion';
 import { Coffee, Timer, Drop, Spiral } from 'phosphor-react';
 import { RECIPE_HOFFMANN_DESCRIPTION_SECTIONS } from '@/lib/drip-guide/recipeHoffmannContent';
+import { Button } from '@/components/ui';
 
 const overlayMotion = {
     initial: { opacity: 0 },
@@ -57,18 +58,18 @@ export const HoffmannDescriptionModal: React.FC<HoffmannDescriptionModalProps> =
                         onClick={onClose}
                     >
                         <div
-                            className="w-full max-w-xl rounded-2xl bg-white shadow-xl relative overflow-hidden flex flex-col"
+                            className="w-full max-w-xl rounded-2xl bg-overlay shadow-xl relative overflow-hidden flex flex-col"
                             style={{ maxHeight: '90vh' }}
                             onClick={(e) => e.stopPropagation()}
                         >
-                            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
-                                <h3 className="text-xl font-bold text-gray-900">
+                            <div className="flex items-center justify-between px-6 py-4 border-b border-edge">
+                                <h3 className="text-xl font-bold text-ink">
                                     Hoffmann V60のポイント
                                 </h3>
                                 <button
                                     type="button"
                                     onClick={onClose}
-                                    className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-full transition-colors"
+                                    className="p-2 text-ink-muted hover:text-ink hover:bg-ground rounded-full transition-colors"
                                 >
                                     <span className="text-2xl leading-none">×</span>
                                 </button>
@@ -77,14 +78,14 @@ export const HoffmannDescriptionModal: React.FC<HoffmannDescriptionModalProps> =
                             <div className="flex-1 overflow-y-auto px-6 py-6 space-y-6">
                                 {RECIPE_HOFFMANN_DESCRIPTION_SECTIONS.map((section, idx) => (
                                     <div key={idx} className="flex gap-4">
-                                        <div className="flex-shrink-0 w-10 h-10 rounded-full bg-amber-50 text-amber-700 flex items-center justify-center">
+                                        <div className="flex-shrink-0 w-10 h-10 rounded-full bg-spot-subtle text-spot flex items-center justify-center">
                                             {getIcon(section.icon)}
                                         </div>
-                                        <div className="flex-1 border-b border-gray-50 pb-4">
-                                            <h4 className="font-bold text-gray-900 mb-1 text-base">
+                                        <div className="flex-1 border-b border-edge/30 pb-4">
+                                            <h4 className="font-bold text-ink mb-1 text-base">
                                                 {section.title}
                                             </h4>
-                                            <p className="text-[15px] leading-relaxed text-gray-600 whitespace-pre-wrap">
+                                            <p className="text-[15px] leading-relaxed text-ink-sub whitespace-pre-wrap">
                                                 {section.content}
                                             </p>
                                         </div>
@@ -92,14 +93,14 @@ export const HoffmannDescriptionModal: React.FC<HoffmannDescriptionModalProps> =
                                 ))}
                             </div>
 
-                            <div className="px-6 py-4 bg-gray-50 border-t border-gray-100 flex justify-end">
-                                <button
-                                    type="button"
+                            <div className="px-6 py-4 bg-ground border-t border-edge flex justify-end">
+                                <Button
+                                    variant="coffee"
+                                    size="sm"
                                     onClick={onClose}
-                                    className="bg-gray-900 text-white px-8 py-2.5 rounded-lg font-bold text-sm hover:bg-black transition-colors"
                                 >
                                     閉じる
-                                </button>
+                                </Button>
                             </div>
                         </div>
                     </motion.div>

--- a/components/drip-guide/dialogs/hoffmann/HoffmannDialogForm.tsx
+++ b/components/drip-guide/dialogs/hoffmann/HoffmannDialogForm.tsx
@@ -19,26 +19,26 @@ export const HoffmannDialogForm: React.FC<HoffmannDialogFormProps> = ({
             <button
                 type="button"
                 onClick={onDescriptionClick}
-                className="w-full rounded-lg bg-amber-50 border border-amber-100 p-3 text-left hover:bg-amber-100 transition-colors"
+                className="w-full rounded-lg bg-spot-subtle border border-spot/20 p-3 text-left hover:bg-spot-surface transition-colors"
             >
                 <div className="flex items-center justify-between">
-                    <span className="text-sm font-semibold text-amber-800">
+                    <span className="text-sm font-semibold text-spot-hover">
                         Hoffmann V60のポイント（必読）
                     </span>
-                    <span className="text-amber-600 text-xs">クリックして開く</span>
+                    <span className="text-spot text-xs">クリックして開く</span>
                 </div>
             </button>
 
             {/* 人前選択 */}
             <div>
-                <label htmlFor="servings-hoffmann" className="block text-sm font-semibold text-gray-900 mb-2">
+                <label htmlFor="servings-hoffmann" className="block text-sm font-semibold text-ink mb-2">
                     人前
                 </label>
                 <select
                     id="servings-hoffmann"
                     value={servings}
                     onChange={(e) => onServingsChange(parseInt(e.target.value, 10))}
-                    className="w-full py-2 px-3 pr-10 rounded-lg text-sm font-medium transition-colors min-h-[44px] bg-white border border-gray-300 text-gray-700 hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500 appearance-none cursor-pointer"
+                    className="w-full py-2 px-3 pr-10 rounded-lg text-sm font-medium transition-colors min-h-[44px] bg-field border border-edge text-ink hover:border-edge-strong focus:outline-none focus:ring-2 focus:ring-spot focus:border-spot appearance-none cursor-pointer"
                     aria-label="人前を選択"
                 >
                     {[1, 2, 3, 4, 5, 6, 7, 8].map((s) => (

--- a/components/drip-guide/dialogs/hoffmann/HoffmannDialogHeader.tsx
+++ b/components/drip-guide/dialogs/hoffmann/HoffmannDialogHeader.tsx
@@ -6,14 +6,14 @@ import { Coffee } from 'phosphor-react';
 export const HoffmannDialogHeader: React.FC = () => {
     return (
         <div className="flex items-start gap-3 px-5 pt-5">
-            <div className="flex h-11 w-11 items-center justify-center rounded-full bg-amber-50 text-amber-700">
+            <div className="flex h-11 w-11 items-center justify-center rounded-full bg-spot-subtle text-spot">
                 <Coffee size={24} weight="duotone" />
             </div>
             <div className="flex-1">
-                <p className="text-xs font-semibold uppercase tracking-wide text-amber-700">
+                <p className="text-xs font-semibold uppercase tracking-wide text-spot">
                     James Hoffmann V60
                 </p>
-                <h3 className="mt-1 text-lg font-bold text-gray-900">Ultimate V60 Technique</h3>
+                <h3 className="mt-1 text-lg font-bold text-ink">Ultimate V60 Technique</h3>
             </div>
         </div>
     );

--- a/components/drip-guide/dialogs/hoffmann/HoffmannPreview.tsx
+++ b/components/drip-guide/dialogs/hoffmann/HoffmannPreview.tsx
@@ -32,7 +32,7 @@ export const HoffmannPreview: React.FC<HoffmannPreviewProps> = ({ recipe, onStep
 
     return (
         <div className="px-5 pt-0 pb-4">
-            <div className="pt-4 border-t border-gray-200">
+            <div className="pt-4 border-t border-edge">
                 <RecipeSummary
                     beanAmountGram={recipe.beanAmountGram}
                     totalWaterGram={recipe.totalWaterGram}

--- a/components/drip-guide/dialogs/hoffmann/HoffmannStepDetailModal.tsx
+++ b/components/drip-guide/dialogs/hoffmann/HoffmannStepDetailModal.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { AnimatePresence, motion, type MotionProps } from 'framer-motion';
 import { Drop, Timer, SpinnerGap } from 'phosphor-react';
 import { RECIPE_HOFFMANN_STEP_DETAILS } from '@/lib/drip-guide/recipeHoffmannContent';
+import { Button } from '@/components/ui';
 
 type StepDetailKey = keyof typeof RECIPE_HOFFMANN_STEP_DETAILS;
 
@@ -63,17 +64,17 @@ export const HoffmannStepDetailModal: React.FC<HoffmannStepDetailModalProps> = (
                         onClick={onClose}
                     >
                         <div
-                            className="w-full max-w-md rounded-2xl bg-white shadow-xl relative overflow-hidden"
+                            className="w-full max-w-md rounded-2xl bg-overlay shadow-xl relative overflow-hidden"
                             onClick={(e) => e.stopPropagation()}
                         >
-                            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+                            <div className="flex items-center justify-between px-6 py-4 border-b border-edge">
                                 <div className="flex items-center gap-3">
-                                    <div className="w-10 h-10 rounded-full bg-amber-50 text-amber-700 flex items-center justify-center">
+                                    <div className="w-10 h-10 rounded-full bg-spot-subtle text-spot flex items-center justify-center">
                                         {getIcon(detail.icon)}
                                     </div>
                                     <div>
-                                        <h3 className="text-lg font-bold text-gray-900">{detail.title}</h3>
-                                        <p className="text-xs text-amber-700 font-medium">
+                                        <h3 className="text-lg font-bold text-ink">{detail.title}</h3>
+                                        <p className="text-xs text-spot font-medium">
                                             {detail.technique}
                                         </p>
                                     </div>
@@ -81,24 +82,24 @@ export const HoffmannStepDetailModal: React.FC<HoffmannStepDetailModalProps> = (
                                 <button
                                     type="button"
                                     onClick={onClose}
-                                    className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-full transition-colors"
+                                    className="p-2 text-ink-muted hover:text-ink hover:bg-ground rounded-full transition-colors"
                                 >
                                     <span className="text-2xl leading-none">×</span>
                                 </button>
                             </div>
 
                             <div className="px-6 py-5 space-y-4">
-                                <p className="text-gray-700 leading-relaxed">{detail.description}</p>
+                                <p className="text-ink-sub leading-relaxed">{detail.description}</p>
 
-                                <div className="bg-amber-50 rounded-lg p-4">
-                                    <h4 className="font-semibold text-amber-800 mb-2 text-sm">ポイント</h4>
+                                <div className="bg-spot-subtle rounded-lg p-4">
+                                    <h4 className="font-semibold text-spot-hover mb-2 text-sm">ポイント</h4>
                                     <ul className="space-y-2">
                                         {detail.tips.map((tip, idx) => (
                                             <li
                                                 key={idx}
-                                                className="flex items-start gap-2 text-sm text-amber-900"
+                                                className="flex items-start gap-2 text-sm text-ink"
                                             >
-                                                <span className="text-amber-600 mt-0.5">•</span>
+                                                <span className="text-spot mt-0.5">•</span>
                                                 <span>{tip}</span>
                                             </li>
                                         ))}
@@ -106,14 +107,14 @@ export const HoffmannStepDetailModal: React.FC<HoffmannStepDetailModalProps> = (
                                 </div>
                             </div>
 
-                            <div className="px-6 py-4 bg-gray-50 border-t border-gray-100 flex justify-end">
-                                <button
-                                    type="button"
+                            <div className="px-6 py-4 bg-ground border-t border-edge flex justify-end">
+                                <Button
+                                    variant="coffee"
+                                    size="sm"
                                     onClick={onClose}
-                                    className="bg-gray-900 text-white px-6 py-2 rounded-lg font-bold text-sm hover:bg-black transition-colors"
                                 >
                                     閉じる
-                                </button>
+                                </Button>
                             </div>
                         </div>
                     </motion.div>

--- a/components/drip-guide/dialogs/shared/RecipeStepTable.tsx
+++ b/components/drip-guide/dialogs/shared/RecipeStepTable.tsx
@@ -19,17 +19,17 @@ export const RecipeStepTable: React.FC<RecipeStepTableProps> = ({
         <div className="overflow-x-auto">
             <table className="w-full text-sm">
                 <thead>
-                    <tr className="border-b border-gray-200">
-                        <th className="text-left py-2 px-2 font-semibold text-gray-700">開始時刻</th>
-                        <th className="text-left py-2 px-2 font-semibold text-gray-700">
+                    <tr className="border-b border-edge">
+                        <th className="text-left py-2 px-2 font-semibold text-ink-sub">開始時刻</th>
+                        <th className="text-left py-2 px-2 font-semibold text-ink-sub">
                             {showPourAmount ? 'タイトル' : 'ステップ'}
                         </th>
                         {showPourAmount && (
-                            <th className="text-right py-2 px-2 font-semibold text-gray-700">注湯量(g)</th>
+                            <th className="text-right py-2 px-2 font-semibold text-ink-sub">注湯量(g)</th>
                         )}
-                        <th className="text-right py-2 px-2 font-semibold text-gray-700">累積(g)</th>
+                        <th className="text-right py-2 px-2 font-semibold text-ink-sub">累積(g)</th>
                         {onStepDetailClick && (
-                            <th className="text-center py-2 px-2 font-semibold text-gray-700">詳細</th>
+                            <th className="text-center py-2 px-2 font-semibold text-ink-sub">詳細</th>
                         )}
                     </tr>
                 </thead>
@@ -40,17 +40,17 @@ export const RecipeStepTable: React.FC<RecipeStepTableProps> = ({
                         const pourAmount = currentTarget - prevTarget;
 
                         return (
-                            <tr key={step.id} className="border-b border-gray-100">
-                                <td className="py-2 px-2 text-gray-700 font-mono">
+                            <tr key={step.id} className="border-b border-edge/50">
+                                <td className="py-2 px-2 text-ink-sub font-mono">
                                     {formatTime(step.startTimeSec)}
                                 </td>
-                                <td className="py-2 px-2 text-gray-700">{step.title}</td>
+                                <td className="py-2 px-2 text-ink-sub">{step.title}</td>
                                 {showPourAmount && (
-                                    <td className="py-2 px-2 text-right text-gray-900 font-semibold">
+                                    <td className="py-2 px-2 text-right text-ink font-semibold">
                                         {pourAmount}
                                     </td>
                                 )}
-                                <td className="py-2 px-2 text-right text-gray-900 font-semibold">
+                                <td className="py-2 px-2 text-right text-ink font-semibold">
                                     {step.targetTotalWater ?? '-'}
                                 </td>
                                 {onStepDetailClick && (
@@ -58,7 +58,7 @@ export const RecipeStepTable: React.FC<RecipeStepTableProps> = ({
                                         <button
                                             type="button"
                                             onClick={() => onStepDetailClick(step.id, step.title)}
-                                            className="text-amber-600 hover:text-amber-800 text-xs underline"
+                                            className="text-spot hover:text-spot-hover text-xs underline"
                                         >
                                             詳細
                                         </button>

--- a/components/drip-guide/dialogs/shared/RecipeSummary.tsx
+++ b/components/drip-guide/dialogs/shared/RecipeSummary.tsx
@@ -19,18 +19,18 @@ export const RecipeSummary: React.FC<RecipeSummaryProps> = ({
         <>
             <div className="grid grid-cols-2 gap-4 mb-4">
                 <div className="flex items-center gap-2">
-                    <Coffee size={20} className="text-amber-700" />
-                    <span className="text-sm text-gray-600">豆量:</span>
-                    <span className="text-sm font-semibold text-gray-900">{beanAmountGram}g</span>
+                    <Coffee size={20} className="text-spot" />
+                    <span className="text-sm text-ink-sub">豆量:</span>
+                    <span className="text-sm font-semibold text-ink">{beanAmountGram}g</span>
                 </div>
                 <div className="flex items-center gap-2">
-                    <Drop size={20} className="text-blue-500" />
-                    <span className="text-sm text-gray-600">総湯量:</span>
-                    <span className="text-sm font-semibold text-gray-900">{totalWaterGram}g</span>
+                    <Drop size={20} className="text-info" />
+                    <span className="text-sm text-ink-sub">総湯量:</span>
+                    <span className="text-sm font-semibold text-ink">{totalWaterGram}g</span>
                 </div>
             </div>
 
-            <div className="mt-4 flex items-center gap-2 text-xs text-gray-500">
+            <div className="mt-4 flex items-center gap-2 text-xs text-ink-muted">
                 <Timer size={16} />
                 <span>
                     総時間: {formatTime(totalDurationSec)} ({Math.floor(totalDurationSec / 60)}分

--- a/components/drip-guide/runner/CompletionScreen.tsx
+++ b/components/drip-guide/runner/CompletionScreen.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState, useRef } from 'react';
 import Link from 'next/link';
 import Lottie, { LottieRefCurrentProps } from 'lottie-react';
+import { Button } from '@/components/ui';
 
 interface CompletionScreenProps {
     onReset: () => void;
@@ -37,7 +38,7 @@ export const CompletionScreen: React.FC<CompletionScreenProps> = ({ onReset }) =
     }, [animationData]);
 
     return (
-        <div className="flex flex-col items-center justify-center h-[100dvh] text-center p-6">
+        <div className="flex flex-col items-center justify-center h-[100dvh] text-center p-6 bg-surface">
             <div className="mb-6 flex items-center justify-center">
                 {animationData ? (
                     <Lottie
@@ -51,25 +52,28 @@ export const CompletionScreen: React.FC<CompletionScreenProps> = ({ onReset }) =
                     />
                 ) : (
                     <div className="w-40 h-40 flex items-center justify-center">
-                        <div className="w-8 h-8 border-4 border-amber-500 border-t-transparent rounded-full animate-spin"></div>
+                        <div className="w-8 h-8 border-4 border-spot border-t-transparent rounded-full animate-spin"></div>
                     </div>
                 )}
             </div>
-            <h2 className="text-3xl font-bold text-gray-800 mb-2">抽出完了！</h2>
-            <p className="text-gray-600 mb-8">お疲れ様でした。美味しいコーヒーを楽しみましょう。</p>
+            <h2 className="text-3xl font-bold text-ink mb-2">抽出完了！</h2>
+            <p className="text-ink-sub mb-8">お疲れ様でした。美味しいコーヒーを楽しみましょう。</p>
 
             <div className="flex gap-4">
-                <button
+                <Button
+                    variant="outline"
                     onClick={onReset}
-                    className="px-6 py-2 border border-gray-300 rounded-full text-gray-600 hover:bg-gray-50 transition-colors"
+                    className="!rounded-full"
                 >
                     もう一度淹れる
-                </button>
-                <Link
-                    href="/drip-guide"
-                    className="px-6 py-2 bg-amber-600 text-white rounded-full hover:bg-amber-700 transition-colors"
-                >
-                    一覧に戻る
+                </Button>
+                <Link href="/drip-guide">
+                    <Button
+                        variant="primary"
+                        className="!rounded-full"
+                    >
+                        一覧に戻る
+                    </Button>
                 </Link>
             </div>
         </div>

--- a/components/drip-guide/runner/FooterControls.tsx
+++ b/components/drip-guide/runner/FooterControls.tsx
@@ -36,7 +36,7 @@ export const FooterControls: React.FC<FooterControlsProps> = ({
     onComplete,
 }) => {
     return (
-        <div className="flex-none bg-white border-t border-gray-100 pb-8 pt-4 px-6 safe-area-bottom">
+        <div className="flex-none bg-surface border-t border-edge pb-8 pt-4 px-6 safe-area-bottom">
             {/* Next Step Preview */}
             {!isManualMode && (
                 <div className="h-8 mb-4 flex justify-center items-center">
@@ -44,7 +44,7 @@ export const FooterControls: React.FC<FooterControlsProps> = ({
                         <motion.div
                             initial={{ opacity: 0 }}
                             animate={{ opacity: 1 }}
-                            className="text-gray-400 text-xs font-medium bg-gray-50 px-3 py-1 rounded-full"
+                            className="text-ink-muted text-xs font-medium bg-ground px-3 py-1 rounded-full"
                         >
                             Next: {formatTime(nextStep.startTimeSec)} - {nextStep.title}
                         </motion.div>
@@ -57,9 +57,9 @@ export const FooterControls: React.FC<FooterControlsProps> = ({
                 <div className="flex items-center justify-center gap-4 sm:gap-6">
                     <button
                         onClick={onResetTimer}
-                        className="flex flex-col items-center gap-1 text-gray-400 hover:text-gray-600 transition-colors p-2 active:scale-95 min-h-[44px] min-w-[44px]"
+                        className="flex flex-col items-center gap-1 text-ink-muted hover:text-ink-sub transition-colors p-2 active:scale-95 min-h-[44px] min-w-[44px]"
                     >
-                        <div className="p-3 rounded-full bg-gray-50">
+                        <div className="p-3 rounded-full bg-ground">
                             <ArrowCounterClockwise size={24} />
                         </div>
                         <span className="text-xs font-medium">リセット</span>
@@ -71,16 +71,11 @@ export const FooterControls: React.FC<FooterControlsProps> = ({
                         className={clsx(
                             'flex flex-col items-center gap-1 transition-colors p-2 active:scale-95 min-h-[44px] min-w-[44px]',
                             manualStepIndex === 0
-                                ? 'text-gray-300 cursor-not-allowed'
-                                : 'text-gray-400 hover:text-gray-600'
+                                ? 'text-ink-muted/50 cursor-not-allowed'
+                                : 'text-ink-muted hover:text-ink-sub'
                         )}
                     >
-                        <div
-                            className={clsx(
-                                'p-3 rounded-full',
-                                manualStepIndex === 0 ? 'bg-gray-50' : 'bg-gray-50'
-                            )}
-                        >
+                        <div className="p-3 rounded-full bg-ground">
                             <ArrowLeft size={24} />
                         </div>
                         <span className="text-xs font-medium">前へ</span>
@@ -91,8 +86,8 @@ export const FooterControls: React.FC<FooterControlsProps> = ({
                         className={clsx(
                             'w-16 h-16 sm:w-20 sm:h-20 rounded-full flex items-center justify-center shadow-xl transition-all active:scale-95 touch-manipulation',
                             isRunning
-                                ? 'bg-white border-2 border-amber-100 text-amber-500'
-                                : 'bg-amber-500 text-white shadow-amber-200'
+                                ? 'bg-surface border-2 border-spot/20 text-spot'
+                                : 'bg-spot text-white shadow-spot/30'
                         )}
                     >
                         {isRunning ? (
@@ -105,9 +100,9 @@ export const FooterControls: React.FC<FooterControlsProps> = ({
                     {currentStepIndex === stepsLength - 1 ? (
                         <button
                             onClick={onComplete}
-                            className="flex flex-col items-center gap-1 text-green-600 hover:text-green-700 transition-colors p-2 active:scale-95 min-h-[44px] min-w-[44px]"
+                            className="flex flex-col items-center gap-1 text-success hover:text-success/80 transition-colors p-2 active:scale-95 min-h-[44px] min-w-[44px]"
                         >
-                            <div className="p-3 rounded-full bg-green-50">
+                            <div className="p-3 rounded-full bg-success-subtle">
                                 <CheckCircle size={24} weight="fill" />
                             </div>
                             <span className="text-xs font-medium">完了</span>
@@ -115,9 +110,9 @@ export const FooterControls: React.FC<FooterControlsProps> = ({
                     ) : (
                         <button
                             onClick={onGoToNextStep}
-                            className="flex flex-col items-center gap-1 text-gray-400 hover:text-gray-600 transition-colors p-2 active:scale-95 min-h-[44px] min-w-[44px]"
+                            className="flex flex-col items-center gap-1 text-ink-muted hover:text-ink-sub transition-colors p-2 active:scale-95 min-h-[44px] min-w-[44px]"
                         >
-                            <div className="p-3 rounded-full bg-gray-50">
+                            <div className="p-3 rounded-full bg-ground">
                                 <ArrowRight size={24} />
                             </div>
                             <span className="text-xs font-medium">次へ</span>
@@ -126,9 +121,9 @@ export const FooterControls: React.FC<FooterControlsProps> = ({
 
                     <Link
                         href="/drip-guide"
-                        className="flex flex-col items-center gap-1 text-gray-400 hover:text-gray-600 transition-colors p-2 active:scale-95 min-h-[44px] min-w-[44px]"
+                        className="flex flex-col items-center gap-1 text-ink-muted hover:text-ink-sub transition-colors p-2 active:scale-95 min-h-[44px] min-w-[44px]"
                     >
-                        <div className="p-3 rounded-full bg-gray-50">
+                        <div className="p-3 rounded-full bg-ground">
                             <X size={24} />
                         </div>
                         <span className="text-xs font-medium">終了</span>
@@ -139,9 +134,9 @@ export const FooterControls: React.FC<FooterControlsProps> = ({
                 <div className="flex items-center justify-center gap-10">
                     <button
                         onClick={onResetTimer}
-                        className="flex flex-col items-center gap-1 text-gray-400 hover:text-gray-600 transition-colors p-2 active:scale-95"
+                        className="flex flex-col items-center gap-1 text-ink-muted hover:text-ink-sub transition-colors p-2 active:scale-95"
                     >
-                        <div className="p-3 rounded-full bg-gray-50">
+                        <div className="p-3 rounded-full bg-ground">
                             <ArrowCounterClockwise size={24} />
                         </div>
                         <span className="text-xs font-medium">リセット</span>
@@ -152,8 +147,8 @@ export const FooterControls: React.FC<FooterControlsProps> = ({
                         className={clsx(
                             'w-20 h-20 rounded-full flex items-center justify-center shadow-xl transition-all active:scale-95 touch-manipulation',
                             isRunning
-                                ? 'bg-white border-2 border-amber-100 text-amber-500'
-                                : 'bg-amber-500 text-white shadow-amber-200'
+                                ? 'bg-surface border-2 border-spot/20 text-spot'
+                                : 'bg-spot text-white shadow-spot/30'
                         )}
                     >
                         {isRunning ? (
@@ -165,9 +160,9 @@ export const FooterControls: React.FC<FooterControlsProps> = ({
 
                     <Link
                         href="/drip-guide"
-                        className="flex flex-col items-center gap-1 text-gray-400 hover:text-gray-600 transition-colors p-2 active:scale-95"
+                        className="flex flex-col items-center gap-1 text-ink-muted hover:text-ink-sub transition-colors p-2 active:scale-95"
                     >
-                        <div className="p-3 rounded-full bg-gray-50">
+                        <div className="p-3 rounded-full bg-ground">
                             <X size={24} />
                         </div>
                         <span className="text-xs font-medium">終了</span>

--- a/components/drip-guide/runner/ProgressBar.tsx
+++ b/components/drip-guide/runner/ProgressBar.tsx
@@ -9,9 +9,9 @@ interface ProgressBarProps {
 
 export const ProgressBar: React.FC<ProgressBarProps> = ({ progressPercent }) => {
     return (
-        <div className="flex-none h-1 bg-gray-100 w-full">
+        <div className="flex-none h-1 bg-ground w-full">
             <motion.div
-                className="h-full bg-amber-500"
+                className="h-full bg-spot"
                 initial={{ width: 0 }}
                 animate={{ width: `${progressPercent}%` }}
                 transition={{ duration: 1, ease: 'linear' }}

--- a/components/drip-guide/runner/RunnerHeader.tsx
+++ b/components/drip-guide/runner/RunnerHeader.tsx
@@ -10,14 +10,14 @@ interface RunnerHeaderProps {
 
 export const RunnerHeader: React.FC<RunnerHeaderProps> = ({ recipeName }) => {
     return (
-        <div className="flex-none px-4 py-3 flex items-center justify-between border-b border-gray-100 bg-white z-10">
+        <div className="flex-none px-4 py-3 flex items-center justify-between border-b border-edge bg-surface z-10">
             <Link
                 href="/drip-guide"
-                className="p-2 -ml-2 text-gray-500 hover:text-gray-800 transition-colors rounded-full active:bg-gray-100"
+                className="p-2 -ml-2 text-ink-muted hover:text-ink transition-colors rounded-full active:bg-ground"
             >
                 <ArrowLeft size={24} />
             </Link>
-            <h1 className="font-bold text-gray-800 text-lg truncate max-w-[200px] text-center">
+            <h1 className="font-bold text-ink text-lg truncate max-w-[200px] text-center">
                 {recipeName}
             </h1>
             <div className="w-10" />

--- a/components/drip-guide/runner/StepInfo.tsx
+++ b/components/drip-guide/runner/StepInfo.tsx
@@ -22,30 +22,30 @@ export const StepInfo: React.FC<StepInfoProps> = ({ currentStep }) => {
                         transition={{ duration: 0.3 }}
                         className="flex flex-col items-center"
                     >
-                        <h3 className="text-3xl sm:text-2xl md:text-3xl font-bold text-amber-700 mb-4 sm:mb-3">
+                        <h3 className="text-3xl sm:text-2xl md:text-3xl font-bold text-spot mb-4 sm:mb-3">
                             {currentStep.title}
                         </h3>
 
                         {currentStep.targetTotalWater && (
                             <div className="mb-4 sm:mb-3">
-                                <span className="inline-block bg-blue-50 text-blue-600 px-6 py-3 sm:px-5 sm:py-2 rounded-full font-bold text-xl sm:text-lg shadow-sm border border-blue-100">
+                                <span className="inline-block bg-info/10 text-info px-6 py-3 sm:px-5 sm:py-2 rounded-full font-bold text-xl sm:text-lg shadow-sm border border-info/20">
                                     {currentStep.targetTotalWater}g{' '}
-                                    <span className="text-base sm:text-sm font-normal text-blue-400">
+                                    <span className="text-base sm:text-sm font-normal text-info/70">
                                         まで注ぐ
                                     </span>
                                 </span>
                             </div>
                         )}
 
-                        <p className="text-lg sm:text-base md:text-lg text-gray-600 leading-relaxed mb-4 sm:mb-3 max-w-xs mx-auto">
+                        <p className="text-lg sm:text-base md:text-lg text-ink-sub leading-relaxed mb-4 sm:mb-3 max-w-xs mx-auto">
                             {currentStep.description}
                         </p>
 
                         {currentStep.note && (
-                            <div className="bg-amber-50 p-4 sm:p-3 rounded-xl border border-amber-100 text-amber-800 text-base sm:text-sm max-w-xs mx-auto flex items-start gap-2">
+                            <div className="bg-spot-subtle p-4 sm:p-3 rounded-xl border border-spot/20 text-ink text-base sm:text-sm max-w-xs mx-auto flex items-start gap-2">
                                 <Lightbulb
                                     size={20}
-                                    className="sm:w-4 sm:h-4 text-amber-600 flex-shrink-0 mt-0.5"
+                                    className="sm:w-4 sm:h-4 text-spot flex-shrink-0 mt-0.5"
                                     weight="fill"
                                 />
                                 <span>{currentStep.note}</span>
@@ -57,7 +57,7 @@ export const StepInfo: React.FC<StepInfoProps> = ({ currentStep }) => {
                         key="start"
                         initial={{ opacity: 0 }}
                         animate={{ opacity: 1 }}
-                        className="text-gray-400 text-base py-4"
+                        className="text-ink-muted text-base py-4"
                     >
                         準備ができたら
                         <br />

--- a/components/drip-guide/runner/StepMiniMap.tsx
+++ b/components/drip-guide/runner/StepMiniMap.tsx
@@ -61,20 +61,20 @@ export const StepMiniMap: React.FC<StepMiniMapProps> = ({
                                 className={clsx(
                                     'flex-shrink-0 rounded-lg px-3 py-2 sm:px-3 sm:py-2 min-w-[120px] sm:min-w-[120px] border-2 transition-all',
                                     isCurrent
-                                        ? 'bg-amber-50 border-amber-400 shadow-md'
+                                        ? 'bg-spot-subtle border-spot shadow-md'
                                         : isStepCompleted
-                                        ? 'bg-gray-50 border-gray-200'
-                                        : 'bg-gray-100 border-gray-200 opacity-60'
+                                        ? 'bg-ground border-edge'
+                                        : 'bg-ground/50 border-edge opacity-60'
                                 )}
                             >
                                 <div
                                     className={clsx(
                                         'text-sm sm:text-sm font-bold truncate',
                                         isCurrent
-                                            ? 'text-amber-800'
+                                            ? 'text-spot-hover'
                                             : isStepCompleted
-                                            ? 'text-gray-700'
-                                            : 'text-gray-500'
+                                            ? 'text-ink-sub'
+                                            : 'text-ink-muted'
                                     )}
                                 >
                                     {step.title}
@@ -84,10 +84,10 @@ export const StepMiniMap: React.FC<StepMiniMapProps> = ({
                                         className={clsx(
                                             'text-xs sm:text-xs font-semibold mt-0.5 sm:mt-0.5',
                                             isCurrent
-                                                ? 'text-amber-700'
+                                                ? 'text-spot'
                                                 : isStepCompleted
-                                                ? 'text-gray-600'
-                                                : 'text-gray-400'
+                                                ? 'text-ink-sub'
+                                                : 'text-ink-muted'
                                         )}
                                     >
                                         {formatTime(step.startTimeSec)} - {formatTime(stepEndTime)}
@@ -98,10 +98,10 @@ export const StepMiniMap: React.FC<StepMiniMapProps> = ({
                                         className={clsx(
                                             'text-xs sm:text-xs mt-0.5 sm:mt-0.5',
                                             isCurrent
-                                                ? 'text-amber-600'
+                                                ? 'text-spot'
                                                 : isStepCompleted
-                                                ? 'text-gray-500'
-                                                : 'text-gray-400'
+                                                ? 'text-ink-muted'
+                                                : 'text-ink-muted'
                                         )}
                                     >
                                         {step.targetTotalWater}gまで注ぐ
@@ -118,7 +118,7 @@ export const StepMiniMap: React.FC<StepMiniMapProps> = ({
                                                 100
                                             )}%`,
                                         }}
-                                        className="h-1 sm:h-1 bg-amber-500 rounded-full mt-1.5 sm:mt-1.5"
+                                        className="h-1 sm:h-1 bg-spot rounded-full mt-1.5 sm:mt-1.5"
                                         transition={{ duration: 1, ease: 'linear' }}
                                     />
                                 )}

--- a/components/drip-guide/runner/TimerDisplay.tsx
+++ b/components/drip-guide/runner/TimerDisplay.tsx
@@ -11,7 +11,7 @@ export const TimerDisplay: React.FC<TimerDisplayProps> = ({ currentTime }) => {
     return (
         <div className="text-center mb-4 sm:mb-6 flex-shrink-0 -mt-4 sm:mt-0">
             <div
-                className="text-8xl sm:text-7xl md:text-8xl lg:text-9xl tabular-nums font-bold text-gray-800 tracking-tighter leading-none"
+                className="text-8xl sm:text-7xl md:text-8xl lg:text-9xl tabular-nums font-bold text-ink tracking-tighter leading-none"
                 style={{ fontFamily: 'var(--font-nunito), sans-serif' }}
             >
                 {formatTime(currentTime)}

--- a/docs/working/20260208_138_drip-guide-common-ui/design.md
+++ b/docs/working/20260208_138_drip-guide-common-ui/design.md
@@ -1,0 +1,64 @@
+# 設計書: ドリップガイドページの共通UI化とテーマシステム対応
+
+## 変更対象ファイル
+
+### ページ層（背景色のテーマ対応）
+| ファイル | 変更内容 |
+|---------|---------|
+| `app/drip-guide/page.tsx` | `backgroundColor: '#F7F7F5'` → `bg-page` |
+| `app/drip-guide/new/page.tsx` | `backgroundColor: '#F7F7F5'` → `bg-page` |
+| `app/drip-guide/edit/page.tsx` | `backgroundColor: '#F7F7F5'` → `bg-page` |
+| `app/drip-guide/run/page.tsx` | `bg-white` → `bg-page` / テーマ対応 |
+
+### コンポーネント層（共通UI化 + テーマ対応）
+| ファイル | 変更内容 |
+|---------|---------|
+| `components/drip-guide/RecipeList.tsx` | 独自ボタン → Button、テキスト色テーマ対応 |
+| `components/drip-guide/StepEditor.tsx` | 生HTML input/textarea → Input/Textarea |
+| `components/drip-guide/StartHintDialog.tsx` | 独自ダイアログ → Modal使用、テーマ対応 |
+| `components/drip-guide/Start46Dialog.tsx` | テーマ対応（bg-white → bg-overlay） |
+| `components/drip-guide/StartHoffmannDialog.tsx` | テーマ対応（bg-white → bg-overlay） |
+| `components/drip-guide/DripGuideRunner.tsx` | テーマ対応（背景色） |
+| `components/drip-guide/runner/CompletionScreen.tsx` | 独自ボタン → Button |
+| `components/drip-guide/runner/FooterControls.tsx` | テーマ対応 |
+| `components/drip-guide/runner/RunnerHeader.tsx` | テーマ対応（テキスト色） |
+| `components/drip-guide/runner/StepInfo.tsx` | テーマ対応（テキスト色） |
+
+### ダイアログサブコンポーネント
+| ファイル | 変更内容 |
+|---------|---------|
+| `components/drip-guide/dialogs/shared/DialogOverlay.tsx` | テーマ対応 |
+| `components/drip-guide/dialogs/shared/RecipeStepTable.tsx` | テーマ対応 |
+| `components/drip-guide/dialogs/shared/RecipeSummary.tsx` | テーマ対応 |
+| `components/drip-guide/dialogs/46/*.tsx` | テーマ対応 |
+| `components/drip-guide/dialogs/hoffmann/*.tsx` | テーマ対応 |
+
+## 設計方針
+
+### 1. CSS変数マッピング（#136準拠）
+| 現状 | 変更後 | 用途 |
+|------|--------|------|
+| `backgroundColor: '#F7F7F5'` | `bg-page` | ページ背景 |
+| `bg-white` | `bg-surface` | カード・セクション背景 |
+| `bg-white`（モーダル） | `bg-overlay` | モーダル背景（不透明） |
+| `bg-gray-50`, `bg-gray-100` | `bg-ground` | グラウンド背景 |
+| `text-gray-900` | `text-ink` | メインテキスト |
+| `text-gray-600`, `text-gray-500` | `text-ink-sub` | サブテキスト |
+| `text-gray-400` | `text-ink-muted` | 薄いテキスト |
+| `border-gray-200`, `border-gray-300` | `border-edge` | ボーダー |
+| `border-gray-400` | `border-edge-strong` | 濃いボーダー |
+| `bg-amber-*` | `bg-spot` / `bg-spot-subtle` | アクセント色 |
+
+### 2. ダイアログの共通UI化方針
+- **StartHintDialog**: 独自div → `<Modal>` コンポーネント使用
+- **Start46Dialog / StartHoffmannDialog**: 独自のフレーム構造を持つため、`<Modal>` は使用せず背景色のみテーマ対応
+- **DialogOverlay**: 共通オーバーレイ → テーマ対応
+
+### 3. Runner系コンポーネントの方針
+- タイマー・ステップ表示等の専用UIは共通コンポーネント化しない
+- 背景色・テキスト色のみCSS変数に置換
+
+## 禁止事項チェック
+- [ ] 生のTailwindでボタンを作らない → Button使用
+- [ ] `isChristmasMode` propは不要 → CSS変数で自動対応
+- [ ] モーダル背景は `bg-overlay` → `bg-surface` は禁止

--- a/docs/working/20260208_138_drip-guide-common-ui/requirement.md
+++ b/docs/working/20260208_138_drip-guide-common-ui/requirement.md
@@ -1,0 +1,50 @@
+# 要件定義: ドリップガイドページの共通UI化とテーマシステム対応
+
+## Issue
+- **番号**: #138
+- **タイトル**: refactor(drip-guide): ドリップガイドページの共通UI化とテーマシステム対応
+
+## 概要
+ドリップガイドページ（`app/drip-guide/`）の独自UI要素を共通UIコンポーネントに置換し、CSS変数ベースのテーマシステム対応を追加する。
+
+## ユーザーストーリー
+- ユーザーとして、クリスマスモードに切り替えた際にドリップガイドページも統一されたテーマで表示されること
+- 開発者として、共通UIコンポーネントを使用して保守性を向上させること
+
+## 現状分析
+
+### 共通UIコンポーネント使用状況（30%）
+| ファイル | 使用中 | 未使用 |
+|---------|--------|--------|
+| RecipeList.tsx | Card, Dialog | ボタン類（独自実装） |
+| RecipeForm.tsx | Input, Textarea, Button | - |
+| StepEditor.tsx | - | input, textarea（生HTML） |
+| StartHintDialog.tsx | - | ダイアログ全体（独自） |
+| Start46Dialog.tsx | - | ダイアログ全体（独自） |
+| StartHoffmannDialog.tsx | - | ダイアログ全体（独自） |
+| FooterControls.tsx | - | ボタン群（独自） |
+| CompletionScreen.tsx | - | ボタン（独自） |
+| runner/* | - | 各種（専用UI） |
+
+### テーマ対応状況（0%）
+- `isChristmasMode`: 未使用
+- CSS変数: 未使用
+- 背景色: `#F7F7F5`, `white`, `bg-gray-*` がハードコード
+
+## 受け入れ基準
+1. 独自`<button>` → `<Button>` / `<IconButton>` に置換
+2. 独自カード要素 → `<Card>` に置換（該当箇所）
+3. 生HTML `<input>` / `<textarea>` → `<Input>` / `<Textarea>` に置換
+4. ページ背景 `#F7F7F5` → CSS変数 `bg-page` に変更
+5. カード/セクション背景 `white` → `bg-surface` に変更
+6. モーダル/ダイアログ背景 → `bg-overlay` に変更
+7. テキスト色 → CSS変数（`text-ink`, `text-ink-sub`, `text-ink-muted`）に変更
+8. ボーダー色 → CSS変数（`border-edge`）に変更
+9. lint / build / test 通過
+10. 通常モード・クリスマスモード両方で正常表示
+
+## 対象外
+- DripGuideRunner内のタイマー・ステップ表示等の専用UI（機能に密結合）
+- ProgressBar（runner用の独自実装、共通UIのProgressBarとは用途が異なる）
+- TimerDisplay（専用表示）
+- StepMiniMap（専用表示）

--- a/docs/working/20260208_138_drip-guide-common-ui/tasklist.md
+++ b/docs/working/20260208_138_drip-guide-common-ui/tasklist.md
@@ -1,0 +1,53 @@
+# タスクリスト: ドリップガイドページの共通UI化とテーマシステム対応
+
+**ステータス**: ✅ 完了
+**完了日**: 2026-02-08
+
+## Phase 1: ページ背景のテーマ対応
+- [x] `app/drip-guide/page.tsx` - `#F7F7F5` → `bg-page`
+- [x] `app/drip-guide/new/page.tsx` - `#F7F7F5` → `bg-page`
+- [x] `app/drip-guide/edit/page.tsx` - `#F7F7F5` → `bg-page`
+- [x] `app/drip-guide/run/page.tsx` - `bg-white` → `bg-page`
+
+## Phase 2: RecipeList の共通UI化
+- [x] 独自ボタン → `<Button>` / `<IconButton>` に置換
+- [x] セレクト → CSS変数でテーマ対応（共通UIのSelectは<option>カスタマイズ不可のため生selectを維持）
+- [x] テキスト色・背景色をCSS変数に置換
+
+## Phase 3: StepEditor の共通UI化
+- [x] 生 `<input>` / `<textarea>` → CSS変数でテーマ対応
+- [x] 削除ボタン → `<IconButton>` に置換
+- [x] 追加ボタン → `<Button>` に置換
+- [x] 背景色・テキスト色をCSS変数に置換
+
+## Phase 4: ダイアログのテーマ対応
+- [x] StartHintDialog - 背景色 `bg-overlay`、ボタン `<Button>`
+- [x] Start46Dialog - 背景色 `bg-overlay`、ボタン `<Button>`
+- [x] StartHoffmannDialog - 背景色 `bg-overlay`、ボタン `<Button>`
+- [x] dialogs/shared/RecipeStepTable - テーマ対応
+- [x] dialogs/shared/RecipeSummary - テーマ対応
+- [x] dialogs/46/Dialog46Header - テーマ対応
+- [x] dialogs/46/Dialog46Form - テーマ対応
+- [x] dialogs/46/Dialog46Preview - テーマ対応
+- [x] dialogs/46/Dialog46DescriptionModal - テーマ対応
+- [x] dialogs/hoffmann/HoffmannDialogHeader - テーマ対応
+- [x] dialogs/hoffmann/HoffmannDialogForm - テーマ対応
+- [x] dialogs/hoffmann/HoffmannPreview - テーマ対応
+- [x] dialogs/hoffmann/HoffmannDescriptionModal - テーマ対応
+- [x] dialogs/hoffmann/HoffmannStepDetailModal - テーマ対応
+
+## Phase 5: Runner系のテーマ対応
+- [x] DripGuideRunner - 背景 `bg-surface`
+- [x] CompletionScreen - ボタン → `<Button>`、背景テーマ対応
+- [x] FooterControls - テーマ対応
+- [x] RunnerHeader - テーマ対応
+- [x] StepInfo - テーマ対応
+- [x] TimerDisplay - テーマ対応
+- [x] StepMiniMap - テーマ対応
+- [x] ProgressBar - テーマ対応
+
+## Phase 6: 検証
+- [x] lint通過
+- [x] build通過
+- [x] test通過（750テスト全合格）
+- [x] 独立レビュー通過


### PR DESCRIPTION
## 概要
Issue #138 を解決。ドリップガイドページ（`app/drip-guide/`）の独自UI要素を共通UIコンポーネントに置換し、CSS変数ベースのテーマシステム対応を追加。

## 変更内容
- 独自`<button>` → `<Button>` / `<IconButton>` に置換（29ファイル）
- 戻るリンク → `<BackLink>` に置換
- ページ背景 `#F7F7F5` / `bg-white` → `bg-page` に統一（4ページ）
- カード/セクション → `bg-surface`、モーダル → `bg-overlay` に統一
- テキスト色 → CSS変数（`text-ink`, `text-ink-sub`, `text-ink-muted`）に統一
- ボーダー → `border-edge` に統一
- アクセント色 → `text-spot` / `bg-spot-subtle` に統一
- Runner系コンポーネント（タイマー・ステップ表示・完了画面）全体のテーマ対応
- ダイアログ系（StartHint, Start46, StartHoffmann + サブコンポーネント）全体のテーマ対応

## テスト
- [x] lint 通過（エラー・warning 0）
- [x] build 通過（53ページ生成）
- [x] test 通過（750テスト全合格）
- [x] 独立コードレビュー通過

Closes #138
