### PR TITLE
fix: アプリバージョンをpackage.jsonと連動させる

### DIFF
--- a/lib/version.ts
+++ b/lib/version.ts
@@ -1,7 +1,7 @@
 /**
  * アプリケーションバージョン情報
  *
- * このファイルはGitHub Actionsによって自動更新されます。
- * 手動で編集しないでください。
+ * next.config.ts で NEXT_PUBLIC_APP_VERSION に package.json のバージョンが注入される。
+ * フォールバック値は手動で更新しないこと。
  */
-export const APP_VERSION = '0.11.0';
+export const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION ?? '0.12.0';


### PR DESCRIPTION
## 概要

アプリの設定ページに表示されるバージョンが `package.json` と連動していない問題を修正。

## 原因

`lib/version.ts` の `APP_VERSION` がハードコードされており、`package.json` のバージョンが変わっても自動で追従しなかった。

## 修正

`process.env.NEXT_PUBLIC_APP_VERSION` を使用するように変更。`next.config.ts` が既に `package.json` のバージョンをこの環境変数に注入しているため、以後は `package.json` の更新だけで設定ページの表示も自動的に追従する。

## テスト

- [x] lint / build / test 通過（1066テスト）
- [x] ビルドログに `roastplus@0.12.0` が表示されることを確認
