### PR TITLE
style: spot-subtle/spot-surfaceをニュートラルグレーに変更

### DIFF
--- a/.claude/skills/roastplus-ui/references/design-tokens.md
+++ b/.claude/skills/roastplus-ui/references/design-tokens.md
@@ -54,8 +54,8 @@
 |---------|---------------|-----------|----------------|------|
 | `--spot` | `text-spot`, `bg-spot` | `#d97706` | `#d4af37` | アクセント色 |
 | `--spot-hover` | `text-spot-hover` | `#b45309` | `#e8c65f` | アクセントホバー |
-| `--spot-subtle` | `bg-spot-subtle` | `#fef3c7` | `rgba(212,175,55,0.15)` | アクセント薄背景 |
-| `--spot-surface` | `bg-spot-surface` | `#fffbeb` | `rgba(212,175,55,0.05)` | アクセント極薄背景 |
+| `--spot-subtle` | `bg-spot-subtle` | `#f0f0f0` | `rgba(212,175,55,0.15)` | アクセント薄背景 |
+| `--spot-surface` | `bg-spot-surface` | `#f7f7f7` | `rgba(212,175,55,0.05)` | アクセント極薄背景 |
 
 ### ボタン
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -36,8 +36,8 @@
     /* アクセント */
     --spot: #d97706;
     --spot-hover: #b45309;
-    --spot-subtle: #fef3c7;
-    --spot-surface: #fffbeb;
+    --spot-subtle: #f0f0f0;
+    --spot-surface: #f7f7f7;
     /* ボタン */
     --btn-primary: #d97706;
     --btn-primary-hover: #b45309;


### PR DESCRIPTION
## Summary
- デフォルトテーマの `--spot-subtle` を `#fef3c7`(amber) → `#f0f0f0`(ニュートラルグレー) に変更
- デフォルトテーマの `--spot-surface` を `#fffbeb` → `#f7f7f7` に変更
- オレンジアイコン+黄色背景の「カレーの油」感を排除し、モダンでクリーンな印象に改善
- CSS変数2箇所の変更で42ファイル以上のUIに自動反映（セマンティックトークンの恩恵）

## Test plan
- [x] `npm run lint` — エラー0
- [x] `npm run build` — 53ページ静的エクスポート成功
- [x] `npm run test:run` — 1136テスト全パス
- [x] Playwright でコーヒークイズページのアイコン背景をビジュアル確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
