### PR TITLE
chore: v0.12.0 バージョンバンプ

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roastplus",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "scripts": {
     "dev": "npm run generate:sound-list && next dev",


### PR DESCRIPTION
## 概要

テスト用エントリのクリーンアップ時（PR #257）に `0.11.0` に戻されたバージョンを、正式に `0.12.0` に更新する。

## 背景

- PR #255 マージ時に GitHub Actions が自動で `0.12.0` にバンプ
- PR #257 でテスト用の不正データをクリーンアップした際に `0.11.0` に戻す
- PR #259 で changelog データに正式な v0.12.0 内容を記録済み

## 変更内容

- `package.json`: version `0.11.0` → `0.12.0`
