### PR TITLE
fix(#198): ドリップガイド一覧のスマホ下部余白を修正

### DIFF
--- a/app/drip-guide/page.tsx
+++ b/app/drip-guide/page.tsx
@@ -38,7 +38,7 @@ export default function DripGuidePage() {
                     </div>
                 </header>
 
-                <main className="flex-1 min-h-0 overflow-y-auto pb-20 sm:pb-0">
+                <main className="flex-1 min-h-0 overflow-y-auto pb-4">
                     <RecipeList recipes={recipes} onDelete={deleteRecipe} />
                 </main>
             </div>


### PR DESCRIPTION
## 概要
Issue #198 を解決。ドリップガイド一覧画面のスマホレイアウトで表示される不要な80pxの下部余白を修正。

## 変更内容
- `app/drip-guide/page.tsx` の `<main>` 要素の `pb-20 sm:pb-0` を `pb-4` に変更

## テスト
- [x] lint / build / test 通過（757テスト全合格）
- [x] Chrome DevTools MCPでスマホ表示確認済み

Closes #198
