### PR TITLE
chore: fix-issue Phase 10の冗長なブランチクリーンアップ手順を削除

### DIFF
--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -318,15 +318,7 @@ gh pr merge --merge --delete-branch
 ```
 
 ⚠️ **`--auto` は不使用。lint/build/unit/E2Eはローカルで完了済み。**
-⚠️ **ブランチ保護ルールに required status checks がある場合は事前に削除が必要。**
-
-### 4. ブランチクリーンアップ
-
-```bash
-FEATURE_BRANCH=$(git branch --show-current)
-git switch main && git pull origin main
-git branch -D "$FEATURE_BRANCH"
-```
+⚠️ **`--delete-branch` がローカル・リモートブランチのクリーンアップとmainへの切り替えを自動実行する。**
 
 ---
 


### PR DESCRIPTION
## 概要

`gh pr merge --delete-branch` がローカル・リモートブランチを自動削除することを確認したため、fix-issueスキルのPhase 10にあった冗長な手動クリーンアップ手順を削除。

## 変更内容

- Phase 10から `git switch main && git pull origin main && git branch -D` の手動手順を削除
- `--delete-branch` の動作説明コメントを追記

Closes なし（スキル改善）
