### PR TITLE
fix: Claude ワークフローの実行権限を制限して秘密情報の誤用を防止

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,7 +11,7 @@ on:
     types: [submitted]
 
 jobs:
-  claude:
+  authorize:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
@@ -20,9 +20,37 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      trusted: ${{ steps.permission.outputs.trusted }}
+    steps:
+      - name: Check actor repository permission
+        id: permission
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+
+          permission=$(gh api "repos/${REPOSITORY}/collaborators/${ACTOR}/permission" --jq '.permission' 2>/dev/null || echo none)
+
+          case "$permission" in
+            admin|maintain|write)
+              echo "trusted=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "trusted=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+  claude:
+    needs: authorize
+    if: needs.authorize.outputs.trusted == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
       pull-requests: read
       issues: read
-      id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### Motivation
- `.github/workflows/claude.yml` が外部ユーザーの Issue/コメント本文に含まれる `@claude` のみで第三者アクション（`anthropics/claude-code-action`）を秘密トークン付きで実行できる状態になっており、公開リポジトリで秘密の誤用や OIDC トークン露出のリスクがあったため修正します。

### Description
- `authorize` ジョブを追加し、`@claude` トリガーを検出した際に実行者のリポジトリ権限を `gh api repos/${REPOSITORY}/collaborators/${ACTOR}/permission` で確認して `trusted` 出力を返すようにしました（ファイル: `.github/workflows/claude.yml`）。
- Claude を呼ぶ本体ジョブは `needs: authorize` と `if: needs.authorize.outputs.trusted == 'true'` でガードし、`admin|maintain|write` 相当の権限がある actor のみ秘密トークン付きジョブを実行できるようにしました（ファイル: `.github/workflows/claude.yml`）。
- 不要な `id-token: write` 権限を削除し、ジョブ権限を必要最小限（`contents: read`, `pull-requests: read`, `issues: read`, `actions: read`）に制限しました（ファイル: `.github/workflows/claude.yml`）。

### Testing
- ワークフローファイルの静的チェックとして `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/claude.yml')"` により YAML パースに成功しました。
- 自動アサーションで `id-token: write` が除去されていること、`authorize` ジョブと権限チェックステップ、`claude` ジョブが `needs: authorize` と `if: needs.authorize.outputs.trusted == 'true'` で保護されていることを確認するスクリプト（`python`）を実行し全て成功しました。
- `git diff --check` を実行して差分の問題がないことを確認しました。
- `actionlint` を使った追加検査を試みましたが、この環境からの `actionlint` パッケージ取得が `403 Forbidden` で失敗したため実行できませんでした。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08be013224833186b1248b8fb4d975)