### PR TITLE
fix: PWAのその他画面遷移を修正

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,23 +1,24 @@
 // Service Worker for PWA
-const CACHE_NAME = 'roast-plus-v3';
-const RUNTIME_CACHE = 'roast-plus-runtime-v3';
+const CACHE_NAME = 'roast-plus-v4';
+const RUNTIME_CACHE = 'roast-plus-runtime-v4';
 
 // キャッシュするリソース
 const PRECACHE_URLS = [
   '/',
-  '/assignment.html',
-  '/settings.html',
-  '/login.html',
-  '/notifications.html',
+  '/index.html',
+  '/assignment/index.html',
+  '/settings/index.html',
+  '/login/index.html',
+  '/notifications/index.html',
   '/android-chrome-192x192.png',
   '/android-chrome-512x512.png',
 ];
 
-// Next.jsの静的エクスポートでは、ルートパス（/assignment）は実際には/assignment.htmlとして生成される
+// Next.jsの静的エクスポートでは、ルートパス（/assignment）は実際には/assignment/index.htmlとして生成される
 // この関数は、ルートパスをHTMLファイルパスに変換する
 function getHtmlPath(url) {
   const urlObj = new URL(url);
-  const pathname = urlObj.pathname;
+  const pathname = urlObj.pathname.replace(/\/+$/, '') || '/';
   
   // 既に.htmlで終わっているか、拡張子がある場合はそのまま返す
   if (pathname.endsWith('.html') || pathname.match(/\.[a-zA-Z0-9]+$/)) {
@@ -29,8 +30,8 @@ function getHtmlPath(url) {
     return '/index.html';
   }
   
-  // その他のルートパスは.htmlを追加
-  return `${pathname}.html`;
+  // その他のルートパスはindex.htmlを追加
+  return `${pathname}/index.html`;
 }
 
 // インストール時の処理

--- a/public/sw.test.ts
+++ b/public/sw.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import vm from 'node:vm';
+
+import { describe, expect, it } from 'vitest';
+
+interface ServiceWorkerContext {
+  __getHtmlPath: (url: string) => string;
+  __PRECACHE_URLS: string[];
+}
+
+function loadServiceWorkerContext(): ServiceWorkerContext {
+  const source = readFileSync(join(process.cwd(), 'public', 'sw.js'), 'utf8');
+  const context = {
+    URL,
+    Request,
+    self: {
+      location: { origin: 'https://example.test' },
+      addEventListener: () => undefined,
+      skipWaiting: () => undefined,
+      clients: { claim: () => undefined },
+    },
+  };
+
+  vm.runInNewContext(
+    `${source}
+globalThis.__getHtmlPath = getHtmlPath;
+globalThis.__PRECACHE_URLS = PRECACHE_URLS;`,
+    context
+  );
+
+  return context as typeof context & ServiceWorkerContext;
+}
+
+describe('PWA Service Worker navigation paths', () => {
+  it('静的エクスポートされたページのindex.htmlへ変換する', () => {
+    const { __getHtmlPath } = loadServiceWorkerContext();
+
+    expect(__getHtmlPath('https://example.test/settings')).toBe('/settings/index.html');
+    expect(__getHtmlPath('https://example.test/settings/')).toBe('/settings/index.html');
+    expect(__getHtmlPath('https://example.test/settings/home')).toBe('/settings/home/index.html');
+  });
+
+  it('事前キャッシュにその他ページの実ファイルパスを含める', () => {
+    const { __PRECACHE_URLS } = loadServiceWorkerContext();
+
+    expect(__PRECACHE_URLS).toContain('/settings/index.html');
+    expect(__PRECACHE_URLS).not.toContain('/settings.html');
+  });
+});


### PR DESCRIPTION
## Summary
- Service Workerの静的HTMLパス変換をNext.jsのtrailingSlash出力に合わせて修正
- /settings などのPWAナビゲーションが /settings/index.html を参照するよう変更
- Service Workerの回帰テストを追加

## Test Plan
- npm run test:run -- public/sw.test.ts
- npm run build
- npm run test:run