### PR TITLE
fix(security): Claude の自動 ESLint フックを削除

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,18 +1,5 @@
 {
   "enabledPlugins": {
     "firebase@claude-plugins-official": true
-  },
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Edit|Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "if [[ \"$CLAUDE_TOOL_INPUT_file_path\" =~ \\.(ts|tsx|js|jsx)$ ]]; then npx eslint --fix \"$CLAUDE_TOOL_INPUT_file_path\" 2>&1 || true; fi"
-          }
-        ]
-      }
-    ]
   }
 }


### PR DESCRIPTION
### Motivation
- 結論: リポジトリに登録された Claude の `PostToolUse` フックが、変更可能なワークツリー内のコードを実行する経路を作っていたため、安全上の理由で削除します。 
- 理由: フックは編集／書き込み操作後に `npx eslint --fix` を自動実行し、ワークスペース内の実行可能な `eslint` 設定やコミット済みフックスクリプトを通じて任意のコード実行を引き起こす可能性がありました。

### Description
- `.claude/settings.json` から `PostToolUse` による自動 ESLint 実行設定を削除し、`enabledPlugins` の設定はそのまま残しています。 
- 具体的には `if [[ "$CLAUDE_TOOL_INPUT_file_path" =~ \.(ts|tsx|js|jsx)$ ]]; then npx eslint --fix ... fi` を含むフックエントリを削除しました。 
- 変更は最小限に留め、開発者が明示的に `npm run lint` を実行する従来のワークフローに戻しています。 

### Testing
- 設定ファイルの整合性を `node -e "JSON.parse(require('fs').readFileSync('.claude/settings.json','utf8'))"` で確認し問題無しを確認しました。 (成功)
- リポジトリ内に危険なフックやコマンド文字列が残っていないことを `rg -n 'PostToolUse|eslint --fix|CLAUDE_TOOL_INPUT_file_path|eslint-autofix' .claude` で検査し、何も検出されないことを確認しました。 (成功)
- `npm run lint` を実行し終了コード 0、警告のみ（11 警告）で完了することを確認しました。 (成功)
- `npm run test:run` を実行し全テストがパス（1198 tests）することを確認しました。 (成功)
- `npm run build` はこの環境では Google Fonts の取得失敗によりビルドが失敗しましたが、これは今回の変更とは無関係な外部ネットワーク依存の問題です。 (失敗、非関連)

変更対象ファイル: `.claude/settings.json`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08c869a4a08331bb515ac9201ab820)