### PR TITLE
fix: squash merge後のデプロイ差分検出を修正

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -32,7 +32,14 @@ jobs:
       - name: Detect deploy targets
         id: filter
         run: |
-          changed_files="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")"
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          target_sha="${{ github.event.pull_request.merge_commit_sha }}"
+
+          if [ -z "$target_sha" ] || ! git cat-file -e "$target_sha^{commit}" 2>/dev/null; then
+            target_sha="$(git rev-parse HEAD)"
+          fi
+
+          changed_files="$(git diff --name-only "$base_sha" "$target_sha")"
           echo "$changed_files"
 
           if echo "$changed_files" | grep -Eq '^(app|components|hooks|lib|types|public|data|scripts)/|^(package-lock\.json|package\.json|next\.config\.ts|postcss\.config\.mjs|tsconfig\.json|firebase\.json)$'; then


### PR DESCRIPTION
## Summary
- マージ後デプロイWorkflowの差分検出で pull_request.head.sha ではなく merge_commit_sha を使用
- squash merge後にPR元コミットが参照できず detect_changes が落ちる問題を修正
- merge_commit_sha が取れない場合は HEAD にフォールバック

## Test Plan
- 失敗した実例の base SHA と merge commit SHA で git diff --name-only が成功することを確認