### PR TITLE
Functionsデプロイ前にビルドを実行

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -41,7 +41,7 @@ jobs:
             echo "hosting_changed=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if echo "$changed_files" | grep -q '^functions/'; then
+          if echo "$changed_files" | grep -Eq '^(functions/|firebase\.json$)'; then
             echo "functions_changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "functions_changed=false" >> "$GITHUB_OUTPUT"
@@ -102,8 +102,8 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 20
-      - name: Install Functions dependencies
-        run: cd functions && npm ci
+      - name: Install and build Functions
+        run: cd functions && npm ci && npm run build
       - name: Deploy Functions
         uses: w9jds/firebase-action@v15.10.0
         with:

--- a/firebase.json
+++ b/firebase.json
@@ -7,7 +7,10 @@
   },
   "functions": {
     "source": "functions",
-    "runtime": "nodejs20"
+    "runtime": "nodejs20",
+    "predeploy": [
+      "npm --prefix \"$RESOURCE_DIR\" run build"
+    ]
   },
   "hosting": {
     "public": "out",


### PR DESCRIPTION
## Summary
- Cloud Functionsのデプロイ前にTypeScriptビルドを実行
- firebase.jsonにFunctions predeployビルドを追加
- firebase.json変更時もFunctionsデプロイ対象として検出

## Test Plan
- firebase.jsonのJSON構文確認
- npm run lint

## Notes
- 直近の失敗原因は functions/lib/index.js が生成されていない状態で firebase deploy --only functions が実行されたことです。