### PR TITLE
style(#361): roast-timer/page.tsx デザイン統一

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,8 +17,8 @@
 - [x] L18: `h-screen` → `h-dvh`
 - [x] L24: 生 `<Link className="flex items-center gap-2 bg-btn-primary...">` → セマンティックトークン整理版
 
-### app/roast-timer/page.tsx 🔴
-- [ ] L30: `h-screen` → `h-dvh`
+### app/roast-timer/page.tsx ✅（PR: #364）
+- [x] L30: `h-screen` → `h-dvh`
 
 ### app/tasting/page.tsx 🔴
 - [ ] L14: `phosphor-react` の `Plus` → `react-icons/hi` の `HiPlus`

--- a/app/roast-timer/page.tsx
+++ b/app/roast-timer/page.tsx
@@ -27,7 +27,7 @@ export default function RoastTimerPage() {
   }
 
   return (
-    <div className="h-screen overflow-hidden flex flex-col bg-page">
+    <div className="h-dvh overflow-hidden flex flex-col bg-page">
       <FloatingNav backHref="/" />
       <div className="flex-1 min-h-0">
         <RoastTimer />


### PR DESCRIPTION
## 変更内容

- `h-screen` → `h-dvh`（スマホPWAのレイアウト崩れを修正）

## 確認ポイント
- [ ] 焙煎タイマーページが正常に表示される
- [ ] 見た目に変化がない

Closes #361（部分）