### PR TITLE
fix: マスター欠点豆のクライアント編集を禁止

### DIFF
--- a/app/defect-beans/page.tsx
+++ b/app/defect-beans/page.tsx
@@ -164,6 +164,12 @@ export default function DefectBeansPage() {
 
   // 欠点豆編集
   const handleEditDefectBean = (id: string) => {
+    const defectBean = allDefectBeans.find((db) => db.id === id);
+    if (defectBean?.isMaster) {
+      showToast('マスター欠点豆は編集できません。', 'error');
+      return;
+    }
+
     setEditingDefectBeanId(id);
   };
 
@@ -298,7 +304,7 @@ export default function DefectBeansPage() {
                   isSelected={selectedIds.has(defectBean.id)}
                   onSelect={compareMode ? handleSelect : undefined}
                   onToggleSetting={handleToggleSetting}
-                  onEdit={!compareMode ? handleEditDefectBean : undefined}
+                  onEdit={!compareMode && !defectBean.isMaster ? handleEditDefectBean : undefined}
                   compareMode={compareMode}
                   index={index}
                 />
@@ -328,7 +334,7 @@ export default function DefectBeansPage() {
               defectBean={editingBean}
               onSubmit={handleAddDefectBean} // 使用されないが型のため必要
               onUpdate={handleUpdateDefectBean}
-              onDelete={isDeveloperModeEnabled ? handleDeleteDefectBeanFromEdit : undefined}
+              onDelete={isDeveloperModeEnabled && !editingBean.isMaster ? handleDeleteDefectBeanFromEdit : undefined}
               onCancel={() => setEditingDefectBeanId(null)}
   
             />

--- a/firestore.rules
+++ b/firestore.rules
@@ -11,8 +11,8 @@ service cloud.firestore {
     match /defectBeans/{defectBeanId} {
       // 全ユーザーが読み取り可能
       allow read: if request.auth != null;
-      // 認証済みユーザーが編集可能
-      allow write: if request.auth != null;
+      // マスターデータはクライアントから編集不可（管理者はサーバー側で更新）
+      allow write: if false;
     }
 
     // クイズ進捗データ

--- a/hooks/useDefectBeans.test.ts
+++ b/hooks/useDefectBeans.test.ts
@@ -6,8 +6,6 @@ import type { AppData, User, DefectBean } from '@/types';
 // モック関数（vi.mockファクトリ内で参照可能なようにmockプレフィックスを使用）
 const mockUseAuth = vi.fn();
 const mockGetDefectBeanMasterData = vi.fn();
-const mockUpdateDefectBeanMaster = vi.fn();
-const mockDeleteDefectBeanMaster = vi.fn();
 const mockUploadDefectBeanImage = vi.fn();
 const mockDeleteDefectBeanImage = vi.fn();
 const mockUseAppData = vi.fn();
@@ -20,8 +18,6 @@ vi.mock('@/lib/auth', () => ({
 
 vi.mock('@/lib/firestore', () => ({
   getDefectBeanMasterData: (...args: unknown[]) => mockGetDefectBeanMasterData(...args),
-  updateDefectBeanMaster: (...args: unknown[]) => mockUpdateDefectBeanMaster(...args),
-  deleteDefectBeanMaster: (...args: unknown[]) => mockDeleteDefectBeanMaster(...args),
 }));
 
 vi.mock('@/lib/storage', () => ({
@@ -564,7 +560,6 @@ describe('useDefectBeans - updateDefectBean', () => {
     mockUseAuth.mockReturnValue({ user: mockUser, loading: false });
     mockGetDefectBeanMasterData.mockResolvedValue([MASTER_BEAN]);
     mockUpdateData.mockResolvedValue(undefined);
-    mockUpdateDefectBeanMaster.mockResolvedValue(undefined);
     mockUploadDefectBeanImage.mockResolvedValue('https://example.com/new-image.jpg');
     mockDeleteDefectBeanImage.mockResolvedValue(undefined);
     mockCompressImage.mockImplementation((file: File) => Promise.resolve(file));
@@ -618,7 +613,8 @@ describe('useDefectBeans - updateDefectBean', () => {
     consoleSpy.mockRestore();
   });
 
-  it('マスター豆を画像変更ありで更新する', async () => {
+  it('マスター豆の更新を拒否する', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { result } = renderHook(() => useDefectBeans());
 
     await waitForMasterDataLoad();
@@ -631,35 +627,23 @@ describe('useDefectBeans - updateDefectBean', () => {
       removalReason: '更新済み理由',
     };
 
-    await act(async () => {
-      await result.current.updateDefectBean(
-        'master-1',
-        updatePayload,
-        imageFile,
-        MASTER_BEAN.imageUrl
-      );
-    });
-
-    // マスター豆の画像アップロードはuserId=''
-    expect(mockUploadDefectBeanImage).toHaveBeenCalledWith('', 'master-1', imageFile);
-
-    // 旧画像を削除
-    expect(mockDeleteDefectBeanImage).toHaveBeenCalledWith(MASTER_BEAN.imageUrl);
-
-    // updateDefectBeanMasterが呼ばれた
-    expect(mockUpdateDefectBeanMaster).toHaveBeenCalledWith(
-      'master-1',
-      expect.objectContaining({
-        id: 'master-1',
-        name: '更新カビ豆',
-        imageUrl: 'https://example.com/new-image.jpg',
-        isMaster: true,
-        updatedAt: '2024-06-15T00:00:00.000Z',
+    await expect(
+      act(async () => {
+        await result.current.updateDefectBean(
+          'master-1',
+          updatePayload,
+          imageFile,
+          MASTER_BEAN.imageUrl
+        );
       })
-    );
+    ).rejects.toThrow('Master defect beans cannot be edited from the client');
 
-    // updateDataは呼ばれない（マスター豆なので）
+    expect(mockCompressImage).not.toHaveBeenCalled();
+    expect(mockUploadDefectBeanImage).not.toHaveBeenCalled();
+    expect(mockDeleteDefectBeanImage).not.toHaveBeenCalled();
     expect(mockUpdateData).not.toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
   });
 
   it('ユーザー豆を画像変更ありで更新する', async () => {
@@ -703,9 +687,6 @@ describe('useDefectBeans - updateDefectBean', () => {
       imageUrl: 'https://example.com/new-image.jpg',
       updatedAt: '2024-06-15T00:00:00.000Z',
     });
-
-    // updateDefectBeanMasterは呼ばれない（ユーザー豆なので）
-    expect(mockUpdateDefectBeanMaster).not.toHaveBeenCalled();
   });
 
   it('画像変更なしで更新する（imageFile=null）', async () => {
@@ -809,12 +790,12 @@ describe('useDefectBeans - updateDefectBean', () => {
     expect(mockDeleteDefectBeanImage).not.toHaveBeenCalled();
   });
 
-  it('マスター豆更新時にローカルstateも更新される', async () => {
+  it('マスター豆の更新拒否時にローカルstateを変更しない', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { result } = renderHook(() => useDefectBeans());
 
     await waitForMasterDataLoad();
 
-    // 更新前のマスター豆を確認
     expect(result.current.masterDefectBeans).toEqual([MASTER_BEAN]);
 
     const updatePayload = {
@@ -824,13 +805,15 @@ describe('useDefectBeans - updateDefectBean', () => {
       removalReason: '更新理由',
     };
 
-    await act(async () => {
-      await result.current.updateDefectBean('master-1', updatePayload, null);
-    });
+    await expect(
+      act(async () => {
+        await result.current.updateDefectBean('master-1', updatePayload, null);
+      })
+    ).rejects.toThrow('Master defect beans cannot be edited from the client');
 
-    // ローカルstateが更新された
-    expect(result.current.masterDefectBeans[0].name).toBe('更新済みカビ豆');
-    expect(result.current.masterDefectBeans[0].updatedAt).toBe('2024-06-15T00:00:00.000Z');
+    expect(result.current.masterDefectBeans).toEqual([MASTER_BEAN]);
+
+    consoleSpy.mockRestore();
   });
 
   it('oldImageUrlが未指定の場合は旧画像を削除しない', async () => {
@@ -863,7 +846,6 @@ describe('useDefectBeans - removeDefectBean', () => {
     mockUseAuth.mockReturnValue({ user: mockUser, loading: false });
     mockGetDefectBeanMasterData.mockResolvedValue([MASTER_BEAN]);
     mockUpdateData.mockResolvedValue(undefined);
-    mockDeleteDefectBeanMaster.mockResolvedValue(undefined);
     mockDeleteDefectBeanImage.mockResolvedValue(undefined);
     mockUseAppData.mockReturnValue({
       data: { ...INITIAL_APP_DATA, defectBeans: [USER_BEAN] },
@@ -886,7 +868,7 @@ describe('useDefectBeans - removeDefectBean', () => {
 
     await expect(
       act(async () => {
-        await result.current.removeDefectBean('master-1', MASTER_BEAN.imageUrl);
+        await result.current.removeDefectBean(USER_BEAN.id, USER_BEAN.imageUrl);
       })
     ).rejects.toThrow('User not authenticated');
   });
@@ -907,29 +889,25 @@ describe('useDefectBeans - removeDefectBean', () => {
     consoleSpy.mockRestore();
   });
 
-  it('マスター豆を削除する', async () => {
+  it('マスター豆の削除を拒否する', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { result } = renderHook(() => useDefectBeans());
 
     await waitForMasterDataLoad();
 
-    // 削除前にマスター豆が存在する
     expect(result.current.masterDefectBeans).toEqual([MASTER_BEAN]);
 
-    await act(async () => {
-      await result.current.removeDefectBean('master-1', MASTER_BEAN.imageUrl);
-    });
+    await expect(
+      act(async () => {
+        await result.current.removeDefectBean('master-1', MASTER_BEAN.imageUrl);
+      })
+    ).rejects.toThrow('Master defect beans cannot be deleted from the client');
 
-    // 画像削除が呼ばれた
-    expect(mockDeleteDefectBeanImage).toHaveBeenCalledWith(MASTER_BEAN.imageUrl);
-
-    // Firestoreからの削除が呼ばれた
-    expect(mockDeleteDefectBeanMaster).toHaveBeenCalledWith('master-1');
-
-    // ローカルstateからも削除された
-    expect(result.current.masterDefectBeans).toEqual([]);
-
-    // updateDataは呼ばれない（マスター豆なので）
+    expect(mockDeleteDefectBeanImage).not.toHaveBeenCalled();
     expect(mockUpdateData).not.toHaveBeenCalled();
+    expect(result.current.masterDefectBeans).toEqual([MASTER_BEAN]);
+
+    consoleSpy.mockRestore();
   });
 
   it('ユーザー豆を削除する', async () => {
@@ -951,9 +929,6 @@ describe('useDefectBeans - removeDefectBean', () => {
     const currentData = { ...INITIAL_APP_DATA, defectBeans: [USER_BEAN] };
     const updatedData = updater(currentData);
     expect(updatedData.defectBeans).toEqual([]);
-
-    // deleteDefectBeanMasterは呼ばれない（ユーザー豆なので）
-    expect(mockDeleteDefectBeanMaster).not.toHaveBeenCalled();
   });
 
   it('画像削除失敗時にエラーをスローする', async () => {
@@ -966,32 +941,9 @@ describe('useDefectBeans - removeDefectBean', () => {
 
     await expect(
       act(async () => {
-        await result.current.removeDefectBean('master-1', MASTER_BEAN.imageUrl);
+        await result.current.removeDefectBean(USER_BEAN.id, USER_BEAN.imageUrl);
       })
     ).rejects.toThrow('Image delete failed');
-
-    // Firestore削除は呼ばれない（画像削除で失敗したため）
-    expect(mockDeleteDefectBeanMaster).not.toHaveBeenCalled();
-
-    consoleSpy.mockRestore();
-  });
-
-  it('Firestore削除失敗時にエラーをスローする', async () => {
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    mockDeleteDefectBeanMaster.mockRejectedValue(new Error('Firestore delete failed'));
-
-    const { result } = renderHook(() => useDefectBeans());
-
-    await waitForMasterDataLoad();
-
-    await expect(
-      act(async () => {
-        await result.current.removeDefectBean('master-1', MASTER_BEAN.imageUrl);
-      })
-    ).rejects.toThrow('Firestore delete failed');
-
-    // 画像削除は呼ばれた
-    expect(mockDeleteDefectBeanImage).toHaveBeenCalledWith(MASTER_BEAN.imageUrl);
 
     consoleSpy.mockRestore();
   });

--- a/hooks/useDefectBeans.ts
+++ b/hooks/useDefectBeans.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '@/lib/auth';
-import { getDefectBeanMasterData, updateDefectBeanMaster, deleteDefectBeanMaster } from '@/lib/firestore';
+import { getDefectBeanMasterData } from '@/lib/firestore';
 import { uploadDefectBeanImage, deleteDefectBeanImage } from '@/lib/storage';
 import { compressImage } from '@/lib/imageCompression';
 import { useAppData } from './useAppData';
@@ -113,18 +113,17 @@ export function useDefectBeans() {
           throw new Error('Defect bean not found');
         }
 
+        if (existingBean.isMaster) {
+          throw new Error('Master defect beans cannot be edited from the client');
+        }
+
         let newImageUrl = existingBean.imageUrl;
 
         // 画像が変更された場合
         if (imageFile) {
           // 画像を圧縮してからアップロード
           const compressedFile = await compressImage(imageFile);
-          if (existingBean.isMaster) {
-            // マスターデータの場合は、userIdとして空文字列を使用（パスを統一するため）
-            newImageUrl = await uploadDefectBeanImage('', defectBeanId, compressedFile);
-          } else {
-            newImageUrl = await uploadDefectBeanImage(user.uid, defectBeanId, compressedFile);
-          }
+          newImageUrl = await uploadDefectBeanImage(user.uid, defectBeanId, compressedFile);
 
           // アップロード成功後、既存画像を削除
           if (oldImageUrl && oldImageUrl !== newImageUrl) {
@@ -145,22 +144,13 @@ export function useDefectBeans() {
           updatedAt: now,
         };
 
-        if (existingBean.isMaster) {
-          // マスターデータの更新
-          await updateDefectBeanMaster(defectBeanId, updatedDefectBean);
-          // ローカル状態も更新
-          setMasterDefectBeans((prev) =>
-            prev.map((db) => (db.id === defectBeanId ? updatedDefectBean : db))
-          );
-        } else {
-          // ユーザーデータの更新
-          await updateData((currentData) => ({
-            ...currentData,
-            defectBeans: (currentData.defectBeans || []).map((db) =>
-              db.id === defectBeanId ? updatedDefectBean : db
-            ),
-          }));
-        }
+        // ユーザーデータの更新
+        await updateData((currentData) => ({
+          ...currentData,
+          defectBeans: (currentData.defectBeans || []).map((db) =>
+            db.id === defectBeanId ? updatedDefectBean : db
+          ),
+        }));
       } catch (error) {
         console.error('Failed to update defect bean:', error);
         throw error;
@@ -185,21 +175,18 @@ export function useDefectBeans() {
           throw new Error('Defect bean not found');
         }
 
+        if (existingBean.isMaster) {
+          throw new Error('Master defect beans cannot be deleted from the client');
+        }
+
         // 画像を削除
         await deleteDefectBeanImage(imageUrl);
 
-        if (existingBean.isMaster) {
-          // マスターデータの削除
-          await deleteDefectBeanMaster(defectBeanId);
-          // ローカル状態も更新
-          setMasterDefectBeans((prev) => prev.filter((db) => db.id !== defectBeanId));
-        } else {
-          // ユーザーデータの削除
-          await updateData((currentData) => ({
-            ...currentData,
-            defectBeans: (currentData.defectBeans || []).filter((db) => db.id !== defectBeanId),
-          }));
-        }
+        // ユーザーデータの削除
+        await updateData((currentData) => ({
+          ...currentData,
+          defectBeans: (currentData.defectBeans || []).filter((db) => db.id !== defectBeanId),
+        }));
       } catch (error) {
         console.error('Failed to remove defect bean:', error);
         throw error;

--- a/lib/firestore/defectBeans.ts
+++ b/lib/firestore/defectBeans.ts
@@ -1,7 +1,4 @@
 import {
-  doc,
-  updateDoc,
-  deleteDoc,
   collection,
   getDocs,
 } from 'firebase/firestore';
@@ -53,51 +50,6 @@ export async function getDefectBeanMasterData(): Promise<DefectBean[]> {
   } catch (error) {
     console.error('Failed to get defect bean master data:', error);
     return [];
-  }
-}
-
-/**
- * 欠陥豆マスターデータを更新
- * @param defectBeanId 欠陥豆ID
- * @param defectBean 更新する欠陥豆データ
- */
-export async function updateDefectBeanMaster(
-  defectBeanId: string,
-  defectBean: Partial<DefectBean>
-): Promise<void> {
-  try {
-    const db = getDb();
-    const defectBeanRef = doc(db, 'defectBeans', defectBeanId);
-
-    const updateData: Partial<DefectBean> & { updatedAt: string } = {
-      ...defectBean,
-      updatedAt: new Date().toISOString(),
-    };
-
-    // id, isMaster, createdAtは更新しない
-    delete updateData.id;
-    delete updateData.isMaster;
-    delete updateData.createdAt;
-
-    await updateDoc(defectBeanRef, updateData);
-  } catch (error) {
-    console.error('Failed to update defect bean master:', error);
-    throw error;
-  }
-}
-
-/**
- * 欠陥豆マスターデータを削除
- * @param defectBeanId 削除する欠陥豆ID
- */
-export async function deleteDefectBeanMaster(defectBeanId: string): Promise<void> {
-  try {
-    const db = getDb();
-    const defectBeanRef = doc(db, 'defectBeans', defectBeanId);
-    await deleteDoc(defectBeanRef);
-  } catch (error) {
-    console.error('Failed to delete defect bean master:', error);
-    throw error;
   }
 }
 

--- a/lib/firestore/index.ts
+++ b/lib/firestore/index.ts
@@ -6,8 +6,6 @@ export { getDb, getUserDocRef, removeUndefinedFields, normalizeAppData, defaultD
 export { getUserData, saveUserData, subscribeUserData, SAVE_USER_DATA_DEBOUNCE_MS } from './userData';
 export {
   getDefectBeanMasterData,
-  updateDefectBeanMaster,
-  deleteDefectBeanMaster,
   saveDefectBean,
   deleteDefectBean,
   updateDefectBeanSetting,

--- a/lib/storage.test.ts
+++ b/lib/storage.test.ts
@@ -52,6 +52,17 @@ describe('uploadDefectBeanImage', () => {
     expect(url).toBe('https://example.com/image.jpg');
   });
 
+
+  it('ユーザーIDが空の場合はアップロードを拒否する', async () => {
+    const mockFile = new File([''], 'test.jpg', { type: 'image/jpeg' });
+
+    await expect(uploadDefectBeanImage('', 'beanId123', mockFile)).rejects.toThrow(
+      'User ID is required to upload defect bean images'
+    );
+    expect(mockRef).not.toHaveBeenCalled();
+    expect(mockUploadBytes).not.toHaveBeenCalled();
+  });
+
   it('uploadBytes がエラーをthrowした場合はそのエラーを再throwする', async () => {
     const uploadError = new Error('Storage permission denied');
     mockUploadBytes.mockRejectedValue(uploadError);

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -15,7 +15,7 @@ const UPLOAD_TIMEOUT_MS = 30_000;
 
 /**
  * 欠点豆の画像をFirebase Storageにアップロード
- * @param userId ユーザーID（空文字列の場合はマスターデータ）
+ * @param userId ユーザーID
  * @param defectBeanId 欠点豆ID
  * @param file 画像ファイル
  * @returns ダウンロードURL
@@ -37,10 +37,11 @@ export async function uploadDefectBeanImage(
   const doUpload = async (): Promise<string> => {
     const storageInstance = getStorageInstance();
 
-    // マスターデータの場合は別のパスを使用
-    const storagePath = userId
-      ? `defect-beans/${userId}/${defectBeanId}/${Date.now()}_${file.name}`
-      : `defect-beans-master/${defectBeanId}/${Date.now()}_${file.name}`;
+    if (!userId) {
+      throw new Error('User ID is required to upload defect bean images');
+    }
+
+    const storagePath = `defect-beans/${userId}/${defectBeanId}/${Date.now()}_${file.name}`;
 
     const storageRef = ref(storageInstance, storagePath);
     await uploadBytes(storageRef, file);

--- a/storage.rules
+++ b/storage.rules
@@ -9,12 +9,12 @@ service firebase.storage {
       allow read: if request.auth != null;
     }
     
-    // マスターデータの画像（認証済みユーザーが編集可能）
+    // マスターデータの画像（クライアントから編集不可）
     match /defect-beans-master/{fileName=**} {
       // 全ユーザーが読み取り可能
       allow read: if request.auth != null;
-      // 認証済みユーザーが編集可能
-      allow write: if request.auth != null;
+      // マスター画像はクライアントから編集不可（管理者はサーバー側で更新）
+      allow write: if false;
     }
   }
 }


### PR DESCRIPTION
### Motivation
- 共有マスターデータ（欠点豆マスタとその画像）について、クライアント側から認証済みユーザーに書き込みを許可してしまう脆弱性が導入されていたため、マスターの整合性を保つためにクライアント書き込みを再度禁止する必要がありました。 

### Description
- `firestore.rules` の `/defectBeans/{defectBeanId}` をクライアント書き込み不可に戻し `allow write: if false` としました。 
- `storage.rules` の `defect-beans-master/**` もクライアント書き込み不可に戻し `allow write: if false` としました。 
- クライアント側では `lib/firestore/defectBeans.ts` のマスター更新/削除ヘルパを削除し、barrel エクスポートからも除外しました。 
- 実装側では `hooks/useDefectBeans.ts` にてマスターの更新・削除を受け付けないよう先にチェックして例外を投げるようにし、`lib/storage.ts` は空の `userId` を拒否してマスター用パスへクライアントが書き込めないようにしました。 
- UI 側の `app/defect-beans/page.tsx` ではマスター豆に編集ハンドラを渡さず、編集試行時はトーストで弾く処理にしました。 
- テストを更新し、マスター欠点豆の編集/削除がクライアント側で拒否されることと `userId` が空の画像アップロードが拒否されることを確認するようにしました (該当テストは `hooks/useDefectBeans.test.ts` と `lib/storage.test.ts`)。 

### Testing
- `npm run test:run -- hooks/useDefectBeans.test.ts lib/storage.test.ts` を実行し該当テストは成功しました。 
- フルテスト `npm run test:run` を実行しリポジトリ内のテストは全て通過しました（全テスト通過）。 
- `npm run lint` を実行し終了コードは 0 で完了しましたが既存の警告は残っています。 
- `npm run build` を試行しましたが、この環境では Next.js が Google Fonts を外部取得できずビルドが失敗したためビルド失敗は環境依存でありコード側の変更ではありません。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08dfeefc048331a101dac13c7efbbf)