### PR TITLE
セキュリティ修正: 開発者認証とリダイレクト/Storage保護

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ NEXT_PUBLIC_FIREBASE_PROJECT_ID=your-project-id
 NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your-project.firebasestorage.app
 NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=123456789012
 NEXT_PUBLIC_FIREBASE_APP_ID=1:123456789012:web:abcdef1234567890
+NEXT_PUBLIC_DEVELOPER_EMAILS=developer@example.com,admin@example.com
 
 # --------------------------------------------
 # EmailJS（お問い合わせフォーム用）

--- a/app/coffee-trivia/quiz/page-new.tsx
+++ b/app/coffee-trivia/quiz/page-new.tsx
@@ -13,6 +13,7 @@ import { useQuizSession } from '@/hooks/useQuizSession';
 import { useQuizData } from '@/hooks/useQuizData';
 import { useQuizSound } from '@/hooks/useQuizSound';
 import type { QuizCategory } from '@/lib/coffee-quiz/types';
+import { getSafeReturnUrl } from '@/lib/returnUrl';
 
 const InboxIcon = () => (
   <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
@@ -31,7 +32,7 @@ function QuizPageContent() {
   // 問題IDリストを解析
   const questionIds = questionIdsParam ? questionIdsParam.split(',').filter(Boolean) : undefined;
   // 戻り先URL（デコード）
-  const returnUrl = returnUrlParam ? decodeURIComponent(returnUrlParam) : '/coffee-trivia';
+  const returnUrl = getSafeReturnUrl(returnUrlParam, '/coffee-trivia');
 
   const { isAuthenticated, loading: authLoading, progress } = useQuizData();
 

--- a/app/coffee-trivia/quiz/page.tsx
+++ b/app/coffee-trivia/quiz/page.tsx
@@ -12,6 +12,7 @@ import { useQuizData } from '@/hooks/useQuizData';
 import { useQuizSound } from '@/hooks/useQuizSound';
 import type { QuizCategory } from '@/lib/coffee-quiz/types';
 import { CATEGORY_LABELS } from '@/lib/coffee-quiz/types';
+import { getSafeReturnUrl } from '@/lib/returnUrl';
 
 // アイコン
 const ArrowLeftIcon = () => (
@@ -45,7 +46,7 @@ function QuizPageContent() {
   // 問題IDリストを解析
   const questionIds = questionIdsParam ? questionIdsParam.split(',').filter(Boolean) : undefined;
   // 戻り先URL（デコード）
-  const returnUrl = returnUrlParam ? decodeURIComponent(returnUrlParam) : '/coffee-trivia';
+  const returnUrl = getSafeReturnUrl(returnUrlParam, '/coffee-trivia');
 
   const { isAuthenticated, loading: authLoading, progress } = useQuizData();
 

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -6,6 +6,7 @@ import { createUserWithEmailAndPassword, signInWithEmailAndPassword } from 'fire
 import { auth } from '@/lib/firebase';
 import { Loading } from '@/components/Loading';
 import { Input, Button } from '@/components/ui';
+import { getSafeReturnUrl } from '@/lib/returnUrl';
 
 type TabType = 'login' | 'signup';
 
@@ -40,8 +41,7 @@ function LoginForm() {
         await createUserWithEmailAndPassword(auth, email, password);
       }
       // returnUrlがあればそのURLに、なければホームにリダイレクト
-      const returnUrl = searchParams.get('returnUrl');
-      const redirectUrl = returnUrl && returnUrl.startsWith('/') ? returnUrl : '/';
+      const redirectUrl = getSafeReturnUrl(searchParams.get('returnUrl'), '/');
       router.push(redirectUrl);
     } catch (err: unknown) {
       const errorObj = err as { code?: string; message?: string };

--- a/hooks/useDeveloperMode.ts
+++ b/hooks/useDeveloperMode.ts
@@ -1,41 +1,100 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
+import { getIdTokenResult, type User } from 'firebase/auth';
+import { useAuth } from '@/lib/auth';
 
-const DEVELOPER_MODE_PASSWORD = '4869';
 const STORAGE_KEY = 'roastplus_developer_mode';
+const DEVELOPER_EMAIL_ALLOWLIST = new Set(
+  (process.env.NEXT_PUBLIC_DEVELOPER_EMAILS || '')
+    .split(',')
+    .map((email) => email.trim().toLowerCase())
+    .filter((email) => email.length > 0)
+);
+
+function hasDeveloperClaim(user: User): Promise<boolean> {
+  return getIdTokenResult(user)
+    .then((token) => {
+      const { claims } = token;
+      return (
+        claims.developerMode === true ||
+        claims.developer === true ||
+        claims.isDeveloper === true
+      );
+    })
+    .catch(() => false);
+}
+
+async function isAuthorizedDeveloperUser(user: User): Promise<boolean> {
+  const email = user.email?.toLowerCase();
+  if (DEVELOPER_EMAIL_ALLOWLIST.size > 0 && email && DEVELOPER_EMAIL_ALLOWLIST.has(email)) {
+    return true;
+  }
+
+  return hasDeveloperClaim(user);
+}
 
 export function useDeveloperMode() {
-  const [isEnabled, setIsEnabled] = useState(() => {
-    if (typeof window === 'undefined') return false;
-    const stored = localStorage.getItem(STORAGE_KEY);
-    return stored === 'true';
-  });
-  const isLoading = typeof window === 'undefined';
+  const { user, loading: authLoading } = useAuth();
+  const [isEnabled, setIsEnabled] = useState(false);
+  const [canUseDeveloperMode, setCanUseDeveloperMode] = useState(false);
+  const [isLoading, setIsLoading] = useState<boolean>(typeof window === 'undefined');
 
-  // パスワード検証
-  const verifyPassword = useCallback((password: string): boolean => {
-    return password === DEVELOPER_MODE_PASSWORD;
-  }, []);
-
-  // 開発者モードを有効化（パスワード検証付き）
-  const enableDeveloperMode = useCallback((password: string): boolean => {
-    if (verifyPassword(password)) {
-      if (typeof window !== 'undefined') {
-        localStorage.setItem(STORAGE_KEY, 'true');
-        setIsEnabled(true);
-        return true;
-      }
+  const refreshPermissions = useCallback(async () => {
+    if (typeof window === 'undefined') {
+      return;
     }
-    return false;
-  }, [verifyPassword]);
 
-  // 開発者モードを無効化
-  const disableDeveloperMode = useCallback(() => {
-    if (typeof window !== 'undefined') {
+    if (!user) {
+      setCanUseDeveloperMode(false);
+      setIsEnabled(false);
+      localStorage.removeItem(STORAGE_KEY);
+      setIsLoading(false);
+      return;
+    }
+
+    const isAllowed = await isAuthorizedDeveloperUser(user);
+    setCanUseDeveloperMode(isAllowed);
+    if (isAllowed) {
+      setIsEnabled(localStorage.getItem(STORAGE_KEY) === 'true');
+    } else {
       localStorage.removeItem(STORAGE_KEY);
       setIsEnabled(false);
     }
+    setIsLoading(false);
+  }, [user]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if (authLoading) {
+      setIsLoading(true);
+      return;
+    }
+
+    void refreshPermissions();
+  }, [authLoading, refreshPermissions]);
+
+  // 開発者モードを有効化
+  const enableDeveloperMode = useCallback((_password: string): boolean => {
+    if (!canUseDeveloperMode || typeof window === 'undefined') {
+      return false;
+    }
+
+    localStorage.setItem(STORAGE_KEY, 'true');
+    setIsEnabled(true);
+    return true;
+  }, [canUseDeveloperMode]);
+
+  // 開発者モードを無効化
+  const disableDeveloperMode = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    localStorage.removeItem(STORAGE_KEY);
+    setIsEnabled(false);
   }, []);
 
   return {
@@ -45,4 +104,3 @@ export function useDeveloperMode() {
     disableDeveloperMode,
   };
 }
-

--- a/lib/returnUrl.ts
+++ b/lib/returnUrl.ts
@@ -1,0 +1,36 @@
+/**
+ * リダイレクト用の returnUrl を検証して安全な相対パスとして返します。
+ *
+ * - decodeURIComponent 後に URL パース
+ * - 同一オリジンのみ許可
+ * - 外部スキームやプロトコル相対URLは拒否
+ * - 失敗時は fallback を返却
+ */
+export function getSafeReturnUrl(rawReturnUrl: string | null, fallback: string): string {
+  if (!rawReturnUrl) {
+    return fallback;
+  }
+
+  try {
+    const maybeDecoded = rawReturnUrl.includes('%') ? decodeURIComponent(rawReturnUrl) : rawReturnUrl;
+    const parsed = new URL(maybeDecoded, window.location.origin);
+
+    if (parsed.origin !== window.location.origin) {
+      return fallback;
+    }
+
+    const path = `${parsed.pathname}${parsed.search}${parsed.hash}`;
+    if (!path.startsWith('/')) {
+      return fallback;
+    }
+
+    // プロトコル相対URL対策: //evil.com のような形式を除外
+    if (path.startsWith('//')) {
+      return fallback;
+    }
+
+    return path;
+  } catch {
+    return fallback;
+  }
+}

--- a/storage.rules
+++ b/storage.rules
@@ -5,8 +5,8 @@ service firebase.storage {
     match /defect-beans/{userId}/{defectBeanId}/{fileName=**} {
       // 認証済みユーザーのみアップロード・削除可能
       allow create, update, delete: if request.auth != null && request.auth.uid == userId;
-      // 全ユーザーが読み取り可能
-      allow read: if request.auth != null;
+      // 本人のみ読み取り可能
+      allow read: if request.auth != null && request.auth.uid == userId;
     }
     
     // マスターデータの画像（クライアントから編集不可）


### PR DESCRIPTION
## 変更内容
- 開発者モードを固定パスワード認証から、カスタムクレーム/メール許可リスト認証へ切替
- returnUrl を同一オリジン検証 (getSafeReturnUrl) へ変更
- Storage ead 権限を本人UIDのみに制限
- .env.example に NEXT_PUBLIC_DEVELOPER_EMAILS を追加
