### PR TITLE
ci: lintとunit testsを別ジョブに分離

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ on:
       - "DESIGN.md"
 
 jobs:
-  lint-and-test:
-    name: Lint & Unit Tests
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -22,6 +22,17 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run lint
+
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
       - run: npm run test:run
 
   build:


### PR DESCRIPTION
## Summary
- CIのLintとUnit Testsを別ジョブに分離
- 既存のBuildジョブとdocs変更スキップ設定は維持
- PRチェック結果で失敗箇所を見分けやすくする

## Test Plan
- git diff --check
- ci.yml の基本整合確認