### PR TITLE
style(#206): ホーム画面アイコンの背景丸を削除しサイズを拡大

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -184,6 +184,10 @@
   [data-theme="christmas"] .tab-active { background-color: var(--spot-subtle); color: var(--spot); }
   .select-icon { background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%236B7280'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M19 9l-7 7-7-7'%3E%3C/path%3E%3C/svg%3E"); }
   [data-theme="christmas"] .select-icon { background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%23d4af37'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M19 9l-7 7-7-7'%3E%3C/path%3E%3C/svg%3E"); }
+  /* ホームアイコン: 通常モードは背景なし+大アイコン、クリスマスモードは背景丸+小アイコン */
+  .icon-circle-bg { background-color: transparent; }
+  [data-theme="christmas"] .icon-circle-bg { background-color: var(--spot-subtle); width: 3.5rem; height: 3.5rem; }
+  [data-theme="christmas"] .icon-circle-bg > svg { width: 2rem !important; height: 2rem !important; }
 }
 
 @media (prefers-color-scheme: dark) {

--- a/components/home/ActionCard.tsx
+++ b/components/home/ActionCard.tsx
@@ -50,9 +50,9 @@ export function ActionCard({
       )}
 
       <span
-        className="relative flex h-14 w-14 items-center justify-center rounded-full transition-all duration-300 bg-spot-subtle text-spot group-hover:bg-spot-subtle/80"
+        className="relative flex h-14 w-14 items-center justify-center rounded-full transition-all duration-300 icon-circle-bg text-spot"
       >
-        <Icon className="h-8 w-8 relative z-10" />
+        <Icon className="h-11 w-11 relative z-10" />
       </span>
       <div className="space-y-1 text-center relative z-10">
         <p


### PR DESCRIPTION
## 概要
Issue #206 を解決。ホーム画面メニューカードのアイコン背景丸の色ズレを修正。

## 変更内容
- 通常モード: 背景丸（`bg-spot-subtle`）を非表示にし、アイコンを32px→44pxに拡大
- クリスマスモード: 背景丸を維持（56px）、アイコンは32pxのまま
- `icon-circle-bg`ユーティリティクラスでテーマ別に背景の表示/非表示を制御

## テスト
- [x] lint / build / test 通過（758テスト全パス）
- [x] 通常モード・クリスマスモード両方で表示確認済み

Closes #206
