### PR TITLE
fix(#251): HTMLコメント除去バグ修正・テストデータクリーンアップ

### DIFF
--- a/.github/workflows/changelog-suggest.yml
+++ b/.github/workflows/changelog-suggest.yml
@@ -27,7 +27,10 @@ jobs:
 
             // 「ユーザー向け更新内容」セクションを抽出
             const match = body.match(/## ユーザー向け更新内容[\s\S]*?\n([\s\S]*?)<!-- \/changelog -->/);
-            const content = match ? match[1].trim() : '';
+            const rawContent = match ? match[1].trim() : '';
+
+            // PRテンプレートのHTMLコメント（使い方説明）を除去
+            const content = rawContent.replace(/<!--[\s\S]*?-->/g, '').trim();
 
             // "-" のみ（空エントリ）かどうか判定
             const isEmpty = /^[\s\-*]*$/.test(content);

--- a/.github/workflows/changelog-update.yml
+++ b/.github/workflows/changelog-update.yml
@@ -37,7 +37,10 @@ jobs:
 
             // 「ユーザー向け更新内容」セクションを抽出
             const match = body.match(/## ユーザー向け更新内容[\s\S]*?\n([\s\S]*?)<!-- \/changelog -->/);
-            const content = match ? match[1].trim() : '';
+            const rawContent = match ? match[1].trim() : '';
+
+            // PRテンプレートのHTMLコメント（使い方説明）を除去
+            const content = rawContent.replace(/<!--[\s\S]*?-->/g, '').trim();
 
             // "-" のみ（空エントリ）かどうか判定
             const isEmpty = /^[\s\-*]*$/.test(content);

--- a/data/dev-stories/detailed-changelog.ts
+++ b/data/dev-stories/detailed-changelog.ts
@@ -14,23 +14,6 @@ export const CHANGE_TYPE_CONFIG: Record<ChangelogEntryType, { label: string; col
 // 詳細な更新履歴データ
 export const DETAILED_CHANGELOG: ChangelogEntry[] = [
   {
-    id: 'v0.12.0',
-    version: '0.12.0',
-    date: '2026-02-21',
-    type: 'feature',
-    title: '<!-- ユーザーに見える変化のみ。技術的な内容は不要です --> など 4件の更新',
-    content: `
-<!-- ユーザーに見える変化のみ。技術的な内容は不要です -->
-<!-- ユーザー向けの変更なし（内部改善のみ）の場合は "-" のままにしてください -->
-
-- changelog自動化が使えるようになりました
-- PRに「ユーザー向け更新内容」を書くと、アプリの更新履歴に自動で反映されます
-    `.trim(),
-    tags: [],
-    createdAt: '2026-02-21T23:30:43.802Z',
-    updatedAt: '2026-02-21T23:30:43.802Z',
-  },
-  {
     id: 'v0.11.0',
     version: '0.11.0',
     date: '2026-02-03',

--- a/data/dev-stories/version-history.ts
+++ b/data/dev-stories/version-history.ts
@@ -3,11 +3,6 @@ import type { VersionHistoryEntry } from '@/types';
 // 更新履歴データ
 export const VERSION_HISTORY: VersionHistoryEntry[] = [
   {
-    version: '0.12.0',
-    date: '2026-02-21',
-    summary: '<!-- ユーザーに見える変化のみ。技術的な内容は不要です --> など 4件の更新',
-  },
-  {
     version: '0.11.0',
     date: '2026-02-03',
     summary: '開発者モード時にUIコンポーネントカタログへのリンク追加 [Issue #125] など 3件の更新',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roastplus",
-  "version": "0.12.0",
+  "version": "0.11.0",
   "private": true,
   "scripts": {
     "dev": "npm run generate:sound-list && next dev",


### PR DESCRIPTION
## ユーザー向け更新内容

-

<!-- /changelog -->

---

## 概要

テスト実行で発覚したバグを修正。

PRテンプレートの `<!-- -->` コメント行が changelog の title/content に混入する問題を修正。
抽出した本文から `replace(/<!--[\s\S]*?-->/g, '')` でHTMLコメントを除去するよう変更。

加えてテストデータ（v0.12.0 の不正エントリ）とテスト用ファイルを削除し、バージョンを 0.11.0 に戻す。

Fixes #251
