### PR TITLE
fix: ホーム表示設定をアカウント保存に変更

### DIFF
--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -39,10 +39,14 @@ vi.mock('@/hooks/useChristmasMode', () => ({
   }),
 }));
 
+vi.mock('@/hooks/useHomeFeatureVisibility', () => ({
+  useHomeFeatureVisibility: () => ({
+    isVisible: (key: string) => key !== 'dev-stories',
+  }),
+}));
+
 describe('HomePage', () => {
   it('非表示設定の機能カードをホームに表示しないが、その他は表示する', () => {
-    localStorage.setItem('roastplus_home_hidden_features', JSON.stringify(['dev-stories', 'settings']));
-
     render(<HomePage />);
 
     expect(screen.queryByRole('button', { name: '開発秘話' })).not.toBeInTheDocument();

--- a/app/settings/home/page.test.tsx
+++ b/app/settings/home/page.test.tsx
@@ -3,6 +3,8 @@ import { describe, expect, it, vi } from 'vitest';
 
 import HomeVisibilitySettingsPage from './page';
 
+const mockUpdateFeatureHidden = vi.fn();
+
 vi.mock('@/lib/auth', () => ({
   useAuth: () => ({
     user: { uid: 'user-1', email: 'test@example.com' },
@@ -14,14 +16,21 @@ vi.mock('@/app/login/page', () => ({
   default: () => <div>ログイン画面</div>,
 }));
 
+vi.mock('@/hooks/useHomeFeatureVisibility', () => ({
+  useHomeFeatureVisibility: () => ({
+    hiddenKeys: [],
+    updateFeatureHidden: mockUpdateFeatureHidden,
+    resetVisibility: vi.fn(),
+    isLoading: false,
+  }),
+}));
+
 describe('HomeVisibilitySettingsPage', () => {
-  it('機能のスイッチをOFFにすると非表示設定を保存する', () => {
+  it('機能のスイッチをOFFにするとアカウント設定へ非表示設定を保存する', () => {
     render(<HomeVisibilitySettingsPage />);
 
     fireEvent.click(screen.getByRole('switch', { name: '開発秘話をホームに表示' }));
 
-    expect(localStorage.getItem('roastplus_home_hidden_features')).toBe(
-      JSON.stringify(['dev-stories'])
-    );
+    expect(mockUpdateFeatureHidden).toHaveBeenCalledWith('dev-stories', true);
   });
 });

--- a/app/settings/home/page.tsx
+++ b/app/settings/home/page.tsx
@@ -13,6 +13,7 @@ export default function HomeVisibilitySettingsPage() {
   const { user, loading: authLoading } = useAuth();
   const {
     hiddenKeys,
+    isLoading,
     updateFeatureHidden,
     resetVisibility,
   } = useHomeFeatureVisibility();
@@ -55,7 +56,7 @@ export default function HomeVisibilitySettingsPage() {
                 variant="outline"
                 size="sm"
                 onClick={resetVisibility}
-                disabled={hiddenCount === 0}
+                disabled={isLoading || hiddenCount === 0}
               >
                 <MdRestartAlt className="mr-2 h-5 w-5" />
                 すべて表示に戻す
@@ -80,6 +81,7 @@ export default function HomeVisibilitySettingsPage() {
                     <Switch
                       aria-label={`${feature.title}をホームに表示`}
                       checked={!isHidden}
+                      disabled={isLoading}
                       onChange={(event) => updateFeatureHidden(feature.key, !event.target.checked)}
                     />
                   </div>

--- a/hooks/useHomeFeatureVisibility.test.ts
+++ b/hooks/useHomeFeatureVisibility.test.ts
@@ -1,0 +1,90 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useHomeFeatureVisibility } from './useHomeFeatureVisibility';
+import type { AppData } from '@/types';
+
+const mockUpdateData = vi.fn();
+let mockData: AppData;
+
+vi.mock('./useAppData', () => ({
+  useAppData: () => ({
+    data: mockData,
+    updateData: mockUpdateData,
+    isLoading: false,
+  }),
+}));
+
+const baseData: AppData = {
+  todaySchedules: [],
+  roastSchedules: [],
+  tastingSessions: [],
+  tastingRecords: [],
+  notifications: [],
+  encouragementCount: 0,
+  roastTimerRecords: [],
+  workProgresses: [],
+  dripRecipes: [],
+};
+
+describe('useHomeFeatureVisibility', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockUpdateData.mockReset();
+    mockData = { ...baseData };
+  });
+
+  it('Firestoreのアカウント設定から非表示機能を読み込む', async () => {
+    mockData = {
+      ...baseData,
+      userSettings: {
+        homeHiddenFeatureKeys: ['dev-stories'],
+      },
+    };
+
+    const { result } = renderHook(() => useHomeFeatureVisibility());
+
+    await waitFor(() => {
+      expect(result.current.hiddenKeys).toEqual(['dev-stories']);
+    });
+
+    expect(result.current.isVisible('dev-stories')).toBe(false);
+    expect(result.current.isVisible('assignment')).toBe(true);
+  });
+
+  it('非表示設定の変更をアカウント設定へ保存する', async () => {
+    mockData = {
+      ...baseData,
+      userSettings: {
+        selectedMemberId: 'member-1',
+      },
+    };
+
+    const { result } = renderHook(() => useHomeFeatureVisibility());
+
+    await act(async () => {
+      result.current.updateFeatureHidden('dev-stories', true);
+    });
+
+    expect(mockUpdateData).toHaveBeenCalledWith(expect.any(Function));
+
+    const updater = mockUpdateData.mock.calls[0][0] as (currentData: AppData) => AppData;
+    expect(updater(mockData).userSettings).toEqual({
+      selectedMemberId: 'member-1',
+      homeHiddenFeatureKeys: ['dev-stories'],
+    });
+  });
+
+  it('Firestore側に未設定なら既存localStorage値をアカウント設定へ移行する', async () => {
+    localStorage.setItem('roastplus_home_hidden_features', JSON.stringify(['dev-stories', 'settings']));
+
+    renderHook(() => useHomeFeatureVisibility());
+
+    await waitFor(() => {
+      expect(mockUpdateData).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    const updater = mockUpdateData.mock.calls[0][0] as (currentData: AppData) => AppData;
+    expect(updater(mockData).userSettings?.homeHiddenFeatureKeys).toEqual(['dev-stories']);
+  });
+});

--- a/hooks/useHomeFeatureVisibility.ts
+++ b/hooks/useHomeFeatureVisibility.ts
@@ -1,13 +1,16 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   getHiddenHomeFeatureKeys,
+  normalizeHiddenHomeFeatureKeys,
   setHiddenHomeFeatureKeys,
-  setHomeFeatureHidden,
 } from '@/lib/homeFeatureVisibility';
 import type { HomeFeatureKey } from '@/lib/homeFeatures';
+import type { AppData } from '@/types';
+
+import { useAppData } from './useAppData';
 
 function loadHiddenKeys(): HomeFeatureKey[] {
   if (typeof window === 'undefined') return [];
@@ -15,17 +18,69 @@ function loadHiddenKeys(): HomeFeatureKey[] {
 }
 
 export function useHomeFeatureVisibility() {
-  const [hiddenKeys, setHiddenKeys] = useState<HomeFeatureKey[]>(loadHiddenKeys);
+  const { data, updateData, isLoading } = useAppData();
+  const [localHiddenKeys, setLocalHiddenKeys] = useState<HomeFeatureKey[]>(loadHiddenKeys);
+  const hasMigratedLocalStorageRef = useRef(false);
+  const accountHiddenKeys = useMemo(
+    () => (!isLoading && data.userSettings && 'homeHiddenFeatureKeys' in data.userSettings
+      ? normalizeHiddenHomeFeatureKeys(data.userSettings.homeHiddenFeatureKeys)
+      : null),
+    [data.userSettings, isLoading]
+  );
+  const hiddenKeys = accountHiddenKeys ?? localHiddenKeys;
+
+  useEffect(() => {
+    if (isLoading) return;
+
+    if (accountHiddenKeys) {
+      setHiddenHomeFeatureKeys(accountHiddenKeys);
+      return;
+    }
+
+    if (localHiddenKeys.length === 0 || hasMigratedLocalStorageRef.current) {
+      return;
+    }
+
+    hasMigratedLocalStorageRef.current = true;
+    updateData((currentData: AppData) => ({
+      ...currentData,
+      userSettings: {
+        ...currentData.userSettings,
+        homeHiddenFeatureKeys: localHiddenKeys,
+      },
+    }));
+  }, [accountHiddenKeys, isLoading, localHiddenKeys, updateData]);
 
   const updateFeatureHidden = useCallback((key: HomeFeatureKey, hidden: boolean) => {
-    setHomeFeatureHidden(key, hidden);
-    setHiddenKeys(getHiddenHomeFeatureKeys());
-  }, []);
+    const currentKeys = hiddenKeys;
+    const nextKeys = normalizeHiddenHomeFeatureKeys(
+      hidden
+        ? [...currentKeys, key]
+        : currentKeys.filter((currentKey) => currentKey !== key)
+    );
+
+    setLocalHiddenKeys(nextKeys);
+    setHiddenHomeFeatureKeys(nextKeys);
+    updateData((currentData: AppData) => ({
+      ...currentData,
+      userSettings: {
+        ...currentData.userSettings,
+        homeHiddenFeatureKeys: nextKeys,
+      },
+    }));
+  }, [hiddenKeys, updateData]);
 
   const resetVisibility = useCallback(() => {
     setHiddenHomeFeatureKeys([]);
-    setHiddenKeys([]);
-  }, []);
+    setLocalHiddenKeys([]);
+    updateData((currentData: AppData) => ({
+      ...currentData,
+      userSettings: {
+        ...currentData.userSettings,
+        homeHiddenFeatureKeys: [],
+      },
+    }));
+  }, [updateData]);
 
   const isVisible = useCallback(
     (key: HomeFeatureKey) => !hiddenKeys.includes(key),
@@ -35,6 +90,7 @@ export function useHomeFeatureVisibility() {
   return {
     hiddenKeys,
     isVisible,
+    isLoading,
     updateFeatureHidden,
     resetVisibility,
   };

--- a/lib/firestore/common.test.ts
+++ b/lib/firestore/common.test.ts
@@ -137,6 +137,7 @@ describe('normalizeAppData', () => {
       userSettings: {
         selectedMemberId: 'member-1',
         taskLabelHeaderTextLeft: '  左ヘッダー  ',
+        homeHiddenFeatureKeys: ['dev-stories', 'settings', 'dev-stories', 'unknown'],
         roastTimerSettings: {
 
           timerSoundEnabled: false,
@@ -150,6 +151,7 @@ describe('normalizeAppData', () => {
     } as never);
     expect(result.userSettings?.selectedMemberId).toBe('member-1');
     expect(result.userSettings?.taskLabelHeaderTextLeft).toBe('左ヘッダー');
+    expect(result.userSettings?.homeHiddenFeatureKeys).toEqual(['dev-stories']);
     expect(result.userSettings?.roastTimerSettings?.timerSoundEnabled).toBe(false);
   });
 

--- a/lib/firestore/common.ts
+++ b/lib/firestore/common.ts
@@ -5,6 +5,7 @@ import {
 } from 'firebase/firestore';
 import app from '../firebase';
 import type { AppData, UserSettings } from '@/types';
+import { normalizeHiddenHomeFeatureKeys } from '@/lib/homeFeatureVisibility';
 
 // Firestoreインスタンスのシングルトン管理
 let db: Firestore | null = null;
@@ -115,6 +116,10 @@ export function normalizeAppData(data: Partial<AppData> | undefined | null): App
     }
     if (data.userSettings.selectedManagerId !== undefined) {
       cleanedUserSettings.selectedManagerId = data.userSettings.selectedManagerId;
+    }
+    const homeHiddenFeatureKeys = normalizeHiddenHomeFeatureKeys(data.userSettings.homeHiddenFeatureKeys);
+    if (homeHiddenFeatureKeys.length > 0) {
+      cleanedUserSettings.homeHiddenFeatureKeys = homeHiddenFeatureKeys;
     }
     if (typeof data.userSettings.taskLabelHeaderTextLeft === 'string') {
       const trimmedLeft = data.userSettings.taskLabelHeaderTextLeft.trim();

--- a/lib/homeFeatureVisibility.ts
+++ b/lib/homeFeatureVisibility.ts
@@ -24,7 +24,7 @@ function isConfigurableHomeFeatureKey(value: unknown): value is HomeFeatureKey {
   return typeof value === 'string' && CONFIGURABLE_HOME_FEATURE_KEY_SET.has(value);
 }
 
-function normalizeHiddenKeys(value: unknown): HomeFeatureKey[] {
+export function normalizeHiddenHomeFeatureKeys(value: unknown): HomeFeatureKey[] {
   if (!Array.isArray(value)) return [];
 
   return Array.from(new Set(value)).filter(
@@ -39,13 +39,13 @@ export function getHiddenHomeFeatureKeys(): HomeFeatureKey[] {
   if (!stored) return [];
 
   const parsed = parseJson<unknown>(stored);
-  return normalizeHiddenKeys(parsed);
+  return normalizeHiddenHomeFeatureKeys(parsed);
 }
 
 export function setHiddenHomeFeatureKeys(keys: HomeFeatureKey[]): void {
   if (typeof window === 'undefined') return;
 
-  const normalizedKeys = normalizeHiddenKeys(keys);
+  const normalizedKeys = normalizeHiddenHomeFeatureKeys(keys);
 
   if (normalizedKeys.length === 0) {
     localStorage.removeItem(HOME_HIDDEN_FEATURES_KEY);

--- a/types/settings.ts
+++ b/types/settings.ts
@@ -5,6 +5,7 @@ import type { RoastTimerSettings } from './timer';
 export interface UserSettings {
   selectedMemberId?: string; // 試飲記録用メンバー
   selectedManagerId?: string; // チェイス利用設定用
+  homeHiddenFeatureKeys?: string[]; // ホーム表示設定（非表示にする機能キー）
   roastTimerSettings?: RoastTimerSettings;
   taskLabelHeaderTextLeft?: string;
   taskLabelHeaderTextRight?: string;


### PR DESCRIPTION
## Summary
- ホーム表示設定を localStorage ではなく userSettings.homeHiddenFeatureKeys に保存
- 既存localStorage設定を未設定アカウントへ初回移行
- Firestore読み込み時に不正なホーム機能キーを正規化

## Test Plan
- npm run lint
- npm run test:run
- npm run build