### PR TITLE
feat: ホーム表示設定を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,6 @@
 
 ---
 
-## Screenshots
-
-| ホーム | ローストタイマー |
-|:---:|:---:|
-| ![ホーム画面](docs/screenshots/01-home.png) | ![ローストタイマー](docs/screenshots/02-roast-timer.png) |
-
-| 担当表 | ドリップガイド |
-|:---:|:---:|
-| ![担当表](docs/screenshots/03-assignment.png) | ![ドリップガイド](docs/screenshots/05-drip-guide.png) |
-
----
-
 ## 概要
 
 **RoastPlus** は、コーヒー豆加工業務（焙煎・ハンドピック・ドリップ等）を行う現場向けに開発した**業務効率化・作業支援Webアプリケーション**です。

--- a/app/assignment/components/assignment-table/AssignmentTable.tsx
+++ b/app/assignment/components/assignment-table/AssignmentTable.tsx
@@ -59,7 +59,7 @@ export const AssignmentTable: React.FC<Props> = (props) => {
             {teams.length === 0 && taskLabels.length === 0 && (
                 <Card variant="guide" className="w-full max-w-md">
                     <div className="flex justify-center mb-4">
-                        <div className="p-3 rounded-full bg-spot-subtle text-spot">
+                        <div className="p-3 text-spot">
                             <MdInfoOutline size={32} />
                         </div>
                     </div>
@@ -70,7 +70,7 @@ export const AssignmentTable: React.FC<Props> = (props) => {
                     </p>
 
                     <div className="grid grid-cols-3 gap-2 text-xs text-ink-muted">
-                        <div className="flex flex-col items-center gap-2 p-2 rounded border bg-spot-subtle border-spot/20">
+                        <div className="flex flex-col items-center gap-2 p-2 rounded border bg-surface border-edge">
                             <span className="font-bold text-spot">STEP 1</span>
                             <span>班を追加</span>
                         </div>

--- a/app/assignment/components/assignment-table/DesktopTableView.tsx
+++ b/app/assignment/components/assignment-table/DesktopTableView.tsx
@@ -308,7 +308,7 @@ export const DesktopTableView: React.FC<DesktopTableViewProps> = ({
                                             className={`
                                                 !min-h-0 w-full py-2 md:py-3 px-1 !rounded-lg text-sm md:text-base !font-bold text-center transition-all truncate select-none
                                                 ${member && isSelected ? 'shadow-md scale-105' : ''
-                                                } ${!member && isSelected ? '!bg-spot/20' : ''
+                                                } ${!member && isSelected ? '!bg-surface !border-spot' : ''
                                                 } ${!member && !isSelected ? '!text-ink-muted !bg-ground !border-dashed !border-edge-strong hover:!bg-ground/80 !shadow-none' : ''}
                                             `}
                                         >

--- a/app/assignment/components/assignment-table/MobileListView.tsx
+++ b/app/assignment/components/assignment-table/MobileListView.tsx
@@ -145,7 +145,7 @@ export const MobileListView: React.FC<MobileListViewProps> = ({
                                                 onClick={() => handleCellClick(team.id, label.id)}
                                                 className={`!min-h-0 !py-3 !px-2 truncate select-none ${
                                                     member && isSelected ? 'shadow-md scale-105' : ''
-                                                } ${!member && isSelected ? '!bg-spot/20' : ''
+                                                } ${!member && isSelected ? '!bg-surface !border-spot' : ''
                                                 } ${!member && !isSelected ? '!border-dashed !border-edge-strong !text-ink-muted' : ''}`}
                                             >
                                                 {member ? member.name : '未割当'}

--- a/app/coffee-trivia/stats/page.tsx
+++ b/app/coffee-trivia/stats/page.tsx
@@ -129,7 +129,7 @@ export default function StatsPage() {
                   </span>
                   <p className="text-ink-muted text-sm mt-1">総回答数</p>
                 </div>
-                <div className="bg-spot-subtle rounded-xl p-4 text-center border border-spot/20">
+                <div className="bg-surface rounded-xl p-4 text-center border border-edge">
                   <span className="text-3xl font-bold text-spot">
                     {stats?.averageAccuracy ?? 0}%
                   </span>

--- a/app/globals.css
+++ b/app/globals.css
@@ -472,10 +472,7 @@
   [data-theme="christmas"] .tab-active { background-color: var(--spot-subtle); color: var(--spot); }
   .select-icon { background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%236B7280'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M19 9l-7 7-7-7'%3E%3C/path%3E%3C/svg%3E"); }
   [data-theme="christmas"] .select-icon { background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%23d4af37'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M19 9l-7 7-7-7'%3E%3C/path%3E%3C/svg%3E"); }
-  /* ホームアイコン: 通常モードは背景なし+大アイコン、クリスマスモードは背景丸+小アイコン */
-  .icon-circle-bg { background-color: transparent; }
-  [data-theme="christmas"] .icon-circle-bg { background-color: var(--spot-subtle); width: 3.5rem; height: 3.5rem; }
-  [data-theme="christmas"] .icon-circle-bg > svg { width: 2rem !important; height: 2rem !important; }
+  /* ホームアイコン: テーマに関係なく背景なしで表示 */
 }
 
 @media (prefers-color-scheme: dark) {

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import HomePage from './page';
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  getUserData: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mocks.push,
+  }),
+}));
+
+vi.mock('next/dynamic', () => ({
+  default: () => () => null,
+}));
+
+vi.mock('@/lib/auth', () => ({
+  useAuth: () => ({
+    user: { uid: 'user-1', email: 'test@example.com' },
+    loading: false,
+  }),
+}));
+
+vi.mock('@/lib/firestore', () => ({
+  getUserData: mocks.getUserData,
+}));
+
+vi.mock('@/lib/consent', () => ({
+  needsConsent: () => false,
+}));
+
+vi.mock('@/hooks/useChristmasMode', () => ({
+  useChristmasMode: () => ({
+    isChristmasMode: false,
+  }),
+}));
+
+describe('HomePage', () => {
+  it('非表示設定の機能カードをホームに表示しないが、その他は表示する', () => {
+    localStorage.setItem('roastplus_home_hidden_features', JSON.stringify(['dev-stories', 'settings']));
+
+    render(<HomePage />);
+
+    expect(screen.queryByRole('button', { name: '開発秘話' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'その他' })).toBeInTheDocument();
+  });
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,9 +12,11 @@ import { Loading } from '@/components/Loading';
 import { ActionCard } from '@/components/home/ActionCard';
 import { HomeHeader } from '@/components/home/HomeHeader';
 import { useChristmasMode } from '@/hooks/useChristmasMode';
+import { useHomeFeatureVisibility } from '@/hooks/useHomeFeatureVisibility';
 import { useAuth } from '@/lib/auth';
 import { getUserData } from '@/lib/firestore';
 import { needsConsent } from '@/lib/consent';
+import type { HomeFeatureKey } from '@/lib/homeFeatures';
 import dynamic from 'next/dynamic';
 
 const Snowfall = dynamic(() => import('@/components/Snowfall').then(mod => ({ default: mod.Snowfall })), {
@@ -26,7 +28,7 @@ import { GiCandyCanes, GiGingerbreadMan } from 'react-icons/gi';
 import { BsStars } from 'react-icons/bs';
 
 interface Action {
-  key: string;
+  key: HomeFeatureKey;
   title: string;
   description: string;
   href: string;
@@ -141,6 +143,8 @@ export default function HomePage(_props: HomePageProps = {}) {
   const [cardHeight, setCardHeight] = useState<number | null>(null);
   const [checkingConsent, setCheckingConsent] = useState(true);
   const { isChristmasMode } = useChristmasMode();
+  const { isVisible } = useHomeFeatureVisibility();
+  const visibleActions = ACTIONS.filter((action) => isVisible(action.key));
 
   // スプラッシュ画面の表示時間を管理（フェードアウト時間を加味）
   useEffect(() => {
@@ -199,14 +203,16 @@ export default function HomePage(_props: HomePageProps = {}) {
       const headerHeight = 72; // ヘッダーの高さ目安
       const paddingTop = 8; // pt-2 = 8px
       const paddingBottom = 8; // pb-2 = 8px
-      const gridGap = 48; // 4つのgap × 12px (5行で4つのgap)
+      const rowCount = Math.max(Math.ceil(visibleActions.length / 2), 1);
+      const gridGap = Math.max(rowCount - 1, 0) * 12; // gap-3 = 12px
 
       const availableHeight = viewportHeight - headerHeight - paddingTop - paddingBottom;
-      const cardHeightPerRow = (availableHeight - gridGap) / 5; // 10カードを5行に配置
+      const cardHeightPerRow = (availableHeight - gridGap) / rowCount;
 
-      // 最低100pxは確保
+      // 少ない表示件数でもカードが大きくなりすぎないようにする
       const minCardHeight = 100;
-      const calculatedHeight = Math.max(cardHeightPerRow, minCardHeight);
+      const maxCardHeight = 150;
+      const calculatedHeight = Math.min(Math.max(cardHeightPerRow, minCardHeight), maxCardHeight);
 
       setCardHeight(calculatedHeight);
     };
@@ -223,7 +229,7 @@ export default function HomePage(_props: HomePageProps = {}) {
       window.removeEventListener('resize', calculateCardHeight);
       window.removeEventListener('orientationchange', calculateCardHeight);
     };
-  }, []);
+  }, [visibleActions.length]);
 
   // スプラッシュ表示中はLoadingを出さない（スプラッシュが前面に表示されるため）
   if ((loading || checkingConsent) && !splashVisible) {
@@ -256,7 +262,7 @@ export default function HomePage(_props: HomePageProps = {}) {
           className="grid grid-cols-2 gap-3 md:grid-cols-4 md:gap-4"
           style={cardHeight ? { gridAutoRows: `${cardHeight}px` } : { gridAutoRows: '1fr' }}
         >
-          {ACTIONS.map(({ key, title, description, href, icon: DefaultIcon, badge }, index) => {
+          {visibleActions.map(({ key, title, description, href, icon: DefaultIcon, badge }, index) => {
             const Icon = isChristmasMode ? (CHRISTMAS_ICONS[key] || DefaultIcon) : DefaultIcon;
 
             return (

--- a/app/settings/home/page.test.tsx
+++ b/app/settings/home/page.test.tsx
@@ -1,0 +1,27 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import HomeVisibilitySettingsPage from './page';
+
+vi.mock('@/lib/auth', () => ({
+  useAuth: () => ({
+    user: { uid: 'user-1', email: 'test@example.com' },
+    loading: false,
+  }),
+}));
+
+vi.mock('@/app/login/page', () => ({
+  default: () => <div>ログイン画面</div>,
+}));
+
+describe('HomeVisibilitySettingsPage', () => {
+  it('機能のスイッチをOFFにすると非表示設定を保存する', () => {
+    render(<HomeVisibilitySettingsPage />);
+
+    fireEvent.click(screen.getByRole('switch', { name: '開発秘話をホームに表示' }));
+
+    expect(localStorage.getItem('roastplus_home_hidden_features')).toBe(
+      JSON.stringify(['dev-stories'])
+    );
+  });
+});

--- a/app/settings/home/page.tsx
+++ b/app/settings/home/page.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { MdHome, MdRestartAlt } from 'react-icons/md';
+
+import LoginPage from '@/app/login/page';
+import { Loading } from '@/components/Loading';
+import { Button, Card, FloatingNav, Switch } from '@/components/ui';
+import { useHomeFeatureVisibility } from '@/hooks/useHomeFeatureVisibility';
+import { useAuth } from '@/lib/auth';
+import { CONFIGURABLE_HOME_FEATURES } from '@/lib/homeFeatures';
+
+export default function HomeVisibilitySettingsPage() {
+  const { user, loading: authLoading } = useAuth();
+  const {
+    hiddenKeys,
+    updateFeatureHidden,
+    resetVisibility,
+  } = useHomeFeatureVisibility();
+
+  if (authLoading) {
+    return <Loading />;
+  }
+
+  if (!user) {
+    return <LoginPage />;
+  }
+
+  const hiddenCount = hiddenKeys.length;
+
+  return (
+    <div className="min-h-screen bg-page pt-14 pb-4 sm:pb-6 lg:pb-8 px-4 sm:px-6 lg:px-8 transition-colors">
+      <FloatingNav backHref="/settings" />
+      <div className="max-w-4xl mx-auto">
+        <header className="mb-4 sm:mb-6">
+          <h1 className="text-xl sm:text-2xl font-bold text-ink flex items-center gap-2">
+            <MdHome className="h-6 w-6 text-spot" />
+            ホーム表示設定
+          </h1>
+          <p className="mt-2 text-sm text-ink-sub">
+            ホーム画面に表示する機能を選びます。その他は再表示の入口として常に表示されます。
+          </p>
+        </header>
+
+        <main className="flex flex-col gap-4">
+          <Card variant="default" className="p-6">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h2 className="text-lg font-semibold text-ink">表示中の機能</h2>
+                <p className="text-sm text-ink-sub">
+                  {CONFIGURABLE_HOME_FEATURES.length - hiddenCount} / {CONFIGURABLE_HOME_FEATURES.length} 件を表示中
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={resetVisibility}
+                disabled={hiddenCount === 0}
+              >
+                <MdRestartAlt className="mr-2 h-5 w-5" />
+                すべて表示に戻す
+              </Button>
+            </div>
+          </Card>
+
+          <Card variant="default" className="p-6">
+            <div className="divide-y divide-edge">
+              {CONFIGURABLE_HOME_FEATURES.map((feature) => {
+                const isHidden = hiddenKeys.includes(feature.key);
+
+                return (
+                  <div
+                    key={feature.key}
+                    className="flex min-h-[64px] items-center justify-between gap-4 py-4 first:pt-0 last:pb-0"
+                  >
+                    <div className="min-w-0">
+                      <h2 className="text-base font-semibold text-ink">{feature.title}</h2>
+                      <p className="mt-1 text-sm text-ink-sub">{feature.description}</p>
+                    </div>
+                    <Switch
+                      aria-label={`${feature.title}をホームに表示`}
+                      checked={!isHidden}
+                      onChange={(event) => updateFeatureHidden(feature.key, !event.target.checked)}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          </Card>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/app/settings/page.test.tsx
+++ b/app/settings/page.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import SettingsPage from './page';
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  showToast: vi.fn(),
+  signOut: vi.fn(),
+  getUserData: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mocks.push,
+  }),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  useAuth: () => ({
+    user: { uid: 'user-1', email: 'test@example.com' },
+    loading: false,
+  }),
+  signOut: mocks.signOut,
+}));
+
+vi.mock('@/hooks/useDeveloperMode', () => ({
+  useDeveloperMode: () => ({
+    isEnabled: false,
+    isLoading: false,
+    enableDeveloperMode: vi.fn(),
+    disableDeveloperMode: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useAppTheme', () => ({
+  useAppTheme: () => ({
+    presets: [{ id: 'default', name: 'デフォルト' }],
+    currentTheme: 'default',
+  }),
+}));
+
+vi.mock('@/hooks/useAppVersion', () => ({
+  useAppVersion: () => ({
+    version: '0.17.7',
+    isUpdateAvailable: false,
+    isChecking: false,
+    checkForUpdates: vi.fn(),
+    applyUpdate: vi.fn(),
+  }),
+}));
+
+vi.mock('@/components/Toast', () => ({
+  useToastContext: () => ({
+    showToast: mocks.showToast,
+  }),
+}));
+
+vi.mock('@/lib/firestore', () => ({
+  getUserData: mocks.getUserData,
+}));
+
+vi.mock('@/app/login/page', () => ({
+  default: () => <div>ログイン画面</div>,
+}));
+
+describe('SettingsPage', () => {
+  it('設定項目のカード一覧は適度なgapで上下の余白を確保する', () => {
+    render(<SettingsPage />);
+
+    expect(screen.getByRole('main')).toHaveClass('flex', 'flex-col', 'gap-4');
+  });
+
+  it('ホーム表示設定への入口を表示する', () => {
+    render(<SettingsPage />);
+
+    expect(screen.getByRole('link', { name: /ホーム表示設定/ })).toHaveAttribute(
+      'href',
+      '/settings/home'
+    );
+  });
+
+  it('ホーム表示設定は他の設定カードと同じ横幅で表示する', () => {
+    render(<SettingsPage />);
+
+    const links = screen.getAllByRole('link');
+    const homeVisibilityLink = screen.getByRole('link', { name: /ホーム表示設定/ });
+
+    expect(links[1]).toBe(homeVisibilityLink);
+    expect(homeVisibilityLink).toHaveClass('block');
+    expect(homeVisibilityLink).not.toHaveClass('mx-auto');
+    expect(homeVisibilityLink).not.toHaveClass('max-w-xl');
+  });
+});

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -11,7 +11,7 @@ import { Loading } from '@/components/Loading';
 import { useToastContext } from '@/components/Toast';
 import { PasswordModal } from '@/components/settings/PasswordModal';
 import { HiDocumentText, HiShieldCheck, HiLogout, HiMail, HiColorSwatch } from 'react-icons/hi';
-import { MdHistory } from 'react-icons/md';
+import { MdHistory, MdHome } from 'react-icons/md';
 import LoginPage from '@/app/login/page';
 import { Button, Switch, FloatingNav, Card } from '@/components/ui';
 import { VERSION_HISTORY } from '@/data/dev-stories/version-history';
@@ -91,9 +91,27 @@ export default function SettingsPage() {
         <div className="min-h-screen bg-page pt-14 pb-4 sm:pb-6 lg:pb-8 px-4 sm:px-6 lg:px-8 transition-colors">
             <FloatingNav backHref="/" />
             <div className="max-w-4xl mx-auto">
-                <main className="space-y-6">
+                <main className="flex flex-col gap-4">
+                    {/* ホーム表示設定 */}
+                    <Link href="/settings/home" className="block">
+                      <Card variant="hoverable" className="p-6">
+                        <div className="flex items-center justify-between">
+                            <div className="flex-1">
+                                <h2 className="text-xl font-semibold text-ink mb-2 flex items-center gap-2">
+                                    <MdHome className="h-5 w-5 text-spot" />
+                                    ホーム表示設定
+                                </h2>
+                                <p className="text-sm text-ink-sub">
+                                    ホームに表示する機能を選ぶ
+                                </p>
+                            </div>
+                            <span className="text-ink-muted text-xl">&gt;</span>
+                        </div>
+                      </Card>
+                    </Link>
+
                     {/* テーマ設定 */}
-                    <Link href="/settings/theme">
+                    <Link href="/settings/theme" className="block">
                       <Card variant="hoverable" className="p-6">
                         <div className="flex items-center justify-between">
                             <div className="flex-1">
@@ -133,7 +151,7 @@ export default function SettingsPage() {
 
                     {/* Developer Design Lab（開発者モード有効時のみ表示） */}
                     {isEnabled && (
-                        <Link href="/dev/design-lab">
+                        <Link href="/dev/design-lab" className="block">
                           <Card variant="hoverable" className="p-6">
                             <div className="flex items-center justify-between">
                                 <div className="flex-1">
@@ -166,7 +184,7 @@ export default function SettingsPage() {
                                 </div>
                                 {isUpdateAvailable && (
                                     <div className="ml-4">
-                                        <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-spot/10 text-spot">
+                                        <span className="inline-flex items-center text-sm font-semibold text-spot">
                                             更新あり
                                         </span>
                                     </div>
@@ -199,7 +217,7 @@ export default function SettingsPage() {
                     </Card>
 
                     {/* 更新履歴セクション */}
-                    <Link href="/changelog">
+                    <Link href="/changelog" className="block">
                       <Card variant="hoverable" className="p-6">
                         <div className="flex items-center justify-between">
                             <div className="flex-1">

--- a/components/TastingRecordFormScores.tsx
+++ b/components/TastingRecordFormScores.tsx
@@ -36,7 +36,7 @@ export function TastingRecordFormScores({
             <div className="w-1 h-5 rounded-full bg-spot" />
             <h3 className="text-base font-bold text-ink">評価項目</h3>
           </div>
-          <div className="px-2.5 py-0.5 rounded-full text-[10px] font-bold tracking-wider bg-spot-subtle text-spot">
+          <div className="text-[10px] font-bold tracking-wider text-spot">
             1.0 - 5.0 スケール
           </div>
         </div>

--- a/components/TastingSessionCardMobile.test.tsx
+++ b/components/TastingSessionCardMobile.test.tsx
@@ -1,0 +1,38 @@
+import { render } from '@testing-library/react';
+import { TastingSessionCardMobile } from './TastingSessionCardMobile';
+import type { TastingSession } from '@/types';
+
+const session: TastingSession = {
+  id: 'session-1',
+  beanName: 'エチオピア',
+  roastLevel: '浅煎り',
+  createdAt: '2026-02-11T00:00:00.000Z',
+  updatedAt: '2026-02-11T00:00:00.000Z',
+  userId: 'user-1',
+};
+
+const defaultProps = {
+  session,
+  recordCount: 1,
+  averageScores: {
+    bitterness: 3,
+    acidity: 4,
+    body: 3,
+    sweetness: 4,
+    aroma: 5,
+  },
+  comments: ['明るい酸味で余韻が長い'],
+  isAnalyzing: false,
+  getRoastBadgeStyle: () => ({ bg: '#C8A882', text: '#3E2723', label: '浅煎り' }),
+  formatDate: () => '2026.02.11',
+};
+
+describe('TastingSessionCardMobile', () => {
+  it('強いフリックでもカード単位で止まりやすくする', () => {
+    const { container } = render(<TastingSessionCardMobile {...defaultProps} />);
+
+    const snapItem = container.firstElementChild;
+
+    expect(snapItem).toHaveStyle({ scrollSnapStop: 'always' });
+  });
+});

--- a/components/TastingSessionCardMobile.tsx
+++ b/components/TastingSessionCardMobile.tsx
@@ -38,7 +38,10 @@ export function TastingSessionCardMobile({
 
   return (
     <>
-      <div className="flex-shrink-0 w-[calc(100vw-2rem)] h-full snap-center">
+      <div
+        className="flex-shrink-0 w-[calc(100vw-2rem)] h-full snap-center"
+        style={{ scrollSnapStop: 'always' }}
+      >
         <Link href={`/tasting?sessionId=${session.id}`} className="block h-full">
           <Card variant="hoverable" className="p-0 flex flex-col h-full overflow-hidden shadow-lg">
             <div className="relative z-10 flex flex-col h-full">

--- a/components/TastingSessionDetail.tsx
+++ b/components/TastingSessionDetail.tsx
@@ -123,7 +123,7 @@ export function TastingSessionDetail({
       <Card className="p-6">
         <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
           <div className="flex items-center gap-3">
-            <div className="p-3 rounded-2xl bg-spot-subtle">
+            <div className="p-3">
               <Coffee size={32} weight="fill" className="text-spot" />
             </div>
             <div>

--- a/components/TastingSessionFilterModal.test.tsx
+++ b/components/TastingSessionFilterModal.test.tsx
@@ -80,6 +80,38 @@ describe('TastingSessionFilterModal', () => {
         expect.objectContaining({ sortOption: 'oldest' })
       );
     });
+
+    it('選択チップは統一された高さと角丸で表示する', () => {
+      render(<TastingSessionFilterModal {...baseProps} />);
+
+      [
+        screen.getByRole('button', { name: '新しい順' }),
+        screen.getByRole('button', { name: '古い順' }),
+        screen.getByRole('button', { name: '名前順' }),
+        screen.getByRole('button', { name: '浅煎り' }),
+        screen.getByRole('button', { name: '中煎り' }),
+        screen.getByRole('button', { name: '中深煎り' }),
+        screen.getByRole('button', { name: '深煎り' }),
+      ].forEach((chip) => {
+        expect(chip).toHaveClass('!min-h-[40px]');
+        expect(chip).toHaveClass('!rounded-xl');
+        expect(chip).toHaveClass('!px-3');
+        expect(chip).toHaveClass('!py-2');
+      });
+    });
+
+    it('並び替えと焙煎度合いの選択中チップは同じ色で表示する', () => {
+      render(
+        <TastingSessionFilterModal
+          {...baseProps}
+          sortOption="oldest"
+          selectedRoastLevels={['中深煎り']}
+        />
+      );
+
+      expect(screen.getByRole('button', { name: '古い順' })).toHaveClass('!bg-spot', '!text-white', '!border-spot');
+      expect(screen.getByRole('button', { name: '中深煎り' })).toHaveClass('!bg-spot', '!text-white', '!border-spot');
+    });
   });
 
   describe('焙煎度合いチップ', () => {
@@ -131,6 +163,23 @@ describe('TastingSessionFilterModal', () => {
       fireEvent.click(screen.getByText('適用'));
       expect(onApply).toHaveBeenCalledTimes(1);
       expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('入力欄レイアウト', () => {
+    it('検索入力と日付入力は統一された高さと角丸で表示する', () => {
+      render(<TastingSessionFilterModal {...baseProps} />);
+
+      const inputs = [
+        screen.getByPlaceholderText('豆の名前を入力...'),
+        ...document.querySelectorAll('input[type="date"]'),
+      ];
+
+      inputs.forEach((input) => {
+        expect(input).toHaveClass('!min-h-[52px]');
+        expect(input).toHaveClass('!rounded-xl');
+        expect(input).toHaveClass('!text-base');
+      });
     });
   });
 });

--- a/components/TastingSessionFilterModal.tsx
+++ b/components/TastingSessionFilterModal.tsx
@@ -13,6 +13,13 @@ import { Button, IconButton, Input } from '@/components/ui';
 
 type SortOption = 'newest' | 'oldest' | 'beanName';
 
+const inputControlClassName = '!min-h-[52px] !rounded-xl !border !py-3 !text-base';
+const chipClassName =
+  '!min-h-[40px] !rounded-xl !px-3 !py-2 !text-xs !font-semibold !shadow-none border text-center';
+const selectedChipClassName = '!bg-spot !text-white !border-spot';
+const idleChipClassName =
+  '!bg-ground !text-ink-sub !border-edge hover:!border-edge-strong hover:!bg-surface';
+
 interface TastingSessionFilterModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -119,7 +126,7 @@ export function TastingSessionFilterModal({
             initial={{ opacity: 0, scale: 0.95, y: 20 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.95, y: 20 }}
-            className="relative rounded-2xl shadow-xl max-w-md w-full max-h-[90vh] overflow-hidden flex flex-col bg-overlay border-2 border-edge-strong"
+            className="relative rounded-2xl shadow-xl max-w-md w-full max-h-[90vh] overflow-hidden flex flex-col bg-overlay"
           >
             {/* ヘッダー */}
             <div className="px-5 py-4 flex items-center justify-between bg-[#261a14]">
@@ -131,13 +138,15 @@ export function TastingSessionFilterModal({
               </div>
               <div className="flex items-center gap-2">
                 {hasActiveFilters && (
-                  <button
+                  <Button
+                    variant="ghost"
+                    size="sm"
                     type="button"
                     onClick={handleReset}
-                    className="text-[11px] font-semibold text-white/50 underline underline-offset-2 hover:text-white/80 transition-colors"
+                    className="!min-h-0 !px-0 !py-0 !rounded-none !text-[11px] !font-semibold !text-white/50 underline underline-offset-2 hover:!text-white/80"
                   >
                     リセット
-                  </button>
+                  </Button>
                 )}
                 <IconButton
                   variant="ghost"
@@ -151,7 +160,7 @@ export function TastingSessionFilterModal({
             </div>
 
             {/* コンテンツ */}
-            <div className="flex-1 overflow-y-auto px-6 py-4 space-y-6">
+            <div className="flex-1 overflow-y-auto px-6 py-5 space-y-5">
               {/* 検索バー */}
               <div className="space-y-2">
                 <label className="flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-ink-muted">
@@ -163,6 +172,7 @@ export function TastingSessionFilterModal({
                   value={tempSearchQuery}
                   onChange={(e) => setTempSearchQuery(e.target.value)}
                   placeholder="豆の名前を入力..."
+                  className={inputControlClassName}
                 />
               </div>
 
@@ -180,19 +190,21 @@ export function TastingSessionFilterModal({
                       { id: 'beanName', label: '名前順' },
                     ] as const
                   ).map((opt) => (
-                    <button
+                    <Button
                       key={opt.id}
+                      variant="ghost"
+                      size="sm"
                       type="button"
                       aria-pressed={tempSortOption === opt.id}
                       onClick={() => setTempSortOption(opt.id)}
-                      className={`py-2 rounded-xl text-xs font-semibold text-center transition-colors ${
+                      className={`${chipClassName} ${
                         tempSortOption === opt.id
-                          ? 'bg-spot text-white border border-spot shadow-sm'
-                          : 'bg-ground border border-edge text-ink-sub hover:border-edge-strong'
+                          ? selectedChipClassName
+                          : idleChipClassName
                       }`}
                     >
                       {opt.label}
-                    </button>
+                    </Button>
                   ))}
                 </div>
               </div>
@@ -208,11 +220,13 @@ export function TastingSessionFilterModal({
                     type="date"
                     value={tempDateFrom}
                     onChange={(e) => setTempDateFrom(e.target.value)}
+                    className={inputControlClassName}
                   />
                   <Input
                     type="date"
                     value={tempDateTo}
                     onChange={(e) => setTempDateTo(e.target.value)}
+                    className={inputControlClassName}
                   />
                 </div>
               </div>
@@ -225,19 +239,21 @@ export function TastingSessionFilterModal({
                 </label>
                 <div className="grid grid-cols-4 gap-1.5">
                   {ROAST_LEVELS.map((level) => (
-                    <button
+                    <Button
                       key={level}
+                      variant="ghost"
+                      size="sm"
                       type="button"
                       aria-pressed={tempSelectedRoastLevels.includes(level)}
                       onClick={() => handleRoastLevelToggle(level)}
-                      className={`py-2 rounded-xl text-[11px] font-semibold text-center transition-colors ${
+                      className={`${chipClassName} ${
                         tempSelectedRoastLevels.includes(level)
-                          ? 'bg-[#261a14] text-[#f5c89a] border border-[#261a14]'
-                          : 'bg-ground border border-edge text-ink-sub hover:border-edge-strong'
+                          ? selectedChipClassName
+                          : idleChipClassName
                       }`}
                     >
                       {level}
-                    </button>
+                    </Button>
                   ))}
                 </div>
               </div>
@@ -246,16 +262,16 @@ export function TastingSessionFilterModal({
             {/* フッター */}
             <div className="p-5 pt-4 border-t flex gap-3 bg-ground border-edge">
               <Button
-                variant="secondary"
+                variant="surface"
                 onClick={onClose}
-                className="flex-1"
+                className="flex-1 !min-h-[48px] !rounded-xl !text-[15px]"
               >
                 キャンセル
               </Button>
               <Button
                 variant="primary"
                 onClick={handleApply}
-                className="flex-1"
+                className="flex-1 !min-h-[48px] !rounded-xl !text-[15px]"
               >
                 適用
               </Button>

--- a/components/TastingSessionList.tsx
+++ b/components/TastingSessionList.tsx
@@ -168,10 +168,9 @@ export function TastingSessionList({
           className="max-w-md w-full"
         >
           <Card className="rounded-[3rem] p-10 text-center space-y-8">
-            <div className="relative mx-auto w-32 h-32">
-              <div className="absolute inset-0 rounded-full scale-110 blur-2xl opacity-60 bg-spot-subtle"></div>
-              <div className="relative w-full h-full rounded-full flex items-center justify-center border-2 shadow-inner bg-ground border-edge">
-                <Coffee size={64} weight="duotone" className="text-spot opacity-50" />
+            <div className="relative mx-auto w-32 h-32 flex items-center justify-center">
+              <div className="relative flex items-center justify-center">
+                <Coffee size={64} weight="duotone" className="text-spot opacity-70" />
               </div>
             </div>
 

--- a/components/TodaySchedule.tsx
+++ b/components/TodaySchedule.tsx
@@ -170,7 +170,7 @@ function TodayScheduleInner({ data, onUpdate, selectedDate, currentSchedule, onC
                           placeholder="内容を入力"
                         />
                         {label.continuesUntil && (
-                          <span className="text-xs px-2 py-0.5 rounded-full whitespace-nowrap text-spot bg-spot-subtle">
+                          <span className="text-xs font-medium whitespace-nowrap text-spot">
                             〜{label.continuesUntil}まで
                           </span>
                         )}

--- a/components/changelog/ChangeTypeFilter.tsx
+++ b/components/changelog/ChangeTypeFilter.tsx
@@ -28,10 +28,10 @@ export const ChangeTypeFilter: React.FC<ChangeTypeFilterProps> = ({
             onClick={() => onToggle(type)}
             variant="ghost"
             size="sm"
-            className={`!rounded-full !px-3 !py-1.5 !min-h-0 text-sm font-medium ${
+            className={`!rounded-md !px-2 !py-1 !min-h-0 text-sm font-medium !bg-transparent hover:!bg-transparent ${
               isSelected
-                ? `${config.bgColor} ${config.color} ring-2 ring-offset-1 ring-current`
-                : 'bg-ground text-ink-muted hover:opacity-80'
+                ? `${config.color} underline decoration-current underline-offset-4`
+                : 'text-ink-muted hover:text-ink-sub'
             }`}
           >
             {config.label}

--- a/components/changelog/ChangelogTimeline.tsx
+++ b/components/changelog/ChangelogTimeline.tsx
@@ -14,7 +14,7 @@ export const ChangelogTimeline: React.FC<ChangelogTimelineProps> = ({ entries })
     return (
       <div className="text-center py-12">
         <div className="flex justify-center mb-4">
-          <div className="p-4 bg-ground rounded-full">
+          <div className="p-4">
             <MdHistory className="h-12 w-12 text-ink-muted" />
           </div>
         </div>

--- a/components/changelog/VersionCard.tsx
+++ b/components/changelog/VersionCard.tsx
@@ -26,11 +26,11 @@ export const VersionCard: React.FC<VersionCardProps> = ({ entry }) => {
       {/* ヘッダー部分 */}
       <div className="flex flex-wrap items-center gap-2 mb-3">
         {entry.version && (
-          <span className="px-2.5 py-1 bg-spot-subtle text-spot text-sm font-semibold rounded">
+          <span className="text-sm font-semibold text-ink-sub">
             v{entry.version}
           </span>
         )}
-        <span className={`px-2.5 py-1 ${typeConfig.bgColor} ${typeConfig.color} text-sm font-medium rounded`}>
+        <span className={`${typeConfig.color} text-sm font-medium`}>
           {typeConfig.label}
         </span>
         <span className="text-sm text-ink-muted ml-auto">
@@ -54,7 +54,7 @@ export const VersionCard: React.FC<VersionCardProps> = ({ entry }) => {
           {entry.tags.map((tag) => (
             <span
               key={tag}
-              className="px-2 py-0.5 text-xs rounded bg-ground text-ink-muted"
+              className="text-xs text-ink-muted"
             >
               #{tag}
             </span>

--- a/components/coffee-quiz/CategoryQuestionList.tsx
+++ b/components/coffee-quiz/CategoryQuestionList.tsx
@@ -201,7 +201,7 @@ export function CategoryQuestionList({
               className={`
                 !text-xs !px-2 !py-1 !rounded-md !min-h-0 !font-normal
                 ${sortBy === option.value
-                  ? 'bg-spot/20 text-spot'
+                  ? 'bg-surface text-spot border border-spot/30'
                   : 'bg-edge-subtle text-ink-muted hover:text-ink-sub'
                 }
               `}

--- a/components/coffee-quiz/CategorySelector.tsx
+++ b/components/coffee-quiz/CategorySelector.tsx
@@ -54,25 +54,25 @@ const CATEGORY_CONFIG: Record<QuizCategory, {
     icon: CoffeeIcon,
     bg: 'bg-surface',
     hoverBg: 'hover:bg-edge-subtle',
-    iconBg: 'bg-edge-subtle',
+    iconBg: '',
   },
   roasting: {
     icon: BeanIcon,
     bg: 'bg-surface',
-    hoverBg: 'hover:bg-spot-subtle',
-    iconBg: 'bg-spot-subtle',
+    hoverBg: 'hover:bg-edge-subtle',
+    iconBg: '',
   },
   brewing: {
     icon: DropletIcon,
     bg: 'bg-surface',
-    hoverBg: 'hover:bg-sky-500/10',
-    iconBg: 'bg-sky-500/10',
+    hoverBg: 'hover:bg-edge-subtle',
+    iconBg: '',
   },
   history: {
     icon: BookIcon,
     bg: 'bg-surface',
     hoverBg: 'hover:bg-edge-subtle',
-    iconBg: 'bg-edge-subtle',
+    iconBg: '',
   },
 };
 
@@ -104,7 +104,7 @@ export function CategorySelector({
           >
             <div className="flex items-start gap-2.5">
               {/* アイコン */}
-              <div className={`w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0 ${config.iconBg}`}>
+              <div className={`w-9 h-9 flex items-center justify-center flex-shrink-0 ${config.iconBg}`}>
                 <span className="text-ink-sub">
                   <Icon />
                 </span>

--- a/components/coffee-quiz/DailyGoalProgress.tsx
+++ b/components/coffee-quiz/DailyGoalProgress.tsx
@@ -50,7 +50,7 @@ export function DailyGoalProgress({
           <div className={`w-9 h-9 rounded-lg flex items-center justify-center ${
             isComplete
               ? 'bg-emerald-600 text-white'
-              : 'bg-spot-subtle text-spot'
+              : 'text-spot'
           }`}>
             {isComplete ? <CheckIcon /> : <TargetIcon />}
           </div>

--- a/components/coffee-quiz/HelpGuideModal.tsx
+++ b/components/coffee-quiz/HelpGuideModal.tsx
@@ -71,7 +71,7 @@ function MasteryBadge() {
           transition={{ delay: 0.2 + i * 0.1, type: 'spring', stiffness: 280, damping: 18 }}
           className={`flex flex-col items-center gap-1 flex-1 py-2 rounded-xl border ${
             item.active
-              ? 'bg-spot/10 border-spot/30'
+              ? 'bg-surface border-spot/30'
               : 'bg-surface border-edge'
           }`}
         >
@@ -254,7 +254,7 @@ export function HelpGuideModal({ show, onClose }: HelpGuideModalProps) {
                 initial={{ scale: 0.8, opacity: 0 }}
                 animate={{ scale: 1, opacity: 1 }}
                 transition={{ delay: 0.05, type: 'spring', stiffness: 300, damping: 20 }}
-                className="w-16 h-16 flex items-center justify-center rounded-full bg-spot/10 text-4xl"
+                className="w-16 h-16 flex items-center justify-center text-4xl"
               >
                 {current.icon}
               </motion.div>
@@ -264,7 +264,7 @@ export function HelpGuideModal({ show, onClose }: HelpGuideModalProps) {
                 initial={{ opacity: 0, y: 4 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 0.1 }}
-                className="px-3 py-0.5 rounded-full bg-spot-subtle text-spot text-xs font-semibold border border-spot/20"
+                className="text-spot text-xs font-semibold"
               >
                 {current.label}
               </motion.span>

--- a/components/coffee-quiz/LevelDisplay.tsx
+++ b/components/coffee-quiz/LevelDisplay.tsx
@@ -52,7 +52,7 @@ export function LevelDisplay({ level, compact = false }: LevelDisplayProps) {
           <div className="w-14 h-14 rounded-full bg-spot flex items-center justify-center">
             <span className="text-white font-bold text-xl">{level.level}</span>
           </div>
-          <span className="absolute -bottom-0.5 left-1/2 -translate-x-1/2 bg-spot-subtle text-ink-sub text-[10px] font-medium px-2 py-0.5 rounded-full">
+          <span className="absolute -bottom-0.5 left-1/2 -translate-x-1/2 text-ink-sub text-[10px] font-medium">
             Lv.
           </span>
         </div>

--- a/components/coffee-quiz/LevelUpModal.tsx
+++ b/components/coffee-quiz/LevelUpModal.tsx
@@ -71,7 +71,7 @@ export function LevelUpModal({ show, newLevel, onClose }: LevelUpModalProps) {
                 initial={{ scale: 0 }}
                 animate={{ scale: 1 }}
                 transition={{ delay: 0.3, type: 'spring' }}
-                className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-spot-subtle border-2 border-spot/20 mb-4"
+                className="inline-flex items-center justify-center w-20 h-20 mb-4"
               >
                 <span className="text-4xl font-bold text-spot">
                   {newLevel}

--- a/components/coffee-quiz/QuizCard.tsx
+++ b/components/coffee-quiz/QuizCard.tsx
@@ -160,10 +160,10 @@ export function QuizCard({
               animate={{ opacity: 1, y: 0, scale: 1 }}
               exit={{ opacity: 0, y: -20 }}
               transition={{ type: 'spring', stiffness: 300, damping: 25 }}
-              className="mt-5 p-4 bg-spot-subtle rounded-xl border border-spot/20"
+              className="mt-5 p-4 bg-surface rounded-xl border border-edge"
             >
               <h3 className="font-bold text-ink mb-2 flex items-center gap-2 text-sm">
-                <span className="w-7 h-7 rounded-lg bg-spot/10 flex items-center justify-center text-spot">
+                <span className="w-7 h-7 flex items-center justify-center text-spot">
                   <LightbulbIcon />
                 </span>
                 解説

--- a/components/coffee-quiz/QuizDashboard.tsx
+++ b/components/coffee-quiz/QuizDashboard.tsx
@@ -195,7 +195,7 @@ export function QuizDashboard({
           href="/coffee-trivia/badges"
           className="group flex items-center gap-3 bg-surface rounded-xl p-3.5 border border-edge hover:border-spot/20 hover:shadow-sm transition-all"
         >
-          <div className="w-10 h-10 rounded-lg bg-spot-subtle group-hover:bg-spot/15 flex items-center justify-center transition-colors text-spot">
+          <div className="w-10 h-10 flex items-center justify-center transition-colors text-spot group-hover:text-spot-hover">
             <TrophyIcon />
           </div>
           <div>

--- a/components/coffee-quiz/QuizOption.tsx
+++ b/components/coffee-quiz/QuizOption.tsx
@@ -46,9 +46,9 @@ export function QuizOption({
     if (!showFeedback) {
       // フィードバック前
       if (isSelected) {
-        return 'bg-spot/10 border-spot text-ink';
+        return 'bg-surface border-spot text-ink';
       }
-      return 'border-edge text-ink hover:bg-spot-subtle hover:border-spot/40';
+      return 'border-edge text-ink hover:bg-ground hover:border-spot/40';
     }
 
     // フィードバック後

--- a/components/coffee-quiz/QuizResult.tsx
+++ b/components/coffee-quiz/QuizResult.tsx
@@ -176,7 +176,7 @@ export function QuizResult({
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: 0.6 }}
-            className="bg-spot-subtle rounded-xl p-3 text-center border border-spot/20"
+            className="bg-surface rounded-xl p-3 text-center border border-edge"
           >
             <span className="text-2xl font-bold text-spot">+{totalXP}</span>
             <p className="text-spot/70 text-xs mt-0.5">XP</p>

--- a/components/coffee-quiz/StreakCounter.tsx
+++ b/components/coffee-quiz/StreakCounter.tsx
@@ -99,7 +99,7 @@ export function StreakCounter({ streak, compact = false }: StreakCounterProps) {
             <motion.div
               initial={{ opacity: 0, y: -4 }}
               animate={{ opacity: 1, y: 0 }}
-              className="mt-1.5 px-2.5 py-1 bg-spot/10 rounded-md inline-block"
+              className="mt-1.5 inline-block"
             >
               <span className="text-spot-hover font-medium text-xs">
                 今日クイズをしないとストリークが切れます

--- a/components/defect-bean-form/DefectBeanFormFields.tsx
+++ b/components/defect-bean-form/DefectBeanFormFields.tsx
@@ -83,13 +83,13 @@ export function DefectBeanFormFields({
             <Button
               variant="ghost"
               onClick={onShowCamera}
-              className="!w-full !px-4 !py-12 !border-2 !border-dashed !rounded-lg flex-col !min-h-[200px] !border-edge-strong hover:!border-spot hover:!bg-spot-subtle"
+              className="!w-full !px-4 !py-12 !border-2 !border-dashed !rounded-lg flex-col !min-h-[200px] !border-edge-strong hover:!border-spot hover:!bg-ground"
             >
               <HiCamera className="h-12 w-12 text-ink-muted" />
               <span className="font-medium text-ink-sub">カメラで撮影</span>
             </Button>
             <div className="text-center text-sm text-ink-muted">または</div>
-            <label className="block w-full px-4 py-3 border-2 rounded-lg transition-colors cursor-pointer text-center min-h-[44px] flex items-center justify-center border-edge-strong hover:border-spot hover:bg-spot-subtle text-ink-sub">
+            <label className="block w-full px-4 py-3 border-2 rounded-lg transition-colors cursor-pointer text-center min-h-[44px] flex items-center justify-center border-edge-strong hover:border-spot hover:bg-ground text-ink-sub">
               <span className="font-medium">ファイルを選択</span>
               <input
                 type="file"

--- a/components/defect-beans/EmptyState.tsx
+++ b/components/defect-beans/EmptyState.tsx
@@ -14,8 +14,7 @@ export function EmptyState({ hasSearchOrFilter, onAddClick }: EmptyStateProps) {
       <div className="flex flex-col items-center justify-center space-y-4 sm:space-y-6">
         {/* アイコン */}
         <div className="relative">
-          <div className="absolute inset-0 rounded-full blur-xl opacity-50 bg-spot-subtle"></div>
-          <div className="relative w-20 h-20 sm:w-24 sm:h-24 rounded-full flex items-center justify-center bg-spot-subtle">
+          <div className="relative w-20 h-20 sm:w-24 sm:h-24 flex items-center justify-center">
             {hasSearchOrFilter ? (
               <HiSearch className="w-10 h-10 sm:w-12 sm:h-12 text-spot" />
             ) : (

--- a/components/defect-beans/FilterMenu.tsx
+++ b/components/defect-beans/FilterMenu.tsx
@@ -129,7 +129,7 @@ export function FilterMenu({
                   onClick={() => onSortChange(option)}
                   className={`!min-h-0 w-full !justify-start !px-3 !py-2 !text-sm !rounded-lg gap-2 ${
                     sortOption === option
-                      ? 'bg-spot-subtle !text-spot !font-medium'
+                      ? 'bg-surface !text-spot !font-medium'
                       : '!text-ink-sub hover:bg-ground'
                   }`}
                 >

--- a/components/drip-guide/StartHintDialog.tsx
+++ b/components/drip-guide/StartHintDialog.tsx
@@ -78,7 +78,7 @@ export const StartHintDialog: React.FC<StartHintDialogProps> = ({
                             onClick={(e) => e.stopPropagation()}
                         >
                             <div className="flex items-start gap-3 px-5 pt-5">
-                                <div className="flex h-11 w-11 items-center justify-center rounded-full bg-spot-subtle text-spot">
+                                <div className="flex h-11 w-11 items-center justify-center text-spot">
                                     <Coffee size={24} weight="duotone" />
                                 </div>
                                 <div className="flex-1">
@@ -96,7 +96,7 @@ export const StartHintDialog: React.FC<StartHintDialogProps> = ({
 
                             <div className="px-5 py-4 space-y-3 text-sm text-ink-sub">
                                 <div className="flex gap-3">
-                                    <div className="mt-1 flex h-9 w-9 items-center justify-center rounded-lg bg-spot-subtle text-spot">
+                                    <div className="mt-1 flex h-9 w-9 items-center justify-center text-spot">
                                         <GiCoffeePot size={18} />
                                     </div>
                                     <div className="flex-1">
@@ -111,7 +111,7 @@ export const StartHintDialog: React.FC<StartHintDialogProps> = ({
                                 </div>
 
                                 <div className="flex gap-3">
-                                    <div className="mt-1 flex h-9 w-9 items-center justify-center rounded-lg bg-spot-subtle text-spot">
+                                    <div className="mt-1 flex h-9 w-9 items-center justify-center text-spot">
                                         <Timer size={18} weight="duotone" />
                                     </div>
                                     <div className="flex-1">
@@ -124,7 +124,7 @@ export const StartHintDialog: React.FC<StartHintDialogProps> = ({
 
                                 {isManualMode && (
                                     <div className="flex gap-3">
-                                        <div className="mt-1 flex h-9 w-9 items-center justify-center rounded-lg bg-spot-subtle text-spot">
+                                        <div className="mt-1 flex h-9 w-9 items-center justify-center text-spot">
                                             <HandPointing size={18} weight="duotone" />
                                         </div>
                                         <div className="flex-1">

--- a/components/drip-guide/dialogs/46/Dialog46DescriptionModal.tsx
+++ b/components/drip-guide/dialogs/46/Dialog46DescriptionModal.tsx
@@ -66,7 +66,7 @@ export const Dialog46DescriptionModal: React.FC<Dialog46DescriptionModalProps> =
                             <div className="flex-1 overflow-y-auto px-6 py-6 space-y-6">
                                 {RECIPE46_DESCRIPTION_SECTIONS.map((section, idx) => (
                                     <div key={idx} className="flex gap-4">
-                                        <div className="flex-shrink-0 w-10 h-10 rounded-full bg-spot-subtle text-spot flex items-center justify-center">
+                                        <div className="flex-shrink-0 w-10 h-10 text-spot flex items-center justify-center">
                                             {section.icon === 'target' && <Drop size={20} weight="bold" />}
                                             {section.icon === 'rule' && <Coffee size={20} weight="bold" />}
                                             {section.icon === 'timer' && <Timer size={20} weight="bold" />}

--- a/components/drip-guide/dialogs/46/Dialog46Form.tsx
+++ b/components/drip-guide/dialogs/46/Dialog46Form.tsx
@@ -30,7 +30,7 @@ export const Dialog46Form: React.FC<Dialog46FormProps> = ({
                 variant="ghost"
                 type="button"
                 onClick={onDescriptionClick}
-                className="!min-h-0 w-full !rounded-lg bg-spot-subtle border border-spot/20 !p-3 !text-left hover:bg-spot-surface !justify-between"
+                className="!min-h-0 w-full !rounded-lg bg-surface border border-edge !p-3 !text-left hover:bg-ground !justify-between"
             >
                 <span className="text-sm font-semibold text-spot-hover">
                     4:6メソッドのポイント（必読）

--- a/components/drip-guide/dialogs/46/Dialog46Header.tsx
+++ b/components/drip-guide/dialogs/46/Dialog46Header.tsx
@@ -6,7 +6,7 @@ import { Coffee } from 'phosphor-react';
 export const Dialog46Header: React.FC = () => {
     return (
         <div className="flex items-start gap-3 px-5 pt-5">
-            <div className="flex h-11 w-11 items-center justify-center rounded-full bg-spot-subtle text-spot">
+            <div className="flex h-11 w-11 items-center justify-center text-spot">
                 <Coffee size={24} weight="duotone" />
             </div>
             <div className="flex-1">

--- a/components/drip-guide/dialogs/hoffmann/HoffmannDescriptionModal.tsx
+++ b/components/drip-guide/dialogs/hoffmann/HoffmannDescriptionModal.tsx
@@ -81,7 +81,7 @@ export const HoffmannDescriptionModal: React.FC<HoffmannDescriptionModalProps> =
                             <div className="flex-1 overflow-y-auto px-6 py-6 space-y-6">
                                 {RECIPE_HOFFMANN_DESCRIPTION_SECTIONS.map((section, idx) => (
                                     <div key={idx} className="flex gap-4">
-                                        <div className="flex-shrink-0 w-10 h-10 rounded-full bg-spot-subtle text-spot flex items-center justify-center">
+                                        <div className="flex-shrink-0 w-10 h-10 text-spot flex items-center justify-center">
                                             {getIcon(section.icon)}
                                         </div>
                                         <div className="flex-1 border-b border-edge/30 pb-4">

--- a/components/drip-guide/dialogs/hoffmann/HoffmannDialogForm.tsx
+++ b/components/drip-guide/dialogs/hoffmann/HoffmannDialogForm.tsx
@@ -21,7 +21,7 @@ export const HoffmannDialogForm: React.FC<HoffmannDialogFormProps> = ({
                 variant="ghost"
                 type="button"
                 onClick={onDescriptionClick}
-                className="!min-h-0 w-full !rounded-lg bg-spot-subtle border border-spot/20 !p-3 !text-left hover:bg-spot-surface !justify-between"
+                className="!min-h-0 w-full !rounded-lg bg-surface border border-edge !p-3 !text-left hover:bg-ground !justify-between"
             >
                 <span className="text-sm font-semibold text-spot-hover">
                     Hoffmann V60のポイント（必読）

--- a/components/drip-guide/dialogs/hoffmann/HoffmannDialogHeader.tsx
+++ b/components/drip-guide/dialogs/hoffmann/HoffmannDialogHeader.tsx
@@ -6,7 +6,7 @@ import { Coffee } from 'phosphor-react';
 export const HoffmannDialogHeader: React.FC = () => {
     return (
         <div className="flex items-start gap-3 px-5 pt-5">
-            <div className="flex h-11 w-11 items-center justify-center rounded-full bg-spot-subtle text-spot">
+            <div className="flex h-11 w-11 items-center justify-center text-spot">
                 <Coffee size={24} weight="duotone" />
             </div>
             <div className="flex-1">

--- a/components/drip-guide/dialogs/hoffmann/HoffmannStepDetailModal.tsx
+++ b/components/drip-guide/dialogs/hoffmann/HoffmannStepDetailModal.tsx
@@ -69,7 +69,7 @@ export const HoffmannStepDetailModal: React.FC<HoffmannStepDetailModalProps> = (
                         >
                             <div className="flex items-center justify-between px-6 py-4 border-b border-edge">
                                 <div className="flex items-center gap-3">
-                                    <div className="w-10 h-10 rounded-full bg-spot-subtle text-spot flex items-center justify-center">
+                                    <div className="w-10 h-10 text-spot flex items-center justify-center">
                                         {getIcon(detail.icon)}
                                     </div>
                                     <div>
@@ -94,7 +94,7 @@ export const HoffmannStepDetailModal: React.FC<HoffmannStepDetailModalProps> = (
                             <div className="px-6 py-5 space-y-4">
                                 <p className="text-ink-sub leading-relaxed">{detail.description}</p>
 
-                                <div className="bg-spot-subtle rounded-lg p-4">
+                                <div className="bg-surface rounded-lg p-4 border border-edge">
                                     <h4 className="font-semibold text-spot-hover mb-2 text-sm">ポイント</h4>
                                     <ul className="space-y-2">
                                         {detail.tips.map((tip, idx) => (

--- a/components/drip-guide/runner/StepMiniMap.tsx
+++ b/components/drip-guide/runner/StepMiniMap.tsx
@@ -61,7 +61,7 @@ export const StepMiniMap: React.FC<StepMiniMapProps> = ({
                                 className={clsx(
                                     'flex-shrink-0 rounded-lg px-3 py-2 sm:px-3 sm:py-2 min-w-[120px] sm:min-w-[120px] border-2 transition-all',
                                     isCurrent
-                                        ? 'bg-spot-subtle border-spot shadow-md'
+                                        ? 'bg-surface border-spot shadow-md'
                                         : isStepCompleted
                                         ? 'bg-ground border-edge'
                                         : 'bg-ground/50 border-edge opacity-60'

--- a/components/home/ActionCard.tsx
+++ b/components/home/ActionCard.tsx
@@ -51,9 +51,7 @@ export function ActionCard({
         </div>
       )}
 
-      <span
-        className="relative flex h-14 w-14 items-center justify-center rounded-full transition-all duration-300 icon-circle-bg text-spot"
-      >
+      <span className="relative flex h-14 w-14 items-center justify-center transition-all duration-300 text-spot">
         <Icon className="h-11 w-11 relative z-10" />
       </span>
       <div className="space-y-1 text-center relative z-10">

--- a/components/ocr-confirm/OCRConfirmModal.tsx
+++ b/components/ocr-confirm/OCRConfirmModal.tsx
@@ -182,7 +182,7 @@ export function OCRConfirmModal({
             onClick={() => setActiveTab('timeLabels')}
             className={`flex-1 !rounded-none !min-h-[44px] flex items-center justify-center gap-2 ${
               activeTab === 'timeLabels'
-                ? 'bg-spot-subtle text-spot border-b-2 border-spot'
+                ? 'bg-surface text-spot border-b-2 border-spot'
                 : 'bg-surface text-ink-sub hover:bg-ground'
             }`}
           >
@@ -198,7 +198,7 @@ export function OCRConfirmModal({
             onClick={() => setActiveTab('roastSchedules')}
             className={`flex-1 !rounded-none !min-h-[44px] flex items-center justify-center gap-2 ${
               activeTab === 'roastSchedules'
-                ? 'bg-spot-subtle text-spot border-b-2 border-spot'
+                ? 'bg-surface text-spot border-b-2 border-spot'
                 : 'bg-surface text-ink-sub hover:bg-ground'
             }`}
           >

--- a/components/ocr-time-label-editor/TimeLabelRow.tsx
+++ b/components/ocr-time-label-editor/TimeLabelRow.tsx
@@ -239,7 +239,7 @@ export function TimeLabelRow({ label, isEditing, editor, onDelete }: TimeLabelRo
               )}
               {/* 継続終了時間 */}
               {label.continuesUntil && (
-                <span className="text-xs px-2 py-0.5 rounded-full text-spot bg-spot-subtle">
+                <span className="text-xs font-medium text-spot">
                   〜{label.continuesUntil}まで
                 </span>
               )}

--- a/components/ui/Switch.test.tsx
+++ b/components/ui/Switch.test.tsx
@@ -115,5 +115,10 @@ describe('Switch', () => {
       render(<Switch label="通知設定" id="notification-switch" />);
       expect(screen.getByRole('switch')).toHaveAttribute('aria-labelledby', 'notification-switch-label');
     });
+
+    it('aria-labelをスイッチ本体に設定できる', () => {
+      render(<Switch aria-label="ホームに表示" checked={false} onChange={() => {}} />);
+      expect(screen.getByRole('switch', { name: 'ホームに表示' })).toBeInTheDocument();
+    });
   });
 });

--- a/components/ui/Switch.tsx
+++ b/components/ui/Switch.tsx
@@ -33,6 +33,7 @@ export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
   ({ label, size = 'md', className = '', id, disabled, checked, ...props }, ref) => {
     const generatedId = useId();
     const switchId = id || generatedId;
+    const ariaLabel = props['aria-label'];
 
     // サイズ設定
     const sizeStyles = {
@@ -56,6 +57,7 @@ export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
           type="button"
           role="switch"
           aria-checked={checked}
+          aria-label={label ? undefined : ariaLabel}
           aria-labelledby={label ? `${switchId}-label` : undefined}
           onClick={() => {
             if (!disabled && props.onChange) {

--- a/components/work-progress/WorkProgressCard.tsx
+++ b/components/work-progress/WorkProgressCard.tsx
@@ -55,7 +55,7 @@ export const WorkProgressCard: React.FC<WorkProgressCardProps> = ({
                         e.stopPropagation();
                         onEdit(wp.id);
                     }}
-                    className="text-xs bg-spot-subtle"
+                    className="text-xs"
                 >
                     <HiPlus className="h-3.5 w-3.5 mr-1.5" />
                     <span>作業を追加</span>
@@ -90,7 +90,7 @@ export const WorkProgressCard: React.FC<WorkProgressCardProps> = ({
                             className={`px-2 py-1 text-xs font-medium rounded border focus:outline-none focus:ring-2 focus:ring-spot min-h-[32px] cursor-pointer ${wp.status === 'completed'
                                     ? 'bg-success/10 text-success border-success/30'
                                     : wp.status === 'in_progress'
-                                        ? 'bg-spot-subtle text-spot border-spot'
+                                        ? 'bg-surface text-spot border-spot'
                                         : 'bg-ground text-ink-sub border-edge'
                                 }`}
                         >

--- a/data/dev-stories/detailed-changelog.ts
+++ b/data/dev-stories/detailed-changelog.ts
@@ -1,14 +1,14 @@
 import type { ChangelogEntry, ChangelogEntryType } from '@/types';
 
 // 変更タイプの日本語ラベルと色定義
-export const CHANGE_TYPE_CONFIG: Record<ChangelogEntryType, { label: string; color: string; bgColor: string }> = {
-  feature: { label: '機能追加', color: 'text-emerald-700', bgColor: 'bg-emerald-100' },
-  bugfix: { label: '修正', color: 'text-red-700', bgColor: 'bg-red-100' },
-  improvement: { label: '改善', color: 'text-blue-700', bgColor: 'bg-blue-100' },
-  docs: { label: 'ドキュメント', color: 'text-purple-700', bgColor: 'bg-purple-100' },
-  style: { label: 'デザイン', color: 'text-pink-700', bgColor: 'bg-pink-100' },
-  update: { label: '更新', color: 'text-gray-700', bgColor: 'bg-gray-100' },
-  story: { label: '開発秘話', color: 'text-amber-700', bgColor: 'bg-amber-100' },
+export const CHANGE_TYPE_CONFIG: Record<ChangelogEntryType, { label: string; color: string }> = {
+  feature: { label: '機能追加', color: 'text-emerald-700' },
+  bugfix: { label: '修正', color: 'text-red-700' },
+  improvement: { label: '改善', color: 'text-blue-700' },
+  docs: { label: 'ドキュメント', color: 'text-purple-700' },
+  style: { label: 'デザイン', color: 'text-pink-700' },
+  update: { label: '更新', color: 'text-gray-700' },
+  story: { label: '開発秘話', color: 'text-amber-700' },
 };
 
 // 詳細な更新履歴データ

--- a/hooks/useHomeFeatureVisibility.ts
+++ b/hooks/useHomeFeatureVisibility.ts
@@ -1,0 +1,41 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+import {
+  getHiddenHomeFeatureKeys,
+  setHiddenHomeFeatureKeys,
+  setHomeFeatureHidden,
+} from '@/lib/homeFeatureVisibility';
+import type { HomeFeatureKey } from '@/lib/homeFeatures';
+
+function loadHiddenKeys(): HomeFeatureKey[] {
+  if (typeof window === 'undefined') return [];
+  return getHiddenHomeFeatureKeys();
+}
+
+export function useHomeFeatureVisibility() {
+  const [hiddenKeys, setHiddenKeys] = useState<HomeFeatureKey[]>(loadHiddenKeys);
+
+  const updateFeatureHidden = useCallback((key: HomeFeatureKey, hidden: boolean) => {
+    setHomeFeatureHidden(key, hidden);
+    setHiddenKeys(getHiddenHomeFeatureKeys());
+  }, []);
+
+  const resetVisibility = useCallback(() => {
+    setHiddenHomeFeatureKeys([]);
+    setHiddenKeys([]);
+  }, []);
+
+  const isVisible = useCallback(
+    (key: HomeFeatureKey) => !hiddenKeys.includes(key),
+    [hiddenKeys]
+  );
+
+  return {
+    hiddenKeys,
+    isVisible,
+    updateFeatureHidden,
+    resetVisibility,
+  };
+}

--- a/lib/homeFeatureVisibility.test.ts
+++ b/lib/homeFeatureVisibility.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  getHiddenHomeFeatureKeys,
+  isHomeFeatureVisible,
+  setHomeFeatureHidden,
+} from './homeFeatureVisibility';
+
+const createLocalStorageMock = () => {
+  const store: Record<string, string> = {};
+
+  return {
+    getItem: vi.fn((key: string) => store[key] || null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      Object.keys(store).forEach((key) => delete store[key]);
+    }),
+  };
+};
+
+describe('homeFeatureVisibility', () => {
+  let localStorageMock: ReturnType<typeof createLocalStorageMock>;
+
+  beforeEach(() => {
+    localStorageMock = createLocalStorageMock();
+    vi.stubGlobal('localStorage', localStorageMock);
+  });
+
+  it('未設定の場合はホーム機能をすべて表示する', () => {
+    expect(isHomeFeatureVisible('assignment')).toBe(true);
+    expect(isHomeFeatureVisible('dev-stories')).toBe(true);
+  });
+
+  it('非表示にした機能だけをlocalStorageに保存する', () => {
+    setHomeFeatureHidden('dev-stories', true);
+
+    expect(getHiddenHomeFeatureKeys()).toEqual(['dev-stories']);
+    expect(isHomeFeatureVisible('dev-stories')).toBe(false);
+    expect(isHomeFeatureVisible('assignment')).toBe(true);
+  });
+
+  it('その他は再表示の入口なので非表示にできない', () => {
+    setHomeFeatureHidden('settings', true);
+
+    expect(getHiddenHomeFeatureKeys()).toEqual([]);
+    expect(isHomeFeatureVisible('settings')).toBe(true);
+  });
+});

--- a/lib/homeFeatureVisibility.ts
+++ b/lib/homeFeatureVisibility.ts
@@ -1,0 +1,71 @@
+import {
+  CONFIGURABLE_HOME_FEATURE_KEYS,
+  HOME_FEATURE_KEYS,
+  type HomeFeatureKey,
+} from './homeFeatures';
+
+const HOME_HIDDEN_FEATURES_KEY = 'roastplus_home_hidden_features';
+const HOME_FEATURE_KEY_SET = new Set<string>(HOME_FEATURE_KEYS);
+const CONFIGURABLE_HOME_FEATURE_KEY_SET = new Set<string>(CONFIGURABLE_HOME_FEATURE_KEYS);
+
+function parseJson<T>(value: string): T | null {
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return null;
+  }
+}
+
+function isHomeFeatureKey(value: unknown): value is HomeFeatureKey {
+  return typeof value === 'string' && HOME_FEATURE_KEY_SET.has(value);
+}
+
+function isConfigurableHomeFeatureKey(value: unknown): value is HomeFeatureKey {
+  return typeof value === 'string' && CONFIGURABLE_HOME_FEATURE_KEY_SET.has(value);
+}
+
+function normalizeHiddenKeys(value: unknown): HomeFeatureKey[] {
+  if (!Array.isArray(value)) return [];
+
+  return Array.from(new Set(value)).filter(
+    (key): key is HomeFeatureKey => isHomeFeatureKey(key) && isConfigurableHomeFeatureKey(key)
+  );
+}
+
+export function getHiddenHomeFeatureKeys(): HomeFeatureKey[] {
+  if (typeof window === 'undefined') return [];
+
+  const stored = localStorage.getItem(HOME_HIDDEN_FEATURES_KEY);
+  if (!stored) return [];
+
+  const parsed = parseJson<unknown>(stored);
+  return normalizeHiddenKeys(parsed);
+}
+
+export function setHiddenHomeFeatureKeys(keys: HomeFeatureKey[]): void {
+  if (typeof window === 'undefined') return;
+
+  const normalizedKeys = normalizeHiddenKeys(keys);
+
+  if (normalizedKeys.length === 0) {
+    localStorage.removeItem(HOME_HIDDEN_FEATURES_KEY);
+    return;
+  }
+
+  localStorage.setItem(HOME_HIDDEN_FEATURES_KEY, JSON.stringify(normalizedKeys));
+}
+
+export function setHomeFeatureHidden(key: HomeFeatureKey, hidden: boolean): void {
+  if (!isConfigurableHomeFeatureKey(key)) return;
+
+  const currentKeys = getHiddenHomeFeatureKeys();
+  const nextKeys = hidden
+    ? [...currentKeys, key]
+    : currentKeys.filter((currentKey) => currentKey !== key);
+
+  setHiddenHomeFeatureKeys(nextKeys);
+}
+
+export function isHomeFeatureVisible(key: HomeFeatureKey): boolean {
+  return !getHiddenHomeFeatureKeys().includes(key);
+}

--- a/lib/homeFeatures.ts
+++ b/lib/homeFeatures.ts
@@ -1,0 +1,64 @@
+export const HOME_FEATURES = [
+  {
+    key: 'assignment',
+    title: '担当表',
+    description: '公平に担当を割り当て',
+  },
+  {
+    key: 'schedule',
+    title: 'スケジュール',
+    description: '一日の予定を確認',
+  },
+  {
+    key: 'tasting',
+    title: '試飲感想記録',
+    description: '試飲の感想を記録',
+  },
+  {
+    key: 'roast-timer',
+    title: 'ローストタイマー',
+    description: '最適なタイマーで焙煎',
+  },
+  {
+    key: 'defect-beans',
+    title: 'コーヒー豆図鑑',
+    description: '欠点豆の知識を共有',
+  },
+  {
+    key: 'progress',
+    title: '作業進捗',
+    description: '進捗を可視化',
+  },
+  {
+    key: 'drip-guide',
+    title: 'ドリップガイド',
+    description: '淹れ方の手順',
+  },
+  {
+    key: 'coffee-trivia',
+    title: 'コーヒークイズ',
+    description: '楽しく学ぶコーヒー知識',
+  },
+  {
+    key: 'dev-stories',
+    title: '開発秘話',
+    description: '開発の裏話を覗く',
+  },
+  {
+    key: 'settings',
+    title: 'その他',
+    description: '設定やアプリ情報など',
+  },
+] as const;
+
+export type HomeFeatureKey = typeof HOME_FEATURES[number]['key'];
+
+export const HOME_FEATURE_KEYS = HOME_FEATURES.map((feature) => feature.key);
+
+export const CONFIGURABLE_HOME_FEATURES = HOME_FEATURES.filter(
+  (feature) => feature.key !== 'settings'
+);
+
+export const CONFIGURABLE_HOME_FEATURE_KEYS = CONFIGURABLE_HOME_FEATURES.map(
+  (feature) => feature.key
+);


### PR DESCRIPTION
## Summary
- その他にホーム表示設定ページへの入口を追加
- ホーム表示設定ページで機能ごとの表示/非表示をlocalStorageに保存
- OFFにしたホームカードを空白なしで詰めて表示し、関連UI調整も含めてコミット

## Test Plan
- npm run test:run
- npm run build（Google Fonts取得のためネットワーク許可付きで成功）
- npm run lint（エラー0、既存警告8件）