### PR TITLE
fix: ルートレイアウトの未固定 Twemoji CDN スクリプトを削除

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata, Viewport } from "next";
 // TEMPORARY: Google Fonts disabled for build - will re-enable after deployment
 // import { Geist, Geist_Mono, Noto_Serif_JP, Playfair_Display, Nunito } from "next/font/google";
-import Script from "next/script";
 import "./globals.css";
 import { ServiceWorkerRegistration } from "@/components/ServiceWorkerRegistration";
 import { SplashScreenWrapper } from "@/components/SplashScreenWrapper";
@@ -95,10 +94,6 @@ export default function RootLayout({
         className={`${zenOldMincho.variable} ${inter.variable} ${robotoMono.variable} ${oswald.variable} ${orbitron.variable} ${notoSansJP.variable} ${raleway.variable} ${playfairDisplay.variable} antialiased font-serif bg-page`}
         suppressHydrationWarning
       >
-        <Script
-          src="https://cdn.jsdelivr.net/npm/twemoji@latest/dist/twemoji.min.js"
-          strategy="afterInteractive"
-        />
         <SplashScreenWrapper />
         <ServiceWorkerRegistration />
         <ThemeProvider>

--- a/components/CountryFlagEmoji.tsx
+++ b/components/CountryFlagEmoji.tsx
@@ -1,17 +1,7 @@
-'use client';
-
-import { useEffect, useRef } from 'react';
-
 interface CountryFlagEmojiProps {
   countryName: string;
   className?: string;
 }
-
-type TwemojiInstance = {
-  parse: (element: Element, options: { folder: string; ext: string; size: string }) => void;
-};
-
-type TwemojiWindow = typeof window & { twemoji?: TwemojiInstance };
 
 // 国名と国旗のマッピング
 const getCountryFlag = (countryName: string): string => {
@@ -32,89 +22,21 @@ const getCountryFlag = (countryName: string): string => {
     'マラウイ': '\u{1F1F2}\u{1F1FC}', // 🇲🇼
     'インド': '\u{1F1EE}\u{1F1F3}', // 🇮🇳
   };
-  
+
   return flagMap[countryName] || '';
 };
 
 export function CountryFlagEmoji({ countryName, className = '' }: CountryFlagEmojiProps) {
-  const flagElementRef = useRef<HTMLSpanElement>(null);
   const flag = getCountryFlag(countryName);
-  const isParsedRef = useRef(false);
-
-  // Twemojiで国旗を変換
-  useEffect(() => {
-    if (!flag || !flagElementRef.current) return;
-
-    isParsedRef.current = false;
-
-    // 既にimgタグに変換されている場合はスキップ
-    if (flagElementRef.current.querySelector('img')) {
-      isParsedRef.current = true;
-      return;
-    }
-
-    const parseFlag = () => {
-      const twemoji = (window as TwemojiWindow).twemoji;
-      if (twemoji && flagElementRef.current && !isParsedRef.current) {
-        // 既にimgタグに変換されている場合はスキップ
-        if (flagElementRef.current.querySelector('img')) {
-          isParsedRef.current = true;
-          return;
-        }
-        
-        try {
-          twemoji.parse(flagElementRef.current, {
-            folder: 'svg',
-            ext: '.svg',
-            size: '16x16',
-          });
-          isParsedRef.current = true;
-        } catch (error) {
-          console.error('Error parsing flag emoji:', error);
-        }
-      }
-    };
-    
-    // Twemojiが既に読み込まれている場合
-    if ((window as TwemojiWindow).twemoji) {
-      parseFlag();
-    } else {
-      // Twemojiの読み込みを待つ
-      let checkInterval: NodeJS.Timeout | null = null;
-      let timeoutId: NodeJS.Timeout | null = null;
-      
-      checkInterval = setInterval(() => {
-        if ((window as TwemojiWindow).twemoji) {
-          parseFlag();
-          if (checkInterval) clearInterval(checkInterval);
-          if (timeoutId) clearTimeout(timeoutId);
-        }
-      }, 100);
-      
-      // 5秒後にタイムアウト
-      timeoutId = setTimeout(() => {
-        if (checkInterval) clearInterval(checkInterval);
-      }, 5000);
-      
-      return () => {
-        if (checkInterval) clearInterval(checkInterval);
-        if (timeoutId) clearTimeout(timeoutId);
-      };
-    }
-  }, [flag, countryName]);
 
   if (!flag) {
-    // デバッグ用: マッピングが見つからない場合
-    if (countryName) {
-      console.warn(`Country flag not found for: "${countryName}"`);
-    }
     return null;
   }
 
   return (
-    <span 
-      ref={flagElementRef} 
-      className={`emoji inline-block ${className}`} 
+    <span
+      className={`emoji inline-block ${className}`}
+      role="img"
       aria-label={`${countryName}の国旗`}
       style={{ minWidth: '16px', minHeight: '16px', display: 'inline-block', verticalAlign: 'middle' }}
     >
@@ -122,4 +44,3 @@ export function CountryFlagEmoji({ countryName, className = '' }: CountryFlagEmo
     </span>
   );
 }
-


### PR DESCRIPTION
### Motivation
- ルートレイアウトで `@latest` を使った jsDelivr の Twemoji スクリプトをグローバルに読み込んでおり、SRI 未設定かつバージョン未固定の外部スクリプトがアプリ起動時に実行されるため、クライアント側の Firebase セッション・データが供与される危険があったため対処しました。

### Description
- `app/layout.tsx` から `next/script` の import と `https://cdn.jsdelivr.net/npm/twemoji@latest/dist/twemoji.min.js` の `<Script>` タグを削除して、全ページでの外部スクリプト実行を止めました。
- `components/CountryFlagEmoji.tsx` の `window.twemoji` 依存と実行ロジックを削除し、既存の国旗絵文字マップをそのまま描画する単純な実装に置き換え、外部スクリプトの必要性を無くしました。
- 変更は最小限に留めて既存の表示機能を維持し、アプリ起動時に任意の第三者 JS が実行されるリスクを排除しました。

### Testing
- `npm run lint` を実行し、既存のワーニングは残るものの今回の変更で新たな lint エラーは発生しませんでした（成功）。
- レポジトリ内検索で `cdn.jsdelivr`, `@latest`, `next/script`, `<Script>`, `window.twemoji` などの痕跡を `rg` で確認し、該当する脆弱な参照が残っていないことを確認しました（成功）。
- `npm run build` はコンテナ内で `next/font` が Google Fonts 取得に失敗したためビルド失敗となり、環境依存の制約によりビルドは検証できませんでした（環境失敗）。
- `npm run test:run`（`vitest`）はタイムアウトにより短時間での完了確認ができませんでした（タイムアウト）。
- `npx tsc --noEmit` は既存のテスト群に起因する型エラー多数のため失敗しましたが、これらは今回の変更箇所に起因するものではありません（既存の問題）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08e40852188331948b75279c51b7ab)