### PR TITLE
style(#361): drip-guide/page.tsx デザイン統一

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,10 +12,10 @@
 
 ## Phase 1: 毎日使う画面（7ページ）
 
-### app/drip-guide/page.tsx 🔴
-- [ ] L7: `phosphor-react` の `Plus` → `react-icons/hi` の `HiPlus`
-- [ ] L18: `h-screen` → `h-dvh`
-- [ ] L24: 生 `<Link className="flex items-center gap-2 bg-btn-primary...">` → セマンティックトークン整理版（計画パターン2参照）
+### app/drip-guide/page.tsx ✅（PR: #363）
+- [x] L7: `phosphor-react` の `Plus` → `react-icons/hi` の `HiPlus`
+- [x] L18: `h-screen` → `h-dvh`
+- [x] L24: 生 `<Link className="flex items-center gap-2 bg-btn-primary...">` → セマンティックトークン整理版
 
 ### app/roast-timer/page.tsx 🔴
 - [ ] L30: `h-screen` → `h-dvh`

--- a/app/drip-guide/page.tsx
+++ b/app/drip-guide/page.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import Link from 'next/link';
 import { RecipeList } from '@/components/drip-guide/RecipeList';
 import { useRecipes } from '@/lib/drip-guide/useRecipes';
-import { Plus } from 'phosphor-react';
+import { HiPlus } from 'react-icons/hi';
 import { FloatingNav } from '@/components/ui';
 
 export default function DripGuidePage() {
@@ -15,15 +15,15 @@ export default function DripGuidePage() {
     }
 
     return (
-        <div className="h-screen overflow-y-hidden flex flex-col px-3 sm:px-6 lg:px-8 pt-14 pb-2 sm:pb-3 lg:pb-4 bg-page transition-colors duration-1000">
+        <div className="h-dvh overflow-y-hidden flex flex-col px-3 sm:px-6 lg:px-8 pt-14 pb-2 sm:pb-3 lg:pb-4 bg-page transition-colors duration-1000">
             <FloatingNav
                 backHref="/"
                 right={
                     <Link
                         href="/drip-guide/new"
-                        className="flex items-center gap-2 bg-btn-primary text-white px-4 py-2 rounded-lg font-bold hover:bg-btn-primary-hover transition-colors shadow-sm min-h-[44px]"
+                        className="inline-flex items-center gap-2 bg-btn-primary hover:bg-btn-primary-hover text-white px-4 py-2 rounded-lg font-semibold transition-colors shadow-sm min-h-[44px]"
                     >
-                        <Plus size={20} />
+                        <HiPlus size={20} />
                         <span className="hidden sm:inline">新規レシピ</span>
                     </Link>
                 }


### PR DESCRIPTION
## 変更内容

- `phosphor-react` の `Plus` → `react-icons/hi` の `HiPlus` に統一
- `h-screen` → `h-dvh`（スマホPWAのレイアウト崩れを修正）
- 生Linkボタンのクラスをセマンティックトークンに整理（`inline-flex` + `font-semibold`）

## 確認ポイント
- [ ] ドリップガイドページが正常に表示される
- [ ] 新規レシピボタンが動作する
- [ ] 見た目に大きな変化がない

Closes #361（部分）