### PR TITLE
fix(#248): コーヒークイズUIを縦中央配置に修正

### DIFF
--- a/app/coffee-trivia/page.tsx
+++ b/app/coffee-trivia/page.tsx
@@ -43,7 +43,7 @@ export default function CoffeeTriviaPage() {
         }
       />
 
-      <main className="flex-1 container mx-auto p-4 lg:p-6 pt-14 max-w-lg">
+      <main className="flex-1 container mx-auto px-4 lg:px-6 pt-14 pb-6 max-w-lg flex flex-col justify-center">
         <QuizDashboard
           progress={progress}
           dueCardsCount={dueCardsCount}


### PR DESCRIPTION
## 概要

コーヒークイズページのUIがFloatingNav移行後に画面上側に寄ってしまった問題を修正。

## 原因

`FloatingNav`は`fixed`配置のためレイアウト高さを占有しない。以前はヘッダー（実体）がコンテンツを下に押し下げていたが、FloatingNavへの移行後はその押し下げ効果がなくなり、`QuizDashboard`が上寄りになった。

## 変更内容

- `app/coffee-trivia/page.tsx`の`<main>`に`flex flex-col justify-center`を追加
- パディングを`px-4 lg:px-6 pt-14 pb-6`に整理（横/縦を分離して明示化）

## テスト

- [x] lint / build / test 通過（1054テスト合格）
- [x] ブラウザ動作確認済み

Closes #248
