### PR TITLE
試飲感想UIを調整

### DIFF
--- a/app/assignment/components/assignment-table/MobileListView.tsx
+++ b/app/assignment/components/assignment-table/MobileListView.tsx
@@ -122,7 +122,7 @@ export const MobileListView: React.FC<MobileListViewProps> = ({
                                 班を作成してください
                             </div>
                         ) : (
-                            <div className="grid grid-cols-2 gap-2">
+                            <div className="grid grid-cols-2 gap-2 rounded-lg border border-edge-subtle bg-ground p-2">
                                 {teams.map(team => {
                                     const assignment = assignments.find(a => a.teamId === team.id && a.taskLabelId === label.id);
                                     const member = members.find(m => m.id === assignment?.memberId);
@@ -132,7 +132,7 @@ export const MobileListView: React.FC<MobileListViewProps> = ({
                                         <div key={team.id} className="flex flex-col gap-1">
                                             <div className="text-[10px] font-bold px-1 text-ink-muted">{formatTeamTitle(team.name)}</div>
                                             <Button
-                                                variant={isSelected ? (member ? 'primary' : 'outline') : 'surface'}
+                                                variant="surface"
                                                 size="sm"
                                                 fullWidth
                                                 onMouseDown={(e) => handleCellTouchStart(team.id, label.id, member?.id || null, e)}
@@ -143,10 +143,12 @@ export const MobileListView: React.FC<MobileListViewProps> = ({
                                                 onTouchEnd={handleCellTouchEnd}
                                                 onTouchMove={handleCellTouchMove}
                                                 onClick={() => handleCellClick(team.id, label.id)}
-                                                className={`!min-h-0 !py-3 !px-2 truncate select-none ${
-                                                    member && isSelected ? 'shadow-md scale-105' : ''
+                                                className={`!min-h-0 !rounded-md !px-2 !py-3 !shadow-none truncate select-none ${
+                                                    member && isSelected ? '!border-spot !bg-spot !text-on-spot ring-2 ring-spot/20'
+                                                        : member ? '!border-edge !bg-surface hover:!bg-spot-surface'
+                                                            : ''
                                                 } ${!member && isSelected ? '!bg-surface !border-spot' : ''
-                                                } ${!member && !isSelected ? '!border-dashed !border-edge-strong !text-ink-muted' : ''}`}
+                                                } ${!member && !isSelected ? '!border-dashed !border-edge-strong !bg-surface !text-ink-muted' : ''}`}
                                             >
                                                 {member ? member.name : '未割当'}
                                             </Button>

--- a/app/settings/theme/page.tsx
+++ b/app/settings/theme/page.tsx
@@ -18,7 +18,7 @@ export default function ThemeSettingsPage() {
     }
 
     return (
-        <div className="min-h-screen bg-page pt-14 pb-4 sm:pb-6 lg:pb-8 px-4 sm:px-6 lg:px-8 transition-colors">
+        <div className="min-h-screen bg-page pt-20 pb-4 sm:pb-6 lg:pb-8 px-4 sm:px-6 lg:px-8 transition-colors">
             <FloatingNav backHref="/settings" />
             <div className="max-w-5xl mx-auto">
                 <main className="space-y-6">

--- a/app/tasting/page.tsx
+++ b/app/tasting/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, Suspense } from 'react';
+import { useEffect, useRef, Suspense, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { useAuth } from '@/lib/auth';
@@ -21,6 +21,7 @@ function TastingPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const hasRedirected = useRef(false);
+  const [isRedirectingAfterDelete, setIsRedirectingAfterDelete] = useState(false);
   const { showToast } = useToastContext();
 
   // クエリパラメータからIDを取得
@@ -56,6 +57,10 @@ function TastingPageContent() {
   if (sessionId && isEditSession) {
     const session = tastingSessions.find((s) => s.id === sessionId);
     if (!session) {
+      if (isRedirectingAfterDelete) {
+        return <Loading />;
+      }
+
       return (
         <div className="min-h-screen py-4 sm:py-6 lg:py-8 px-4 sm:px-6 lg:px-8 bg-page">
           <div className="max-w-2xl mx-auto">
@@ -92,6 +97,7 @@ function TastingPageContent() {
       if (!confirmDelete) return;
 
       try {
+        setIsRedirectingAfterDelete(true);
         // セッションに関連する記録も削除
         const updatedRecords = tastingRecords.filter((r) => r.sessionId !== id);
         const updatedSessions = tastingSessions.filter((s) => s.id !== id);
@@ -103,6 +109,7 @@ function TastingPageContent() {
         router.push('/tasting');
       } catch (error) {
         console.error('Failed to delete session:', error);
+        setIsRedirectingAfterDelete(false);
         showToast('セッションの削除に失敗しました', 'error');
       }
     };
@@ -132,6 +139,10 @@ function TastingPageContent() {
   if (recordId) {
     const record = tastingRecords.find((r) => r.id === recordId);
     if (!record) {
+      if (isRedirectingAfterDelete) {
+        return <Loading />;
+      }
+
       return (
         <div className="min-h-screen py-4 sm:py-6 lg:py-8 px-4 sm:px-6 lg:px-8 bg-page">
           <div className="max-w-2xl mx-auto">
@@ -168,6 +179,7 @@ function TastingPageContent() {
       if (!confirmDelete) return;
 
       try {
+        setIsRedirectingAfterDelete(true);
         const updatedRecords = tastingRecords.filter((r) => r.id !== id);
         await updateData({
           ...data,
@@ -177,6 +189,7 @@ function TastingPageContent() {
         router.push('/tasting');
       } catch (error) {
         console.error('Failed to delete record:', error);
+        setIsRedirectingAfterDelete(false);
         showToast('記録の削除に失敗しました', 'error');
       }
     };
@@ -207,6 +220,10 @@ function TastingPageContent() {
   if (sessionId) {
     const session = tastingSessions.find((s) => s.id === sessionId);
     if (!session) {
+      if (isRedirectingAfterDelete) {
+        return <Loading />;
+      }
+
       return (
         <div className="min-h-screen py-4 sm:py-6 lg:py-8 px-4 sm:px-6 lg:px-8 bg-page">
           <div className="max-w-4xl mx-auto">
@@ -243,17 +260,19 @@ function TastingPageContent() {
         right={
           !isEmpty ? (
             <>
+              <div id="sample-data-button-container" className="hidden sm:block min-w-[1px]"></div>
               <div id="filter-button-container" className="hidden sm:block min-w-[1px]"></div>
               <div id="filter-button-container-mobile" className="sm:hidden min-w-[1px]"></div>
               <div className="hidden sm:block">
                 <Button
                   variant="primary"
+                  size="sm"
                   onClick={() => router.push('/tasting/sessions/new')}
                   aria-label="新規セッション作成"
-                  className="flex items-center gap-2 shadow-md"
+                  className="!px-3 !py-2 gap-1.5 shadow-md"
                 >
                   <HiPlus size={20} />
-                  <span className="whitespace-nowrap">セッションを作成</span>
+                  <span className="text-xs sm:text-sm whitespace-nowrap">セッションを作成</span>
                 </Button>
               </div>
               <div className="sm:hidden">
@@ -275,6 +294,7 @@ function TastingPageContent() {
           <TastingSessionList
             data={data}
             onUpdate={updateData}
+            sampleButtonContainerId="sample-data-button-container"
             filterButtonContainerId="filter-button-container"
             filterButtonContainerIdMobile="filter-button-container-mobile"
           />

--- a/app/tasting/sessions/new/page.tsx
+++ b/app/tasting/sessions/new/page.tsx
@@ -7,10 +7,8 @@ import { useAppData } from '@/hooks/useAppData';
 import { TastingSessionForm } from '@/components/TastingSessionForm';
 import { Loading } from '@/components/Loading';
 import type { TastingSession } from '@/types';
-import { HiPlusCircle } from 'react-icons/hi';
 import { useToastContext } from '@/components/Toast';
-import { motion } from 'framer-motion';
-import { BackLink } from '@/components/ui';
+import { FloatingNav } from '@/components/ui';
 
 export default function NewTastingSessionPage() {
   const { user, loading: authLoading } = useAuth();
@@ -69,36 +67,10 @@ export default function NewTastingSessionPage() {
   };
 
   return (
-    <div
-      className="min-h-screen py-6 sm:py-8 px-4 sm:px-6 bg-page"
-    >
-      <div className="max-w-lg mx-auto space-y-6">
-        <motion.header
-          initial={{ opacity: 0, y: -10 }}
-          animate={{ opacity: 1, y: 0 }}
-          className="relative flex flex-col items-center text-center pt-6"
-        >
-          <BackLink
-            href="/tasting"
-            variant="icon-only"
-            className="absolute left-0 top-0"
-          />
-
-          <div className="flex flex-col items-center space-y-2">
-            <div className="p-3 rounded-2xl shadow-sm mb-2 relative bg-surface border border-edge">
-              <div className="absolute inset-0 rounded-2xl scale-110 blur-xl opacity-30 -z-10 bg-spot-surface" />
-              <HiPlusCircle size={32} className="text-spot" />
-            </div>
-            <h1 className="text-2xl sm:text-3xl font-black tracking-tight text-ink">
-              新規セッション作成
-            </h1>
-            <p className="text-sm font-medium text-ink-muted">
-              新しい試飲の記録を開始しましょう
-            </p>
-          </div>
-        </motion.header>
-
-        <main>
+    <div className="min-h-screen px-4 sm:px-6 bg-page">
+      <FloatingNav backHref="/tasting" />
+      <div className="min-h-screen max-w-lg mx-auto flex items-center py-16">
+        <main className="w-full">
           <TastingSessionForm
             session={null}
             onSave={handleSave}

--- a/components/SliderInput.tsx
+++ b/components/SliderInput.tsx
@@ -27,23 +27,23 @@ export function SliderInput({
 }: SliderInputProps) {
   const containerClass = readOnly
     ? 'bg-ground border-edge'
-    : 'bg-surface border-edge hover:border-spot hover:shadow-md';
+    : 'bg-surface border-edge hover:border-spot hover:shadow-sm';
 
   return (
     <div
-      className={`p-4 rounded-xl border transition-all duration-200 ${containerClass}`}
+      className={`p-3 rounded-lg border transition-all duration-200 ${containerClass}`}
     >
-      <div className="flex items-start justify-between mb-3">
-        <div className="flex items-center gap-2.5">
-          <div className={`p-2 rounded-lg ${colorClass}`}>{icon}</div>
+      <div className="flex items-start justify-between mb-2.5">
+        <div className="flex items-center gap-2">
+          <div className={`p-1.5 rounded-md ${colorClass}`}>{icon}</div>
           <div>
-            <label className="text-base font-bold block leading-tight text-ink">{label}</label>
+            <label className="text-sm font-bold block leading-tight text-ink">{label}</label>
             {description && <span className="text-[11px] font-medium text-ink-muted">{description}</span>}
           </div>
         </div>
         <div className="flex flex-col items-end">
           <span
-            className={`text-2xl font-black tabular-nums leading-none tracking-tight ${accentColor}`}
+            className={`text-xl font-black tabular-nums leading-none ${accentColor}`}
           >
             {value.toFixed(1)}
           </span>
@@ -58,9 +58,9 @@ export function SliderInput({
           step={step}
           value={value}
           onChange={(e) => onChange(parseFloat(e.target.value))}
-          className={`w-full h-2.5 rounded-full appearance-none cursor-pointer transition-all
-          [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-6 [&::-webkit-slider-thumb]:h-6
-          [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:border-[3px] [&::-webkit-slider-thumb]:shadow-md
+          className={`w-full h-2 rounded-full appearance-none cursor-pointer transition-all
+          [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:h-5
+          [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:shadow-sm
           [&::-webkit-slider-thumb]:bg-white ${accentColor.replace('text-', '[&::-webkit-slider-thumb]:border-')}
           hover:[&::-webkit-slider-thumb]:scale-110 active:[&::-webkit-slider-thumb]:scale-95
           disabled:cursor-not-allowed`}
@@ -82,7 +82,7 @@ export function SliderInput({
           }}
           disabled={readOnly}
         />
-        <div className="flex justify-between text-[9px] font-bold mt-2 tracking-wider text-ink-muted">
+        <div className="flex justify-between text-[9px] font-bold mt-1.5 text-ink-muted">
           <span>最小</span>
           <div className="flex gap-1.5 items-center">
             {[1, 2, 3, 4, 5].map((v) => (

--- a/components/TastingRecordForm.tsx
+++ b/components/TastingRecordForm.tsx
@@ -6,7 +6,7 @@ import { getRecordsBySessionId } from '@/lib/tastingUtils';
 import { useToastContext } from '@/components/Toast';
 import { useMembers, getActiveMembers } from '@/hooks/useMembers';
 import { useAuth } from '@/lib/auth';
-import { User, Calendar, Thermometer, Smiley, Coffee } from 'phosphor-react';
+import { User, Calendar, Thermometer, Coffee } from 'phosphor-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Input, Select, Textarea, Button } from '@/components/ui';
 import { ROAST_LEVELS } from '@/lib/constants';
@@ -181,20 +181,20 @@ export function TastingRecordForm({
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
       onSubmit={handleSubmit}
-      className="space-y-5 pb-8"
+      className="space-y-4 pb-6"
     >
       {/* 基本情報カード */}
-      <div className="rounded-2xl p-5 shadow-sm space-y-4 bg-surface border border-edge">
+      <div className="rounded-lg p-4 shadow-sm space-y-3 bg-surface border border-edge">
         <div className="flex items-center gap-2">
-          <div className="w-1 h-5 rounded-full bg-spot" />
-          <h3 className="text-base font-bold text-ink">基本情報</h3>
+          <div className="w-1 h-4 rounded-full bg-spot" />
+          <h3 className="text-sm font-bold text-ink">基本情報</h3>
         </div>
 
-        <div className="grid grid-cols-1 gap-4">
+        <div className="grid grid-cols-1 gap-3">
           {/* メンバー選択 */}
           <div>
-            <label className="flex items-center gap-2 text-sm font-bold mb-1.5 ml-1 text-ink-sub">
-              <User size={16} weight="bold" className="text-spot" />
+            <label className="flex items-center gap-1.5 text-xs font-bold mb-1.5 ml-1 text-ink-sub">
+              <User size={14} weight="bold" className="text-spot" />
               メンバー <span className="text-red-500">*</span>
             </label>
             <Select
@@ -210,8 +210,8 @@ export function TastingRecordForm({
           {/* 豆の名前（セッションモードでは非表示） */}
           {!isSessionMode && (
             <div>
-              <label className="flex items-center gap-2 text-sm font-bold mb-1.5 ml-1 text-ink-sub">
-                <Coffee size={16} weight="bold" className="text-spot" />
+              <label className="flex items-center gap-1.5 text-xs font-bold mb-1.5 ml-1 text-ink-sub">
+                <Coffee size={14} weight="bold" className="text-spot" />
                 豆の名前 <span className="text-red-500">*</span>
               </label>
               <Input
@@ -225,12 +225,12 @@ export function TastingRecordForm({
             </div>
           )}
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             {/* 試飲日（セッションモードでは非表示） */}
             {!isSessionMode && (
               <div>
-                <label className="flex items-center gap-2 text-sm font-bold mb-1.5 ml-1 text-ink-sub">
-                  <Calendar size={16} weight="bold" className="text-spot" />
+                <label className="flex items-center gap-1.5 text-xs font-bold mb-1.5 ml-1 text-ink-sub">
+                  <Calendar size={14} weight="bold" className="text-spot" />
                   試飲日 <span className="text-red-500">*</span>
                 </label>
                 <Input
@@ -246,8 +246,8 @@ export function TastingRecordForm({
             {/* 焙煎度合い（セッションモードでは非表示） */}
             {!isSessionMode && (
               <div>
-                <label className="flex items-center gap-2 text-sm font-bold mb-1.5 ml-1 text-ink-sub">
-                  <Thermometer size={16} weight="bold" className="text-spot" />
+                <label className="flex items-center gap-1.5 text-xs font-bold mb-1.5 ml-1 text-ink-sub">
+                  <Thermometer size={14} weight="bold" className="text-spot" />
                   焙煎度合い <span className="text-red-500">*</span>
                 </label>
                 <Select
@@ -281,15 +281,15 @@ export function TastingRecordForm({
       />
 
       {/* コメント */}
-      <div className="rounded-2xl p-5 shadow-sm space-y-4 bg-surface border border-edge">
+      <div className="rounded-lg p-4 shadow-sm space-y-3 bg-surface border border-edge">
         <div className="w-full flex items-center gap-2">
-          <div className="w-1 h-5 rounded-full bg-spot" />
-          <h3 className="text-base font-bold text-ink">全体的な印象</h3>
+          <div className="w-1 h-4 rounded-full bg-spot" />
+          <h3 className="text-sm font-bold text-ink">全体的な印象</h3>
         </div>
         <Textarea
           value={overallImpression}
           onChange={(e) => setOverallImpression(e.target.value)}
-          rows={4}
+          rows={3}
           placeholder="コーヒーの全体的な印象、味の深み、後味などを自由に記録してください..."
           disabled={readOnly}
         />
@@ -301,15 +301,14 @@ export function TastingRecordForm({
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
-            className="sticky bottom-6 flex gap-4 backdrop-blur-md p-4 rounded-3xl shadow-xl z-20 bg-surface/80 border border-edge"
+            className="flex gap-3 p-3 rounded-xl shadow-sm bg-surface border border-edge"
           >
             {onDelete && record && (
-              <Button type="button" variant="outline" onClick={handleDelete} className="flex-1">
+              <Button type="button" variant="outline" size="md" onClick={handleDelete} className="flex-1">
                 削除
               </Button>
             )}
-            <Button type="submit" variant="primary" size="lg" className="flex-[2]">
-              <Smiley size={24} weight="bold" />
+            <Button type="submit" variant="primary" size="md" className="flex-[2]">
               {existingRecordId || record ? '記録を更新する' : '記録を保存する'}
             </Button>
           </motion.div>

--- a/components/TastingRecordFormScores.tsx
+++ b/components/TastingRecordFormScores.tsx
@@ -29,14 +29,14 @@ export function TastingRecordFormScores({
   readOnly = false,
 }: TastingRecordFormScoresProps) {
   return (
-    <div className="space-y-4">
-      <div className="flex flex-col gap-1.5 px-1">
+    <div className="space-y-3">
+      <div className="flex flex-col gap-1 px-1">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <div className="w-1 h-5 rounded-full bg-spot" />
-            <h3 className="text-base font-bold text-ink">評価項目</h3>
+            <div className="w-1 h-4 rounded-full bg-spot" />
+            <h3 className="text-sm font-bold text-ink">評価項目</h3>
           </div>
-          <div className="text-[10px] font-bold tracking-wider text-spot">
+          <div className="text-[10px] font-bold text-spot">
             1.0 - 5.0 スケール
           </div>
         </div>
@@ -45,14 +45,14 @@ export function TastingRecordFormScores({
         </p>
       </div>
 
-      <div className="grid grid-cols-1 gap-3">
+      <div className="grid grid-cols-1 gap-2.5">
         <SliderInput
           label="苦味"
           value={bitterness}
           onChange={onBitternessChange}
           description="コーヒーの苦みの強さ"
           readOnly={readOnly}
-          icon={<Coffee size={24} weight="fill" className="text-stone-700" />}
+          icon={<Coffee size={18} weight="fill" className="text-stone-700" />}
           colorClass="bg-stone-100"
           accentColor="text-stone-800"
         />
@@ -62,7 +62,7 @@ export function TastingRecordFormScores({
           onChange={onAcidityChange}
           description="コーヒーの酸っぱさや爽やかさ"
           readOnly={readOnly}
-          icon={<Sun size={24} weight="fill" className="text-orange-600" />}
+          icon={<Sun size={18} weight="fill" className="text-orange-600" />}
           colorClass="bg-orange-50"
           accentColor="text-orange-600"
         />
@@ -72,7 +72,7 @@ export function TastingRecordFormScores({
           onChange={onBodyChange}
           description="コーヒーの口当たりや重厚感"
           readOnly={readOnly}
-          icon={<Drop size={24} weight="fill" className="text-amber-800" />}
+          icon={<Drop size={18} weight="fill" className="text-amber-800" />}
           colorClass="bg-amber-50"
           accentColor="text-amber-800"
         />
@@ -82,7 +82,7 @@ export function TastingRecordFormScores({
           onChange={onSweetnessChange}
           description="コーヒーに感じられる甘さ"
           readOnly={readOnly}
-          icon={<Cookie size={24} weight="fill" className="text-rose-600" />}
+          icon={<Cookie size={18} weight="fill" className="text-rose-600" />}
           colorClass="bg-rose-50"
           accentColor="text-rose-600"
         />
@@ -92,7 +92,7 @@ export function TastingRecordFormScores({
           onChange={onAromaChange}
           description="コーヒーの香りの強さや豊かさ"
           readOnly={readOnly}
-          icon={<Wind size={24} weight="fill" className="text-emerald-600" />}
+          icon={<Wind size={18} weight="fill" className="text-emerald-600" />}
           colorClass="bg-emerald-50"
           accentColor="text-emerald-600"
         />

--- a/components/TastingSessionCardDesktop.tsx
+++ b/components/TastingSessionCardDesktop.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import {
   Coffee,
@@ -8,10 +9,12 @@ import {
   CalendarBlank,
   CaretRight,
   Notepad,
+  X,
 } from 'phosphor-react';
+import { AnimatePresence, motion } from 'framer-motion';
 import type { TastingSession } from '@/types';
 import type { AverageScores } from '@/lib/tastingUtils';
-import { IconButton, Card } from '@/components/ui';
+import { IconButton, Card, Button } from '@/components/ui';
 
 interface TastingSessionCardDesktopProps {
   session: TastingSession;
@@ -35,6 +38,7 @@ export function TastingSessionCardDesktop({
   formatDate,
 }: TastingSessionCardDesktopProps) {
   const router = useRouter();
+  const [isAiModalOpen, setIsAiModalOpen] = useState(false);
   const roastStyle = getRoastBadgeStyle(session.roastLevel);
   const hasAnalysis = !!session.aiAnalysis;
 
@@ -43,23 +47,22 @@ export function TastingSessionCardDesktop({
   const textSecondaryClass = 'text-ink-sub';
   const textMutedClass = 'text-ink-muted';
   const bgMutedClass = 'bg-ground';
-  const bgSectionClass = 'bg-ground';
   const borderSectionClass = 'border-edge';
   const iconAccentClass = 'text-spot';
   const spinnerClass = 'border-spot';
 
   return (
-    <div>
-      <Link href={`/tasting?sessionId=${session.id}`} className="block group relative">
-        <Card variant="hoverable" className="p-0 overflow-hidden shadow-xl hover:shadow-2xl transition-all duration-500">
-          <div className="relative z-10">
+    <div className="h-full py-3">
+      <Link href={`/tasting?sessionId=${session.id}`} className="block group relative h-full">
+        <Card variant="hoverable" className="p-0 h-full overflow-hidden shadow-xl hover:shadow-2xl transition-all duration-500">
+          <div className="relative z-10 h-full">
             <div className="h-full flex flex-col">
               {/* ヘッダー */}
-              <div className={`px-8 pt-8 pb-6 border-b border-dashed ${cardBorderClass} flex items-center justify-between`}>
+              <div className={`px-8 pt-6 pb-5 border-b border-dashed ${cardBorderClass} flex items-center justify-between flex-shrink-0`}>
                 <div className="flex items-center gap-6 flex-1 min-w-0">
                   <div>
                     <div className="flex items-center gap-4 mb-1">
-                      <h3 className={`text-4xl font-serif font-bold ${textPrimaryClass} tracking-tight leading-tight truncate`}>
+                      <h3 className={`text-3xl font-serif font-bold ${textPrimaryClass} tracking-tight leading-tight truncate`}>
                         {session.beanName}
                       </h3>
                       <div className="flex items-center gap-2">
@@ -91,11 +94,11 @@ export function TastingSessionCardDesktop({
               </div>
 
               {/* メインコンテンツ */}
-              <div className={`flex items-stretch border-b border-dashed ${cardBorderClass}`}>
+              <div className={`flex items-stretch border-b border-dashed ${cardBorderClass} flex-1 min-h-0`}>
                 {/* 感想 (左) */}
-                <div className={`flex-1 p-8 border-r border-dashed ${cardBorderClass} relative`}>
+                <div className={`flex-1 p-6 border-r border-dashed ${cardBorderClass} relative min-w-0`}>
                   <div className="relative z-10 flex flex-col h-full">
-                    <div className="flex items-center justify-between mb-6">
+                    <div className="flex items-center justify-between mb-4 flex-shrink-0">
                       <div className={`flex items-center gap-2 ${textPrimaryClass}`}>
                         <Quotes size={20} weight="fill" />
                         <h4 className="text-base font-bold">感想</h4>
@@ -107,7 +110,8 @@ export function TastingSessionCardDesktop({
                         </span>
                       </div>
                     </div>
-                    <div className="flex-1 min-h-[160px] max-h-[300px] overflow-y-auto pr-2">
+                    <div className="relative flex-1 min-h-0">
+                      <div className="h-full overflow-y-auto pr-3 pb-6 [scrollbar-width:thin] [scrollbar-color:var(--edge-strong)_var(--ground)] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:rounded-full [&::-webkit-scrollbar-track]:bg-ground [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-edge-strong">
                       {comments.length > 0 ? (
                         <ul className="space-y-4">
                           {comments.map((comment, commentIndex) => (
@@ -120,17 +124,19 @@ export function TastingSessionCardDesktop({
                           ))}
                         </ul>
                       ) : (
-                        <div className="flex flex-col items-center justify-center h-full opacity-40 py-4">
-                          <Coffee size={40} weight="thin" className={textMutedClass} />
-                          <p className={`text-xs ${textMutedClass} italic`}>まだ感想がありません...</p>
+                        <div className={`flex flex-col items-center justify-center h-full rounded-lg border border-dashed ${cardBorderClass} py-6 px-4`}>
+                          <Coffee size={32} weight="duotone" className={textMutedClass} />
+                          <p className={`mt-2 text-sm font-bold ${textSecondaryClass}`}>感想はまだありません</p>
+                          <p className={`mt-1 text-xs ${textMutedClass}`}>右下の「記録を追加する」から入力できます</p>
                         </div>
                       )}
+                      </div>
                     </div>
                   </div>
                 </div>
 
                 {/* チャート (右) */}
-                <div className="w-80 flex-shrink-0 p-8 flex flex-col justify-center relative overflow-hidden">
+                <div className="w-80 flex-shrink-0 p-6 flex flex-col justify-center relative overflow-hidden">
                   {recordCount > 0 ? (
                     <div className="space-y-5 w-full relative z-10">
                       {[
@@ -141,11 +147,11 @@ export function TastingSessionCardDesktop({
                         { label: '香り', value: averageScores.aroma, color: '#00897b' },
                       ].map((item) => (
                         <div key={item.label} className="space-y-1">
-                          <div className={`flex justify-between items-center text-xs font-bold ${textSecondaryClass}`}>
+                          <div className={`flex justify-between items-center text-sm font-bold ${textSecondaryClass}`}>
                             <span>{item.label}</span>
                             <span>{item.value.toFixed(1)}</span>
                           </div>
-                          <div className={`w-full ${bgMutedClass} h-1.5 rounded overflow-hidden`}>
+                          <div className={`w-full ${bgMutedClass} h-2 rounded overflow-hidden`}>
                             <div
                               className="h-full transition-all duration-700"
                               style={{
@@ -158,10 +164,10 @@ export function TastingSessionCardDesktop({
                       ))}
                     </div>
                   ) : (
-                    <div className={`flex flex-col items-center justify-center w-full h-full border-2 border-dashed ${cardBorderClass} rounded-xl p-8 opacity-60`}>
-                      <Coffee size={40} weight="thin" className={textMutedClass} />
-                      <p className={`text-xs font-bold ${textMutedClass} tracking-widest text-center`}>
-                        データなし
+                    <div className={`flex flex-col items-center justify-center w-full h-full border border-dashed ${cardBorderClass} rounded-lg p-8`}>
+                      <Coffee size={32} weight="duotone" className={textMutedClass} />
+                      <p className={`mt-2 text-xs font-bold ${textSecondaryClass} text-center`}>
+                        評価データなし
                       </p>
                     </div>
                   )}
@@ -169,10 +175,10 @@ export function TastingSessionCardDesktop({
               </div>
 
               {/* AI分析レポート (下) */}
-              <div className="p-8 relative min-h-[120px] transition-all duration-500">
+              <div className="px-5 py-3 relative flex-shrink-0">
                 <div className="relative z-10">
                   {!hasAnalysis && !isAnalyzing && recordCount === 0 && (
-                    <div className="flex items-center justify-center py-2">
+                    <div className="flex items-center justify-center py-1">
                       <p className={`text-xs ${textSecondaryClass} italic`}>
                         記録が追加されるとAI分析が開始されます
                       </p>
@@ -180,8 +186,8 @@ export function TastingSessionCardDesktop({
                   )}
 
                   {isAnalyzing && (
-                    <div className="flex flex-col items-center justify-center py-6 gap-3">
-                      <div className={`animate-spin rounded-full h-8 w-8 border-b-2 ${spinnerClass}`}></div>
+                    <div className="flex items-center justify-center py-2 gap-2">
+                      <div className={`animate-spin rounded-full h-4 w-4 border-b-2 ${spinnerClass}`}></div>
                       <p className={`text-xs ${textSecondaryClass} animate-pulse`}>
                         コーヒーの香りを分析中...
                       </p>
@@ -189,23 +195,32 @@ export function TastingSessionCardDesktop({
                   )}
 
                   {hasAnalysis && (
-                    <div className={`${bgSectionClass} rounded-xl p-6 border ${borderSectionClass}`}>
-                      <div className="flex items-center gap-2 mb-4">
-                        <Notepad size={20} weight="fill" className={iconAccentClass} />
+                    <Button
+                      type="button"
+                      variant="surface"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        setIsAiModalOpen(true);
+                      }}
+                      className="w-full !justify-between !px-4 !py-3 !rounded-lg !shadow-sm hover:!shadow-card"
+                    >
+                      <div className="flex items-center gap-2">
+                        <Notepad size={18} weight="fill" className={iconAccentClass} />
                         <h4 className={`text-sm font-bold tracking-wide ${textPrimaryClass}`}>
                           AIコーヒーマイスターのコメント
                         </h4>
                       </div>
-                      <p className={`text-sm leading-relaxed ${textPrimaryClass} whitespace-pre-wrap`}>
-                        {session.aiAnalysis}
-                      </p>
-                    </div>
+                      <span className={`flex items-center gap-1 text-xs font-bold ${textSecondaryClass}`}>
+                        開く <CaretRight size={14} weight="bold" />
+                      </span>
+                    </Button>
                   )}
                 </div>
               </div>
 
               {/* フッター */}
-              <div className={`px-8 py-4 ${bgSectionClass} border-t ${borderSectionClass} flex justify-between items-center`}>
+              <div className={`px-8 py-2.5 bg-surface border-t ${borderSectionClass} flex justify-between items-center flex-shrink-0`}>
                 <div className={`flex items-center gap-1.5 text-xs ${textMutedClass}`}>
                   <CalendarBlank size={14} weight="fill" />
                   <span>{formatDate(session.createdAt)}</span>
@@ -218,6 +233,50 @@ export function TastingSessionCardDesktop({
           </div>
         </Card>
       </Link>
+
+      <AnimatePresence>
+        {isAiModalOpen && (
+          <div className="fixed inset-0 z-[100] flex items-center justify-center px-4">
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              onClick={() => setIsAiModalOpen(false)}
+              className="absolute inset-0 bg-stone-900/40 backdrop-blur-sm"
+            />
+            <motion.div
+              initial={{ opacity: 0, y: 16, scale: 0.98 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: 16, scale: 0.98 }}
+              className="relative w-full max-w-2xl max-h-[78vh] bg-overlay rounded-xl shadow-2xl border border-edge overflow-hidden flex flex-col"
+            >
+              <div className={`px-5 py-4 border-b ${borderSectionClass} flex items-center justify-between gap-4`}>
+                <div className="flex items-center gap-2 min-w-0">
+                  <Notepad size={20} weight="fill" className={iconAccentClass} />
+                  <div className="min-w-0">
+                    <h3 className={`text-base font-bold ${textPrimaryClass}`}>AIコーヒーマイスターのコメント</h3>
+                    <p className={`text-xs ${textMutedClass} truncate`}>{session.beanName}</p>
+                  </div>
+                </div>
+                <IconButton
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setIsAiModalOpen(false)}
+                  aria-label="閉じる"
+                >
+                  <X size={18} weight="bold" />
+                </IconButton>
+              </div>
+
+              <div className="flex-1 overflow-y-auto p-5">
+                <p className={`text-sm leading-relaxed ${textPrimaryClass} whitespace-pre-wrap`}>
+                  {session.aiAnalysis}
+                </p>
+              </div>
+            </motion.div>
+          </div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/components/TastingSessionCardMobile.tsx
+++ b/components/TastingSessionCardMobile.tsx
@@ -71,44 +71,11 @@ export function TastingSessionCardMobile({
                   </div>
                 </div>
 
-                {/* 横バーチャート（スコア表示） */}
-                {recordCount > 0 && (
-                  <div className={`flex-shrink-0 px-4 py-3 border-b border-dashed ${cardBorderClass}`}>
-                    <div className="space-y-2.5">
-                      {[
-                        { label: '苦味', value: averageScores.bitterness, color: '#3e2723' },
-                        { label: '酸味', value: averageScores.acidity, color: '#ff7043' },
-                        { label: 'ボディ', value: averageScores.body, color: '#8d6e63' },
-                        { label: '甘み', value: averageScores.sweetness, color: '#d81b60' },
-                        { label: '香り', value: averageScores.aroma, color: '#00897b' },
-                      ].map((item) => (
-                        <div key={item.label} className="flex items-center gap-2">
-                          <span className={`text-[10px] font-bold ${textSecondaryClass} w-10 flex-shrink-0`}>
-                            {item.label}
-                          </span>
-                          <div className={`flex-1 h-1.5 ${bgMutedClass} rounded overflow-hidden`}>
-                            <div
-                              className="h-full transition-all duration-500"
-                              style={{
-                                width: `${((item.value - 1) / 4) * 100}%`,
-                                backgroundColor: item.color,
-                              }}
-                            />
-                          </div>
-                          <span className={`text-[10px] font-bold ${textSecondaryClass} w-6 text-right`}>
-                            {item.value.toFixed(1)}
-                          </span>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
                 {/* 感想 + AIコメント */}
                 <div className="flex-1 flex flex-col min-h-0 p-4">
                   {/* 感想セクション */}
                   <div className="flex-1 min-h-0 overflow-hidden">
-                    <div className="flex items-center gap-2 mb-3">
+                    <div className="flex items-center gap-2 mb-2">
                       <Quotes size={16} weight="fill" className={textPrimaryClass} />
                       <h4 className={`text-sm font-bold ${textPrimaryClass}`}>感想</h4>
                       <span className={`text-[10px] font-bold ${textMutedClass} ml-auto`}>
@@ -116,13 +83,14 @@ export function TastingSessionCardMobile({
                       </span>
                     </div>
 
-                    <div className="h-[calc(100%-28px)] overflow-y-auto pr-1">
+                    <div className="relative h-[calc(100%-28px)]">
+                      <div className="h-full overflow-y-auto pr-2 pb-3 [scrollbar-width:thin] [scrollbar-color:var(--edge-strong)_var(--ground)] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:rounded-full [&::-webkit-scrollbar-track]:bg-ground [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-edge-strong">
                       {comments.length > 0 ? (
-                        <ul className="space-y-3">
+                        <ul className="space-y-2">
                           {comments.map((comment, commentIndex) => (
                             <li
                               key={commentIndex}
-                              className={`text-sm italic ${textSecondaryClass} leading-relaxed pl-3 border-l-2 ${cardBorderClass}`}
+                              className={`text-[13px] italic ${textSecondaryClass} leading-snug pl-3 border-l-2 ${cardBorderClass}`}
                             >
                               {comment}
                             </li>
@@ -134,11 +102,45 @@ export function TastingSessionCardMobile({
                           <p className={`text-xs ${textMutedClass} italic`}>まだ感想がありません</p>
                         </div>
                       )}
+                      </div>
                     </div>
                   </div>
 
+                  {/* 横バーチャート（スコア表示） */}
+                  {recordCount > 0 && (
+                    <div className={`flex-shrink-0 border-t border-dashed ${cardBorderClass} pt-2 mt-2`}>
+                      <div className="space-y-1.5">
+                        {[
+                          { label: '苦味', value: averageScores.bitterness, color: '#3e2723' },
+                          { label: '酸味', value: averageScores.acidity, color: '#ff7043' },
+                          { label: 'ボディ', value: averageScores.body, color: '#8d6e63' },
+                          { label: '甘み', value: averageScores.sweetness, color: '#d81b60' },
+                          { label: '香り', value: averageScores.aroma, color: '#00897b' },
+                        ].map((item) => (
+                          <div key={item.label} className="flex items-center gap-2">
+                            <span className={`text-[9px] font-bold ${textSecondaryClass} w-9 flex-shrink-0`}>
+                              {item.label}
+                            </span>
+                            <div className={`flex-1 h-1 ${bgMutedClass} rounded overflow-hidden`}>
+                              <div
+                                className="h-full transition-all duration-500"
+                                style={{
+                                  width: `${((item.value - 1) / 4) * 100}%`,
+                                  backgroundColor: item.color,
+                                }}
+                              />
+                            </div>
+                            <span className={`text-[9px] font-bold ${textSecondaryClass} w-6 text-right`}>
+                              {item.value.toFixed(1)}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
                   {/* AI分析ボタン */}
-                  <div className={`flex-shrink-0 border-t border-dashed ${cardBorderClass} pt-3 mt-3`}>
+                  <div className={`flex-shrink-0 border-t border-dashed ${cardBorderClass} pt-2 mt-2`}>
                     {!hasAnalysis && !isAnalyzing && recordCount === 0 && (
                       <p className={`text-center text-xs ${textSecondaryClass} italic py-2`}>
                         記録が追加されるとAI分析が開始されます
@@ -161,7 +163,7 @@ export function TastingSessionCardMobile({
                           setAiModalSession(session);
                         }}
                         fullWidth
-                        className="justify-between !p-3"
+                        className="justify-between !px-3 !py-2"
                       >
                         <div className="flex items-center gap-2">
                           <Notepad size={16} weight="fill" className={iconAccentClass} />

--- a/components/TastingSessionCarousel.tsx
+++ b/components/TastingSessionCarousel.tsx
@@ -20,8 +20,8 @@ const getRoastBadgeStyle = (level: string) => {
   switch (level) {
     case '浅煎り':
       return {
-        bg: '#C8A882',
-        text: '#3E2723',
+        bg: '#B9824F',
+        text: '#FFFFFF',
         label: level,
       };
     case '中煎り':
@@ -66,7 +66,8 @@ export function TastingSessionCarousel({
   router: _router,
   onUpdateSession,
 }: TastingSessionCarouselProps) {
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const desktopScrollContainerRef = useRef<HTMLDivElement>(null);
+  const mobileScrollContainerRef = useRef<HTMLDivElement>(null);
   const [activeIndex, setActiveIndex] = useState(0);
 
   // セッションカードの共通データを準備
@@ -93,33 +94,39 @@ export function TastingSessionCarousel({
     onUpdateSession,
   });
 
-  // 横スクロールの追跡（モバイル用）
+  // 横スクロールの追跡
   useEffect(() => {
-    const container = scrollContainerRef.current;
-    if (!container) return;
+    const containers = [
+      desktopScrollContainerRef.current,
+      mobileScrollContainerRef.current,
+    ].filter((container): container is HTMLDivElement => container !== null);
 
-    const mediaQuery = window.matchMedia('(min-width: 768px)');
-    if (mediaQuery.matches) return;
+    const cleanups = containers.map((container) => {
+      const handleScroll = () => {
+        if (container.clientWidth === 0) return;
+        const index = Math.round(container.scrollLeft / container.clientWidth);
+        if (index !== activeIndex) {
+          setActiveIndex(index);
+        }
+      };
 
-    const handleScroll = () => {
-      const index = Math.round(container.scrollLeft / container.clientWidth);
-      if (index !== activeIndex) {
-        setActiveIndex(index);
-      }
-    };
+      const handleWheel = (e: WheelEvent) => {
+        if (Math.abs(e.deltaX) > Math.abs(e.deltaY)) return;
+        e.preventDefault();
+        container.scrollLeft += e.deltaY;
+      };
 
-    const handleWheel = (e: WheelEvent) => {
-      if (Math.abs(e.deltaX) > Math.abs(e.deltaY)) return;
-      e.preventDefault();
-      container.scrollLeft += e.deltaY;
-    };
+      container.addEventListener('scroll', handleScroll, { passive: true });
+      container.addEventListener('wheel', handleWheel, { passive: false });
 
-    container.addEventListener('scroll', handleScroll, { passive: true });
-    container.addEventListener('wheel', handleWheel, { passive: false });
+      return () => {
+        container.removeEventListener('scroll', handleScroll);
+        container.removeEventListener('wheel', handleWheel);
+      };
+    });
 
     return () => {
-      container.removeEventListener('scroll', handleScroll);
-      container.removeEventListener('wheel', handleWheel);
+      cleanups.forEach((cleanup) => cleanup());
     };
   }, [activeIndex]);
 
@@ -136,19 +143,47 @@ export function TastingSessionCarousel({
   return (
     <>
       {/* デスクトップ向けレイアウト (md以上で表示) */}
-      <div className="hidden md:block w-full px-4 md:px-8 lg:px-12 py-8">
-        <div className="flex flex-col gap-10 max-w-5xl mx-auto">
+      <div className="hidden md:flex relative w-full h-[calc(100dvh-112px)] min-h-[520px] overflow-hidden flex-col">
+        <div
+          ref={desktopScrollContainerRef}
+          className="flex flex-row gap-6 px-8 lg:px-12 pb-3 h-full overflow-x-auto overflow-y-hidden snap-x snap-mandatory
+                     [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-track]:mx-24 [&::-webkit-scrollbar-track]:rounded-full
+                     [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-ground [&::-webkit-scrollbar-thumb]:bg-spot"
+          style={{
+            WebkitOverflowScrolling: 'touch',
+          }}
+        >
           {sessionData.map(({ session, recordCount, averageScores, comments }) => (
-            <TastingSessionCardDesktop
+            <div
               key={session.id}
-              session={session}
-              recordCount={recordCount}
-              averageScores={averageScores}
-              comments={comments}
-              activeMemberCount={activeMemberCount}
-              isAnalyzing={!!isAnalyzing[session.id]}
-              getRoastBadgeStyle={getRoastBadgeStyle}
-              formatDate={formatDate}
+              className="flex-shrink-0 w-full h-full snap-center flex justify-center"
+              style={{ scrollSnapStop: 'always' }}
+            >
+              <div className="w-full max-w-5xl h-full">
+                <TastingSessionCardDesktop
+                  session={session}
+                  recordCount={recordCount}
+                  averageScores={averageScores}
+                  comments={comments}
+                  activeMemberCount={activeMemberCount}
+                  isAnalyzing={!!isAnalyzing[session.id]}
+                  getRoastBadgeStyle={getRoastBadgeStyle}
+                  formatDate={formatDate}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex-shrink-0 flex justify-center gap-1.5 py-2">
+          {sessionData.map((_, index) => (
+            <div
+              key={index}
+              className={`w-1.5 h-1.5 rounded-full transition-all duration-300 ${
+                index === activeIndex
+                  ? 'bg-spot scale-125'
+                  : 'bg-spot/30'
+              }`}
             />
           ))}
         </div>
@@ -158,7 +193,7 @@ export function TastingSessionCarousel({
       <div className="md:hidden relative w-full h-[calc(100dvh-130px)] overflow-hidden flex flex-col">
         {/* 横スクロールコンテナ */}
         <div
-          ref={scrollContainerRef}
+          ref={mobileScrollContainerRef}
           className="flex flex-row gap-4 px-4 pb-3 h-full overflow-x-auto overflow-y-hidden snap-x snap-mandatory
                      [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-track]:mx-8 [&::-webkit-scrollbar-track]:rounded-full
                      [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-ground [&::-webkit-scrollbar-thumb]:bg-spot"

--- a/components/TastingSessionFilterModal.test.tsx
+++ b/components/TastingSessionFilterModal.test.tsx
@@ -15,9 +15,9 @@ const baseProps = {
 
 describe('TastingSessionFilterModal', () => {
   describe('ヘッダー', () => {
-    it('フィルター設定タイトルを表示する', () => {
+    it('フィルタータイトルを表示する', () => {
       render(<TastingSessionFilterModal {...baseProps} />);
-      expect(screen.getByText('フィルター設定')).toBeInTheDocument();
+      expect(screen.getByText('フィルター')).toBeInTheDocument();
     });
 
     it('フィルター未適用時はリセットボタンを表示しない', () => {
@@ -81,26 +81,31 @@ describe('TastingSessionFilterModal', () => {
       );
     });
 
-    it('選択チップは統一された高さと角丸で表示する', () => {
+    it('選択肢は豆図鑑フィルターと同じ角丸で表示する', () => {
       render(<TastingSessionFilterModal {...baseProps} />);
 
       [
-        screen.getByRole('button', { name: '新しい順' }),
-        screen.getByRole('button', { name: '古い順' }),
-        screen.getByRole('button', { name: '名前順' }),
         screen.getByRole('button', { name: '浅煎り' }),
         screen.getByRole('button', { name: '中煎り' }),
         screen.getByRole('button', { name: '中深煎り' }),
         screen.getByRole('button', { name: '深煎り' }),
       ].forEach((chip) => {
         expect(chip).toHaveClass('!min-h-[40px]');
-        expect(chip).toHaveClass('!rounded-xl');
-        expect(chip).toHaveClass('!px-3');
+        expect(chip).toHaveClass('!rounded-lg');
         expect(chip).toHaveClass('!py-2');
+      });
+
+      [
+        screen.getByRole('button', { name: '新しい順' }),
+        screen.getByRole('button', { name: '古い順' }),
+        screen.getByRole('button', { name: '名前順' }),
+      ].forEach((row) => {
+        expect(row).toHaveClass('!rounded-lg');
+        expect(row).toHaveClass('!justify-start');
       });
     });
 
-    it('並び替えと焙煎度合いの選択中チップは同じ色で表示する', () => {
+    it('ソート行と焙煎度合いは共通フィルターの選択表示になる', () => {
       render(
         <TastingSessionFilterModal
           {...baseProps}
@@ -109,7 +114,7 @@ describe('TastingSessionFilterModal', () => {
         />
       );
 
-      expect(screen.getByRole('button', { name: '古い順' })).toHaveClass('!bg-spot', '!text-white', '!border-spot');
+      expect(screen.getByRole('button', { name: '古い順' })).toHaveClass('!text-spot');
       expect(screen.getByRole('button', { name: '中深煎り' })).toHaveClass('!bg-spot', '!text-white', '!border-spot');
     });
   });
@@ -171,14 +176,14 @@ describe('TastingSessionFilterModal', () => {
       render(<TastingSessionFilterModal {...baseProps} />);
 
       const inputs = [
-        screen.getByPlaceholderText('豆の名前を入力...'),
+        screen.getByPlaceholderText('豆の名前で検索...'),
         ...document.querySelectorAll('input[type="date"]'),
       ];
 
       inputs.forEach((input) => {
-        expect(input).toHaveClass('!min-h-[52px]');
-        expect(input).toHaveClass('!rounded-xl');
-        expect(input).toHaveClass('!text-base');
+        expect(input).toHaveClass('!min-h-[40px]');
+        expect(input).toHaveClass('!rounded-lg');
+        expect(input).toHaveClass('!text-sm');
       });
     });
   });

--- a/components/TastingSessionFilterModal.tsx
+++ b/components/TastingSessionFilterModal.tsx
@@ -1,25 +1,14 @@
 import { useState, useEffect } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
 import {
-  MagnifyingGlass,
-  X,
-  Faders,
-  CalendarBlank,
   SortAscending,
-  Thermometer,
+  SortDescending,
 } from 'phosphor-react';
 import { ROAST_LEVELS } from '@/lib/constants';
-import { Button, IconButton, Input } from '@/components/ui';
+import { Button, FilterModal, FilterOptionButton, FilterSearchInput, FilterSection, FilterSortOption, Input } from '@/components/ui';
 
 type SortOption = 'newest' | 'oldest' | 'beanName';
 
-const inputControlClassName = '!min-h-[52px] !rounded-xl !border !py-3 !text-base';
-const chipClassName =
-  '!min-h-[40px] !rounded-xl !px-3 !py-2 !text-xs !font-semibold !shadow-none border text-center';
-const selectedChipClassName = '!bg-spot !text-white !border-spot';
-const idleChipClassName =
-  '!bg-ground !text-ink-sub !border-edge hover:!border-edge-strong hover:!bg-surface';
-
+const inputControlClassName = '!min-h-[40px] !rounded-lg !py-2 !text-sm';
 interface TastingSessionFilterModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -111,174 +100,112 @@ export function TastingSessionFilterModal({
   const hasActiveFilters =
     tempSearchQuery.trim() || tempDateFrom || tempDateTo || tempSelectedRoastLevels.length > 0;
 
+  const sortOptions = [
+    { id: 'newest', label: '新しい順', icon: <SortDescending size={20} weight="bold" /> },
+    { id: 'oldest', label: '古い順', icon: <SortAscending size={20} weight="bold" /> },
+    { id: 'beanName', label: '名前順', icon: <SortAscending size={20} weight="bold" /> },
+  ] as const;
+
   return (
-    <AnimatePresence>
-      {isOpen && (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center p-4">
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            onClick={onClose}
-            className="absolute inset-0 bg-black/40"
-          />
-          <motion.div
-            initial={{ opacity: 0, scale: 0.95, y: 20 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 0.95, y: 20 }}
-            className="relative rounded-2xl shadow-xl max-w-md w-full max-h-[90vh] overflow-hidden flex flex-col bg-overlay"
+    <FilterModal
+      show={isOpen}
+      onClose={onClose}
+      title="フィルター"
+      headerAction={
+        hasActiveFilters ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            type="button"
+            onClick={handleReset}
+            className="!min-h-0 !px-0 !py-0 !rounded-none !text-xs !font-semibold !text-spot underline underline-offset-2 hover:!text-spot-hover"
           >
-            {/* ヘッダー */}
-            <div className="px-5 py-4 flex items-center justify-between bg-[#261a14]">
-              <div className="flex items-center gap-3">
-                <div className="p-1.5 rounded-xl bg-white/10">
-                  <Faders size={20} weight="fill" className="text-primary" />
-                </div>
-                <h2 className="text-[15px] font-bold text-white tracking-tight">フィルター設定</h2>
-              </div>
-              <div className="flex items-center gap-2">
-                {hasActiveFilters && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    type="button"
-                    onClick={handleReset}
-                    className="!min-h-0 !px-0 !py-0 !rounded-none !text-[11px] !font-semibold !text-white/50 underline underline-offset-2 hover:!text-white/80"
-                  >
-                    リセット
-                  </Button>
-                )}
-                <IconButton
-                  variant="ghost"
-                  onClick={onClose}
-                  aria-label="閉じる"
-                  className="text-white/60 hover:text-white/90 hover:bg-white/10"
-                >
-                  <X size={20} weight="bold" />
-                </IconButton>
-              </div>
-            </div>
+            リセット
+          </Button>
+        ) : null
+      }
+      footer={
+        <>
+          <Button
+            variant="surface"
+            onClick={onClose}
+            className="flex-1 !min-h-[44px] !rounded-lg !text-sm"
+          >
+            キャンセル
+          </Button>
+          <Button
+            variant="primary"
+            onClick={handleApply}
+            className="flex-1 !min-h-[44px] !rounded-lg !text-sm"
+          >
+            適用
+          </Button>
+        </>
+      }
+    >
+      {/* 検索バー */}
+      <FilterSection label="検索">
+        <FilterSearchInput
+          value={tempSearchQuery}
+          onChange={setTempSearchQuery}
+          placeholder="豆の名前で検索..."
+          className={inputControlClassName}
+        />
+      </FilterSection>
 
-            {/* コンテンツ */}
-            <div className="flex-1 overflow-y-auto px-6 py-5 space-y-5">
-              {/* 検索バー */}
-              <div className="space-y-2">
-                <label className="flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-ink-muted">
-                  <MagnifyingGlass size={16} weight="bold" />
-                  豆の名前で検索
-                </label>
-                <Input
-                  type="text"
-                  value={tempSearchQuery}
-                  onChange={(e) => setTempSearchQuery(e.target.value)}
-                  placeholder="豆の名前を入力..."
-                  className={inputControlClassName}
-                />
-              </div>
-
-              {/* ソート */}
-              <div className="space-y-2">
-                <label className="flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-ink-muted">
-                  <SortAscending size={16} weight="bold" />
-                  並び替え
-                </label>
-                <div className="grid grid-cols-3 gap-1.5">
-                  {(
-                    [
-                      { id: 'newest', label: '新しい順' },
-                      { id: 'oldest', label: '古い順' },
-                      { id: 'beanName', label: '名前順' },
-                    ] as const
-                  ).map((opt) => (
-                    <Button
-                      key={opt.id}
-                      variant="ghost"
-                      size="sm"
-                      type="button"
-                      aria-pressed={tempSortOption === opt.id}
-                      onClick={() => setTempSortOption(opt.id)}
-                      className={`${chipClassName} ${
-                        tempSortOption === opt.id
-                          ? selectedChipClassName
-                          : idleChipClassName
-                      }`}
-                    >
-                      {opt.label}
-                    </Button>
-                  ))}
-                </div>
-              </div>
-
-              {/* 日付範囲 */}
-              <div className="space-y-2">
-                <label className="flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-ink-muted">
-                  <CalendarBlank size={16} weight="bold" />
-                  日付範囲
-                </label>
-                <div className="grid grid-cols-2 gap-3">
-                  <Input
-                    type="date"
-                    value={tempDateFrom}
-                    onChange={(e) => setTempDateFrom(e.target.value)}
-                    className={inputControlClassName}
-                  />
-                  <Input
-                    type="date"
-                    value={tempDateTo}
-                    onChange={(e) => setTempDateTo(e.target.value)}
-                    className={inputControlClassName}
-                  />
-                </div>
-              </div>
-
-              {/* 焙煎度合い */}
-              <div className="space-y-2 pb-2">
-                <label className="flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-ink-muted">
-                  <Thermometer size={16} weight="bold" />
-                  焙煎度合い
-                </label>
-                <div className="grid grid-cols-4 gap-1.5">
-                  {ROAST_LEVELS.map((level) => (
-                    <Button
-                      key={level}
-                      variant="ghost"
-                      size="sm"
-                      type="button"
-                      aria-pressed={tempSelectedRoastLevels.includes(level)}
-                      onClick={() => handleRoastLevelToggle(level)}
-                      className={`${chipClassName} ${
-                        tempSelectedRoastLevels.includes(level)
-                          ? selectedChipClassName
-                          : idleChipClassName
-                      }`}
-                    >
-                      {level}
-                    </Button>
-                  ))}
-                </div>
-              </div>
-            </div>
-
-            {/* フッター */}
-            <div className="p-5 pt-4 border-t flex gap-3 bg-ground border-edge">
-              <Button
-                variant="surface"
-                onClick={onClose}
-                className="flex-1 !min-h-[48px] !rounded-xl !text-[15px]"
-              >
-                キャンセル
-              </Button>
-              <Button
-                variant="primary"
-                onClick={handleApply}
-                className="flex-1 !min-h-[48px] !rounded-xl !text-[15px]"
-              >
-                適用
-              </Button>
-            </div>
-          </motion.div>
+      {/* ソート */}
+      <FilterSection label="ソート">
+        <div className="flex flex-col gap-1">
+          {sortOptions.map((opt) => (
+            <FilterSortOption
+              key={opt.id}
+              selected={tempSortOption === opt.id}
+              icon={opt.icon}
+              type="button"
+              aria-pressed={tempSortOption === opt.id}
+              onClick={() => setTempSortOption(opt.id)}
+            >
+              {opt.label}
+            </FilterSortOption>
+          ))}
         </div>
-      )}
-    </AnimatePresence>
+      </FilterSection>
+
+      {/* 日付範囲 */}
+      <FilterSection label="日付範囲">
+        <div className="grid grid-cols-2 gap-2">
+          <Input
+            type="date"
+            value={tempDateFrom}
+            onChange={(e) => setTempDateFrom(e.target.value)}
+            className={inputControlClassName}
+          />
+          <Input
+            type="date"
+            value={tempDateTo}
+            onChange={(e) => setTempDateTo(e.target.value)}
+            className={inputControlClassName}
+          />
+        </div>
+      </FilterSection>
+
+      {/* 焙煎度合い */}
+      <FilterSection label="焙煎度合い">
+        <div className="grid grid-cols-4 gap-2">
+          {ROAST_LEVELS.map((level) => (
+            <FilterOptionButton
+              key={level}
+              selected={tempSelectedRoastLevels.includes(level)}
+              type="button"
+              aria-pressed={tempSelectedRoastLevels.includes(level)}
+              onClick={() => handleRoastLevelToggle(level)}
+              className="!min-h-[40px] !px-1.5 !text-[12px] whitespace-nowrap"
+            >
+              {level}
+            </FilterOptionButton>
+          ))}
+        </div>
+      </FilterSection>
+    </FilterModal>
   );
 }

--- a/components/TastingSessionForm.tsx
+++ b/components/TastingSessionForm.tsx
@@ -9,9 +9,7 @@ import {
   CalendarBlank,
   Thermometer,
   Trash,
-  X,
   Plus,
-  Check,
   Warning,
 } from 'phosphor-react';
 import { Input, Select, Button } from '@/components/ui';
@@ -24,23 +22,6 @@ interface TastingSessionFormProps {
   onCancel: () => void;
   onDelete?: (id: string) => void;
 }
-
-const containerVariants = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-    transition: { staggerChildren: 0.08, delayChildren: 0.05 },
-  },
-};
-
-const itemVariants = {
-  hidden: { y: 14, opacity: 0 },
-  visible: {
-    y: 0,
-    opacity: 1,
-    transition: { type: 'spring' as const, damping: 22, stiffness: 350 },
-  },
-};
 
 export function TastingSessionForm({
   session,
@@ -88,29 +69,24 @@ export function TastingSessionForm({
 
   return (
     <motion.form
-      variants={containerVariants}
-      initial="hidden"
-      animate="visible"
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
       onSubmit={handleSubmit}
       className="space-y-4"
     >
       {/* メインカード */}
-      <motion.div
-        variants={itemVariants}
-        className="rounded-2xl bg-surface border border-edge shadow-sm overflow-hidden"
-      >
+      <div className="rounded-lg bg-surface border border-edge shadow-sm overflow-hidden">
         {/* セクションヘッダー */}
-        <div className="px-5 sm:px-6 pt-5 sm:pt-6 pb-4 border-b border-edge flex items-center gap-2">
-          <Coffee size={16} weight="fill" className="text-spot" />
-          <span className="text-sm font-semibold text-ink">セッション詳細</span>
+        <div className="px-4 py-3 border-b border-edge flex items-center gap-2">
+          <Coffee size={15} weight="fill" className="text-spot" />
+          <span className="text-sm font-semibold text-ink">基本情報</span>
         </div>
 
         {/* フィールド群 */}
-        <div className="px-5 sm:px-6 pt-4 pb-5 sm:pb-6 space-y-5">
+        <div className="p-4 space-y-4">
           {/* 豆の名前 */}
-          <div className="space-y-2">
-            <label className="flex items-center gap-2 text-sm font-bold ml-1 text-ink-sub">
-              <Coffee size={18} weight="bold" className="text-spot" />
+          <div className="space-y-1.5">
+            <label className="flex items-center gap-1.5 text-xs font-bold ml-1 text-ink-sub">
               豆の名前 <span className="text-red-500">*</span>
             </label>
             <Input
@@ -122,11 +98,11 @@ export function TastingSessionForm({
             />
           </div>
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             {/* 焙煎度合い */}
-            <div className="space-y-2">
-              <label className="flex items-center gap-2 text-sm font-bold ml-1 text-ink-sub">
-                <Thermometer size={18} weight="bold" className="text-spot" />
+            <div className="space-y-1.5">
+              <label className="flex items-center gap-1.5 text-xs font-bold ml-1 text-ink-sub">
+                <Thermometer size={14} weight="bold" className="text-spot" />
                 焙煎度合い <span className="text-red-500">*</span>
               </label>
               <Select
@@ -142,9 +118,9 @@ export function TastingSessionForm({
             </div>
 
             {/* 試飲日 */}
-            <div className="space-y-2">
-              <label className="flex items-center gap-2 text-sm font-bold ml-1 text-ink-sub">
-                <CalendarBlank size={18} weight="bold" className="text-spot" />
+            <div className="space-y-1.5">
+              <label className="flex items-center gap-1.5 text-xs font-bold ml-1 text-ink-sub">
+                <CalendarBlank size={14} weight="bold" className="text-spot" />
                 試飲日 <span className="text-red-500">*</span>
               </label>
               <Input
@@ -156,17 +132,16 @@ export function TastingSessionForm({
             </div>
           </div>
         </div>
-      </motion.div>
+      </div>
 
       {/* ボタン行 */}
-      <motion.div variants={itemVariants} className="flex gap-3">
+      <div className="flex gap-3">
         <Button
           type="button"
-          variant="secondary"
+          variant="surface"
           onClick={onCancel}
           className="flex-1"
         >
-          <X size={20} weight="bold" />
           キャンセル
         </Button>
         <Button
@@ -176,45 +151,34 @@ export function TastingSessionForm({
         >
           {isNew ? (
             <>
-              <Plus size={20} weight="bold" />
-              セッションを作成
+              <Plus size={18} weight="bold" />
+              試飲感想を追加
             </>
           ) : (
-            <>
-              <Check size={20} weight="bold" />
-              更新する
-            </>
+            '更新する'
           )}
         </Button>
-      </motion.div>
+      </div>
 
       {/* Danger Zone（編集時のみ） */}
       {!isNew && onDelete && (
-        <motion.div
-          variants={itemVariants}
-          className="rounded-xl border border-edge bg-danger-subtle p-4"
-        >
+        <div className="rounded-lg border border-edge bg-surface p-4">
           <div className="flex items-center gap-1.5 mb-3">
             <Warning size={13} weight="fill" className="text-danger" />
-            <span className="text-xs font-bold text-danger tracking-wider">
+            <span className="text-xs font-bold text-danger">
               危険な操作
             </span>
           </div>
-          <motion.div
-            whileHover={{ x: [0, -3, 3, -2, 2, 0] }}
-            transition={{ duration: 0.4 }}
+          <Button
+            type="button"
+            variant="danger"
+            onClick={handleDelete}
+            className="w-full"
           >
-            <Button
-              type="button"
-              variant="danger"
-              onClick={handleDelete}
-              className="w-full"
-            >
-              <Trash size={16} weight="bold" />
-              この試飲セッションを削除する
-            </Button>
-          </motion.div>
-        </motion.div>
+            <Trash size={16} weight="bold" />
+            試飲感想を削除する
+          </Button>
+        </div>
       )}
     </motion.form>
   );

--- a/components/TastingSessionList.tsx
+++ b/components/TastingSessionList.tsx
@@ -3,20 +3,106 @@
 import { useState, useMemo, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { useRouter } from 'next/navigation';
-import Link from 'next/link';
 import { Coffee, Plus, Faders } from 'phosphor-react';
-import type { AppData } from '@/types';
+import type { AppData, TastingRecord, TastingSession } from '@/types';
 import { TastingSessionCarousel } from './TastingSessionCarousel';
 import { TastingSessionFilterModal } from './TastingSessionFilterModal';
 import { useMembers, getActiveMembers } from '@/hooks/useMembers';
 import { useAuth } from '@/lib/auth';
 import { useTastingFilters } from '@/hooks/useTastingFilters';
 import { motion } from 'framer-motion';
-import { Button, IconButton, Card } from '@/components/ui';
+import { Button, IconButton, EmptyState } from '@/components/ui';
+
+const SAMPLE_TASTING_PREFIX = 'sample-tasting-';
+
+const SAMPLE_SESSIONS = [
+  {
+    beanName: 'エチオピア イルガチェフェ',
+    roastLevel: '浅煎り',
+    comments: [
+      '花のような香りが強く、冷めるとレモンティーのような明るさが出ました。',
+      '酸味はきれいだけど少し軽め。朝の一杯にちょうどよさそうです。',
+      '香りの印象が一番残りました。甘みは控えめで後味がすっきりしています。',
+      '口に含んだ瞬間は華やかで、後半は少し紅茶っぽい余韻でした。',
+      '苦味が少ないので飲みやすいです。浅煎りが苦手な人にも説明しやすそう。',
+      '香りはかなり良いですが、もう少し甘さがあるとさらに好みです。',
+      '冷めてからの透明感がよく、試飲の変化を見るには面白い豆でした。',
+      '軽やかで明るい印象。お菓子と合わせるより単体で飲みたいです。',
+    ],
+  },
+  {
+    beanName: 'ブラジル ショコラ',
+    roastLevel: '中煎り',
+    comments: [
+      'ナッツ感とチョコっぽさがあって飲みやすいです。ミルクにも合いそう。',
+      '酸味が少なく、苦味も丸いので万人向けに感じました。',
+      '香りは穏やかですが、甘みとコクのバランスが良かったです。',
+      '後味に少しカカオ感が残ります。毎日飲むならこれが一番安定しそう。',
+      '派手さはないけど安心感があります。ホットでもアイスでも使いやすそう。',
+      '口当たりがやわらかく、苦味が尖っていないところが良いです。',
+      'もう少し香りが立つと嬉しいですが、味のまとまりは高いと思います。',
+      'ミルクを入れても味が消えなさそう。店頭向けに使いやすい印象です。',
+    ],
+  },
+  {
+    beanName: 'グアテマラ アンティグア',
+    roastLevel: '中深煎り',
+    comments: [
+      'ココアのような厚みがあり、後半に少しスパイス感がありました。',
+      '苦味と甘みのバランスがよく、ホットでゆっくり飲みたい味です。',
+      '口当たりがしっかりしていて、余韻も長めに残りました。',
+      '香ばしさが前に出ますが、重すぎないので飲み疲れしにくいです。',
+      '甘い焼き菓子と合わせると良さそう。酸味は控えめでした。',
+      '中深煎りらしいコクがあり、後味に少しビター感が残ります。',
+      '香りよりも味の厚みが印象的でした。安定した人気が出そうです。',
+      '温度が下がっても薄くならず、最後までコーヒー感が残りました。',
+    ],
+  },
+  {
+    beanName: 'コロンビア ウィラ',
+    roastLevel: '中煎り',
+    comments: [
+      '赤い果実っぽい酸味がありつつ、甘みもあって飲みやすいです。',
+      '温度が下がると酸味が少し前に出ます。香りは華やかでした。',
+      '全体的にまとまりがよく、試飲会でも説明しやすそうです。',
+      '酸味と甘みのバランスがよく、明るいけど尖っていない印象です。',
+      '飲み始めは軽く、後味に少しシロップのような甘さが残りました。',
+      '香りは控えめですが、味の輪郭が分かりやすいです。',
+      '冷めると果実感が出てきて、時間変化を見るのが楽しい豆でした。',
+      '苦味が弱めなので、酸味を楽しみたい人にすすめやすいと思います。',
+    ],
+  },
+  {
+    beanName: 'インドネシア マンデリン',
+    roastLevel: '深煎り',
+    comments: [
+      '重めのボディとハーブっぽい香りがあり、かなり個性的でした。',
+      '苦味はしっかりありますが、嫌な焦げ感は少ないです。',
+      '余韻が長く、アイスコーヒーにしても存在感が残りそうです。',
+      '土っぽさとスパイス感があり、好き嫌いは分かれそうですが印象的です。',
+      'ミルクを入れると丸くなりそう。ブラックだとかなり力強いです。',
+      '苦味の奥に甘さがあり、深煎り好きには刺さりそうです。',
+      '香りに独特の重さがあります。食後の一杯に向いていそうです。',
+      '後味が長く続くので、少量でも満足感がありました。',
+    ],
+  },
+] as const;
+
+const SAMPLE_REVIEWERS = [
+  { id: `${SAMPLE_TASTING_PREFIX}member-1`, name: '佐藤' },
+  { id: `${SAMPLE_TASTING_PREFIX}member-2`, name: '飯田' },
+  { id: `${SAMPLE_TASTING_PREFIX}member-3`, name: '鈴木' },
+  { id: `${SAMPLE_TASTING_PREFIX}member-4`, name: '田中' },
+  { id: `${SAMPLE_TASTING_PREFIX}member-5`, name: '高橋' },
+  { id: `${SAMPLE_TASTING_PREFIX}member-6`, name: '伊藤' },
+  { id: `${SAMPLE_TASTING_PREFIX}member-7`, name: '中村' },
+  { id: `${SAMPLE_TASTING_PREFIX}member-8`, name: '小林' },
+];
 
 interface TastingSessionListProps {
   data: AppData;
   onUpdate?: (newDataOrUpdater: AppData | ((currentData: AppData) => AppData)) => Promise<void> | void;
+  sampleButtonContainerId?: string;
   filterButtonContainerId?: string;
   filterButtonContainerIdMobile?: string;
 }
@@ -24,6 +110,7 @@ interface TastingSessionListProps {
 export function TastingSessionList({
   data,
   onUpdate,
+  sampleButtonContainerId,
   filterButtonContainerId,
   filterButtonContainerIdMobile,
 }: TastingSessionListProps) {
@@ -42,6 +129,9 @@ export function TastingSessionList({
   );
 
   const activeMemberCount = getActiveMembers(allMembers).length + (manager ? 1 : 0);
+  const [isEmptyPreview, setIsEmptyPreview] = useState(false);
+  const visibleTastingSessions = isEmptyPreview ? [] : tastingSessions;
+  const visibleTastingRecords = isEmptyPreview ? [] : tastingRecords;
 
   const {
     searchQuery,
@@ -56,14 +146,16 @@ export function TastingSessionList({
     setSelectedRoastLevels,
     filteredAndSortedSessions,
     activeFilterCount,
-  } = useTastingFilters(tastingSessions);
+  } = useTastingFilters(visibleTastingSessions);
 
   const [isFilterModalOpen, setIsFilterModalOpen] = useState(false);
   const [mounted, setMounted] = useState(false);
   const [containers, setContainers] = useState<{
+    sample: HTMLElement | null;
     desktop: HTMLElement | null;
     mobile: HTMLElement | null;
-  }>({ desktop: null, mobile: null });
+  }>({ sample: null, desktop: null, mobile: null });
+  const showDevDataButtons = process.env.NODE_ENV !== 'production' && !!onUpdate;
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- ハイドレーション後のポータル有効化に必要
@@ -72,11 +164,15 @@ export function TastingSessionList({
       const desktopEl = filterButtonContainerId
         ? document.getElementById(filterButtonContainerId)
         : null;
+      const sampleEl = sampleButtonContainerId
+        ? document.getElementById(sampleButtonContainerId)
+        : null;
       const mobileEl = filterButtonContainerIdMobile
         ? document.getElementById(filterButtonContainerIdMobile)
         : null;
 
       setContainers({
+        sample: sampleEl && sampleEl.getBoundingClientRect().width > 0 ? sampleEl : null,
         desktop: desktopEl && desktopEl.getBoundingClientRect().width > 0 ? desktopEl : null,
         mobile: mobileEl && mobileEl.getBoundingClientRect().width > 0 ? mobileEl : null,
       });
@@ -90,7 +186,7 @@ export function TastingSessionList({
       clearTimeout(timer);
       window.removeEventListener('resize', updateContainers);
     };
-  }, [filterButtonContainerId, filterButtonContainerIdMobile]);
+  }, [sampleButtonContainerId, filterButtonContainerId, filterButtonContainerIdMobile]);
 
   // AI分析結果をFirestoreに保存するコールバック
   const handleUpdateSession = (sessionId: string, aiAnalysis: string, recordCount: number) => {
@@ -129,22 +225,125 @@ export function TastingSessionList({
     setSelectedRoastLevels(filters.selectedRoastLevels);
   };
 
+  const handleAddSampleData = () => {
+    if (!onUpdate) return;
+
+    const now = new Date('2026-02-08T09:00:00.000Z');
+    const ownerId = userId ?? `${SAMPLE_TASTING_PREFIX}user`;
+    const sampleMembers = [
+      ...(manager ? [{ id: manager.id, name: manager.name }] : []),
+      ...getActiveMembers(allMembers).map((member) => ({ id: member.id, name: member.name })),
+    ];
+    const existingReviewerIds = new Set(sampleMembers.map((member) => member.id));
+    const reviewers = [
+      ...sampleMembers,
+      ...SAMPLE_REVIEWERS.filter((member) => !existingReviewerIds.has(member.id)),
+    ].slice(0, 8);
+
+    const sampleSessions: TastingSession[] = SAMPLE_SESSIONS.map((session, sessionIndex) => {
+      const createdAt = new Date(now);
+      createdAt.setDate(now.getDate() - sessionIndex);
+
+      return {
+        id: `${SAMPLE_TASTING_PREFIX}session-${sessionIndex + 1}`,
+        beanName: session.beanName,
+        roastLevel: session.roastLevel,
+        memo: '見た目確認用のテストデータです。',
+        createdAt: createdAt.toISOString(),
+        updatedAt: createdAt.toISOString(),
+        userId: ownerId,
+        aiAnalysis: `${session.beanName}は、${session.comments[0]} 複数人の感想でも方向性が揃っており、現場で共有しやすいサンプルです。`,
+        aiAnalysisUpdatedAt: createdAt.toISOString(),
+        aiAnalysisRecordCount: reviewers.length,
+      };
+    });
+
+    const sampleRecords: TastingRecord[] = SAMPLE_SESSIONS.flatMap((session, sessionIndex) => {
+      const tastingDate = new Date(now);
+      tastingDate.setDate(now.getDate() - sessionIndex);
+      const dateText = tastingDate.toISOString().split('T')[0];
+
+      return reviewers.map((reviewer, reviewerIndex) => {
+        const createdAt = new Date(tastingDate);
+        createdAt.setHours(9 + reviewerIndex, 15, 0, 0);
+        const base = 3 + ((sessionIndex + reviewerIndex) % 3);
+
+        return {
+          id: `${SAMPLE_TASTING_PREFIX}record-${sessionIndex + 1}-${reviewerIndex + 1}`,
+          sessionId: `${SAMPLE_TASTING_PREFIX}session-${sessionIndex + 1}`,
+          beanName: session.beanName,
+          tastingDate: dateText,
+          roastLevel: session.roastLevel,
+          bitterness: Math.min(5, session.roastLevel === '深煎り' ? base + 1 : base),
+          acidity: Math.max(1, session.roastLevel === '浅煎り' ? base + 1 : base - 1),
+          body: Math.min(5, session.roastLevel === '深煎り' || session.roastLevel === '中深煎り' ? base + 1 : base),
+          sweetness: Math.min(5, base),
+          aroma: Math.min(5, session.roastLevel === '浅煎り' ? base + 1 : base),
+          overallRating: Math.min(5, base),
+          overallImpression: `${reviewer.name}: ${session.comments[reviewerIndex]}`,
+          createdAt: createdAt.toISOString(),
+          updatedAt: createdAt.toISOString(),
+          userId: ownerId,
+          memberId: reviewer.id,
+        };
+      });
+    });
+
+    onUpdate((currentData) => ({
+      ...currentData,
+      tastingSessions: [
+        ...currentData.tastingSessions.filter((session) => !session.id.startsWith(SAMPLE_TASTING_PREFIX)),
+        ...sampleSessions,
+      ],
+      tastingRecords: [
+        ...currentData.tastingRecords.filter((record) => !record.id.startsWith(SAMPLE_TASTING_PREFIX)),
+        ...sampleRecords,
+      ],
+    }));
+  };
+
   const filterButtonDesktop = (
     <Button
       variant="surface"
+      size="sm"
       onClick={() => setIsFilterModalOpen(true)}
       badge={activeFilterCount}
       title="フィルター"
       aria-label="フィルター"
-      className="flex items-center gap-2"
+      className="!px-3 !py-2 gap-1.5"
     >
       <Faders
         size={20}
         weight={activeFilterCount > 0 ? 'fill' : 'bold'}
       />
-      <span className="whitespace-nowrap">フィルター</span>
+      <span className="text-xs sm:text-sm whitespace-nowrap">フィルター</span>
     </Button>
   );
+
+  const devDataButtonsDesktop = showDevDataButtons ? (
+    <div className="flex items-center gap-2">
+      {tastingSessions.length > 0 && (
+        <Button
+          variant="surface"
+          size="sm"
+          onClick={() => setIsEmptyPreview((current) => !current)}
+          className="!px-3 !py-2 gap-1.5"
+        >
+          <span className="text-xs sm:text-sm whitespace-nowrap">
+            {isEmptyPreview ? '元の表示に戻す' : '空表示を確認'}
+          </span>
+        </Button>
+      )}
+      <Button
+        variant="surface"
+        size="sm"
+        onClick={handleAddSampleData}
+        className="!px-3 !py-2 gap-1.5"
+      >
+        <span className="text-xs sm:text-sm whitespace-nowrap">テストデータを追加</span>
+      </Button>
+    </div>
+  ) : null;
 
   const filterButtonMobile = (
     <IconButton
@@ -159,40 +358,56 @@ export function TastingSessionList({
     </IconButton>
   );
 
-  if (tastingSessions.length === 0) {
+  if (visibleTastingSessions.length === 0) {
     return (
-      <div className="h-full flex items-center justify-center py-12 px-4">
+      <div className="min-h-[calc(100dvh-96px)] flex items-center justify-center px-4">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          className="max-w-md w-full"
+          className="w-full"
         >
-          <Card className="rounded-[3rem] p-10 text-center space-y-8">
-            <div className="relative mx-auto w-32 h-32 flex items-center justify-center">
-              <div className="relative flex items-center justify-center">
-                <Coffee size={64} weight="duotone" className="text-spot opacity-70" />
+          <EmptyState
+            size="md"
+            className="mx-auto max-w-sm"
+            icon={<Coffee size={40} weight="duotone" />}
+            title={isEmptyPreview ? '空表示プレビュー中' : '試飲感想がありません'}
+            description={isEmptyPreview ? '実データはそのままです。' : '最初の試飲感想を追加してください。'}
+            action={
+              <div className="flex flex-col gap-3">
+                {isEmptyPreview ? (
+                  <Button
+                    variant="primary"
+                    size="md"
+                    onClick={() => setIsEmptyPreview(false)}
+                    className="justify-center"
+                  >
+                    元の表示に戻す
+                  </Button>
+                ) : (
+                  <Button
+                    variant="primary"
+                    size="md"
+                    onClick={() => router.push('/tasting/sessions/new')}
+                    className="gap-2 justify-center"
+                  >
+                    <Plus size={18} weight="bold" />
+                    試飲感想を追加
+                  </Button>
+                )}
+
+                {showDevDataButtons && !isEmptyPreview && (
+                  <Button
+                    variant="surface"
+                    size="sm"
+                    onClick={handleAddSampleData}
+                    className="justify-center"
+                  >
+                    テストデータを追加
+                  </Button>
+                )}
               </div>
-            </div>
-
-            <div className="space-y-3">
-              <h3 className="text-2xl font-black tracking-tight text-ink">
-                試飲セッションがありません
-              </h3>
-              <p className="text-sm font-medium leading-relaxed text-ink-muted">
-                最初の試飲セッションを作成して、
-                <br />
-                コーヒーの奥深い世界を記録しましょう。
-              </p>
-            </div>
-
-            <Link
-              href="/tasting/sessions/new"
-              className="inline-flex items-center gap-3 px-8 py-4 text-white rounded-2xl font-black text-lg transition-all active:scale-95 bg-gradient-to-r from-spot to-spot/80 shadow-xl shadow-spot/20 hover:from-spot/90 hover:to-spot/70"
-            >
-              <Plus size={24} weight="bold" />
-              <span>セッションを開始</span>
-            </Link>
-          </Card>
+            }
+          />
         </motion.div>
       </div>
     );
@@ -201,6 +416,7 @@ export function TastingSessionList({
   return (
     <>
       {/* フィルターボタンを外部コンテナにPortalでレンダリング */}
+      {mounted && containers.sample && devDataButtonsDesktop && createPortal(devDataButtonsDesktop, containers.sample)}
       {mounted && containers.desktop && createPortal(filterButtonDesktop, containers.desktop)}
       {mounted && containers.mobile && createPortal(filterButtonMobile, containers.mobile)}
 
@@ -220,7 +436,7 @@ export function TastingSessionList({
         <div className="flex-1 min-h-0 overflow-y-hidden pt-4 pb-2">
           <TastingSessionCarousel
             sessions={filteredAndSortedSessions}
-            tastingRecords={tastingRecords}
+            tastingRecords={visibleTastingRecords}
             activeMemberCount={activeMemberCount}
             router={router}
             onUpdateSession={handleUpdateSession}

--- a/components/Toast.tsx
+++ b/components/Toast.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useContext, useEffect } from 'react';
 import { useToast, type Toast as ToastType } from '@/hooks/useToast';
-import { IoCheckmarkCircle, IoCloseCircle, IoInformationCircle, IoWarning } from 'react-icons/io5';
+import { IoCheckmarkCircle, IoClose, IoCloseCircle, IoInformationCircle, IoWarning } from 'react-icons/io5';
 import { IconButton } from '@/components/ui';
 
 const ToastContext = createContext<ReturnType<typeof useToast> | null>(null);
@@ -21,7 +21,7 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   return (
     <ToastContext.Provider value={toast}>
       {children}
-      <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 pointer-events-none">
+      <div className="fixed bottom-4 left-4 right-4 sm:left-auto sm:right-4 z-50 flex flex-col items-stretch sm:items-end gap-2 pointer-events-none">
         {toast.toasts.map((toastItem) => (
           <ToastItem key={toastItem.id} toast={toastItem} onClose={() => toast.removeToast(toastItem.id)} />
         ))}
@@ -40,26 +40,22 @@ function ToastItem({ toast, onClose }: { toast: ToastType; onClose: () => void }
     }
   }, [toast.duration, onClose]);
 
-  const toastStyleMap: Record<string, { bg: string; border: string; text: string }> = {
+  const toastStyleMap: Record<string, { border: string; icon: string }> = {
     success: {
-      bg: 'var(--color-success-subtle)',
-      border: 'var(--color-success)',
-      text: 'var(--color-success)',
+      border: 'border-l-success',
+      icon: 'text-success',
     },
     error: {
-      bg: 'var(--color-danger-subtle)',
-      border: 'var(--color-danger)',
-      text: 'var(--color-danger)',
+      border: 'border-l-danger',
+      icon: 'text-danger',
     },
     warning: {
-      bg: 'var(--color-warning-subtle)',
-      border: 'var(--color-warning)',
-      text: 'var(--color-warning)',
+      border: 'border-l-warning',
+      icon: 'text-warning',
     },
     info: {
-      bg: 'var(--color-spot-subtle)',
-      border: 'var(--color-spot)',
-      text: 'var(--color-spot)',
+      border: 'border-l-spot',
+      icon: 'text-spot',
     },
   };
 
@@ -80,25 +76,19 @@ function ToastItem({ toast, onClose }: { toast: ToastType; onClose: () => void }
 
   return (
     <div
-      className="border rounded-lg shadow-lg p-4 min-w-[300px] max-w-[500px] flex items-start gap-3 pointer-events-auto animate-in slide-in-from-right-full fade-in duration-300"
-      style={{
-        backgroundColor: styles.bg,
-        borderColor: styles.border,
-        color: styles.text,
-      }}
+      className={`w-full sm:w-auto sm:min-w-[300px] sm:max-w-[420px] rounded-lg border border-edge border-l-4 bg-surface shadow-card px-4 py-3 flex items-start gap-3 pointer-events-auto animate-in slide-in-from-bottom-2 sm:slide-in-from-right-4 fade-in duration-200 ${styles.border}`}
       role="alert"
     >
-      <div className="flex-shrink-0 mt-0.5">{getIcon()}</div>
-      <div className="flex-1 text-sm font-medium">{toast.message}</div>
+      <div className={`flex-shrink-0 mt-0.5 ${styles.icon}`}>{getIcon()}</div>
+      <div className="flex-1 text-sm font-medium leading-relaxed text-ink">{toast.message}</div>
       <IconButton
         onClick={onClose}
         variant="ghost"
         size="sm"
-        className="flex-shrink-0 opacity-60 hover:opacity-100 !min-h-0 !min-w-0 !p-0"
-        style={{ color: styles.text }}
+        className="flex-shrink-0 text-ink-muted hover:text-ink !min-h-0 !min-w-0 !p-0"
         aria-label="閉じる"
       >
-        <IoCloseCircle className="w-5 h-5" />
+        <IoClose className="w-4 h-4" />
       </IconButton>
     </div>
   );

--- a/components/defect-beans/FilterMenu.tsx
+++ b/components/defect-beans/FilterMenu.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { useState } from 'react';
-import { HiCheckCircle, HiSearch, HiCollection, HiXCircle } from 'react-icons/hi';
+import { HiCheckCircle, HiCollection, HiXCircle } from 'react-icons/hi';
 import { MdFilterList, MdSort, MdArrowUpward, MdArrowDownward } from 'react-icons/md';
-import { Button, Input, Modal } from '@/components/ui';
+import { Button, FilterModal, FilterOptionButton, FilterSearchInput, FilterSection, FilterSortOption } from '@/components/ui';
 
 type FilterOption = 'all' | 'shouldRemove' | 'shouldNotRemove';
 type SortOption = 'default' | 'createdAtDesc' | 'createdAtAsc' | 'nameAsc' | 'nameDesc';
@@ -75,73 +75,11 @@ export function FilterMenu({
         <span className="text-xs sm:text-sm">フィルター</span>
       </Button>
 
-      <Modal
+      <FilterModal
         show={showModal}
         onClose={() => setShowModal(false)}
-        contentClassName="bg-overlay rounded-2xl shadow-xl overflow-hidden w-full max-w-sm border border-edge"
-      >
-        <div className="p-5 flex flex-col gap-5">
-          <h2 className="text-base font-semibold text-ink">フィルター</h2>
-
-          {/* 検索セクション */}
-          <div className="flex flex-col gap-2">
-            <p className="text-xs font-medium text-ink-sub uppercase tracking-wide">検索</p>
-            <div className="relative">
-              <HiSearch className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-ink-muted z-10" />
-              <Input
-                type="text"
-                value={searchQuery}
-                onChange={(e) => onSearchChange(e.target.value)}
-                placeholder="名称や特徴で検索..."
-                className="pl-10 !py-2 !text-sm !min-h-[40px]"
-              />
-            </div>
-          </div>
-
-          {/* 絞り込みセクション */}
-          <div className="flex flex-col gap-2">
-            <p className="text-xs font-medium text-ink-sub uppercase tracking-wide">絞り込み</p>
-            <div className="flex gap-2">
-              {FILTER_OPTIONS.map(({ value, label, icon }) => (
-                <Button
-                  key={value}
-                  variant={filterOption === value ? 'primary' : 'surface'}
-                  size="sm"
-                  onClick={() => onFilterChange(value)}
-                  className="flex-1 !px-3 !py-2 gap-1.5 justify-center"
-                >
-                  {icon}
-                  <span className="text-xs">{label}</span>
-                </Button>
-              ))}
-            </div>
-          </div>
-
-          {/* ソートセクション */}
-          <div className="flex flex-col gap-2">
-            <p className="text-xs font-medium text-ink-sub uppercase tracking-wide">ソート</p>
-            <div className="flex flex-col gap-1">
-              {SORT_OPTIONS.map((option) => (
-                <Button
-                  key={option}
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => onSortChange(option)}
-                  className={`!min-h-0 w-full !justify-start !px-3 !py-2 !text-sm !rounded-lg gap-2 ${
-                    sortOption === option
-                      ? 'bg-surface !text-spot !font-medium'
-                      : '!text-ink-sub hover:bg-ground'
-                  }`}
-                >
-                  {getSortIcon(option)}
-                  <span>{getSortLabel(option)}</span>
-                  {sortOption === option && <HiCheckCircle className="h-4 w-4 text-spot ml-auto" />}
-                </Button>
-              ))}
-            </div>
-          </div>
-
-          {/* 閉じるボタン */}
+        title="フィルター"
+        footer={
           <Button
             variant="surface"
             size="sm"
@@ -150,8 +88,49 @@ export function FilterMenu({
           >
             閉じる
           </Button>
-        </div>
-      </Modal>
+        }
+      >
+        {/* 検索セクション */}
+        <FilterSection label="検索">
+          <FilterSearchInput
+            value={searchQuery}
+            onChange={onSearchChange}
+            placeholder="名称や特徴で検索..."
+          />
+        </FilterSection>
+
+        {/* 絞り込みセクション */}
+        <FilterSection label="絞り込み">
+          <div className="flex gap-2">
+            {FILTER_OPTIONS.map(({ value, label, icon }) => (
+              <FilterOptionButton
+                key={value}
+                selected={filterOption === value}
+                onClick={() => onFilterChange(value)}
+              >
+                {icon}
+                <span className="text-xs">{label}</span>
+              </FilterOptionButton>
+            ))}
+          </div>
+        </FilterSection>
+
+        {/* ソートセクション */}
+        <FilterSection label="ソート">
+          <div className="flex flex-col gap-1">
+            {SORT_OPTIONS.map((option) => (
+              <FilterSortOption
+                key={option}
+                selected={sortOption === option}
+                icon={getSortIcon(option)}
+                onClick={() => onSortChange(option)}
+              >
+                {getSortLabel(option)}
+              </FilterSortOption>
+            ))}
+          </div>
+        </FilterSection>
+      </FilterModal>
     </>
   );
 }

--- a/components/ui/FilterModal.test.tsx
+++ b/components/ui/FilterModal.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import {
+  FilterModal,
+  FilterOptionButton,
+  FilterSearchInput,
+  FilterSection,
+  FilterSortOption,
+} from './FilterModal';
+
+describe('FilterModal', () => {
+  it('共通のフィルターモーダル構造を表示する', () => {
+    render(
+      <FilterModal show={true} onClose={() => {}} title="フィルター">
+        <FilterSection label="検索">
+          <FilterSearchInput value="" onChange={() => {}} placeholder="名前で検索..." />
+        </FilterSection>
+      </FilterModal>
+    );
+
+    expect(screen.getByText('フィルター')).toBeInTheDocument();
+    expect(screen.getByText('検索')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('名前で検索...')).toBeInTheDocument();
+  });
+
+  it('下部アクションを表示してクリックできる', () => {
+    const onCancel = vi.fn();
+    const onApply = vi.fn();
+
+    render(
+      <FilterModal
+        show={true}
+        onClose={onCancel}
+        title="フィルター"
+        footer={
+          <>
+            <FilterOptionButton onClick={onCancel}>キャンセル</FilterOptionButton>
+            <FilterOptionButton selected onClick={onApply}>適用</FilterOptionButton>
+          </>
+        }
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+    fireEvent.click(screen.getByRole('button', { name: '適用' }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onApply).toHaveBeenCalledTimes(1);
+  });
+
+  it('選択中の選択肢とソート行を同じアクセント色で表示する', () => {
+    render(
+      <FilterModal show={true} onClose={() => {}} title="フィルター">
+        <FilterOptionButton selected>全て</FilterOptionButton>
+        <FilterSortOption selected icon={<span aria-hidden>↓</span>}>
+          新しい順
+        </FilterSortOption>
+      </FilterModal>
+    );
+
+    expect(screen.getByRole('button', { name: '全て' })).toHaveClass('!bg-spot');
+    expect(screen.getByRole('button', { name: '新しい順' })).toHaveClass('!text-spot');
+  });
+});

--- a/components/ui/FilterModal.tsx
+++ b/components/ui/FilterModal.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { HiCheckCircle, HiSearch } from 'react-icons/hi';
+import { Button, type ButtonProps } from './Button';
+import { Input, type InputProps } from './Input';
+import { Modal } from './Modal';
+
+export interface FilterModalProps {
+  show: boolean;
+  onClose: () => void;
+  title?: string;
+  headerAction?: ReactNode;
+  children?: ReactNode;
+  footer?: ReactNode;
+  className?: string;
+}
+
+export function FilterModal({
+  show,
+  onClose,
+  title = 'フィルター',
+  headerAction,
+  children,
+  footer,
+  className = '',
+}: FilterModalProps) {
+  return (
+    <Modal
+      show={show}
+      onClose={onClose}
+      contentClassName={`bg-overlay rounded-2xl shadow-xl overflow-hidden w-full max-w-sm border border-edge ${className}`}
+    >
+      <div className="p-5 flex flex-col gap-5">
+        <div className="flex items-center justify-between gap-3">
+          <h2 className="text-base font-semibold text-ink">{title}</h2>
+          {headerAction}
+        </div>
+        {children}
+        {footer && <div className="flex gap-3">{footer}</div>}
+      </div>
+    </Modal>
+  );
+}
+
+export interface FilterSectionProps {
+  label: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export function FilterSection({ label, children, className = '' }: FilterSectionProps) {
+  return (
+    <div className={`flex flex-col gap-2 ${className}`}>
+      <p className="text-xs font-medium text-ink-sub uppercase tracking-wide">{label}</p>
+      {children}
+    </div>
+  );
+}
+
+export interface FilterSearchInputProps extends Omit<InputProps, 'onChange'> {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function FilterSearchInput({
+  value,
+  onChange,
+  placeholder = '検索...',
+  className = '',
+  ...props
+}: FilterSearchInputProps) {
+  return (
+    <div className="relative">
+      <HiSearch className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-ink-muted z-10" />
+      <Input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className={`pl-10 !py-2 !text-sm !min-h-[40px] ${className}`}
+        {...props}
+      />
+    </div>
+  );
+}
+
+export interface FilterOptionButtonProps extends ButtonProps {
+  selected?: boolean;
+}
+
+export function FilterOptionButton({
+  selected = false,
+  className = '',
+  children,
+  ...props
+}: FilterOptionButtonProps) {
+  return (
+    <Button
+      variant={selected ? 'ghost' : 'surface'}
+      size="sm"
+      className={`flex-1 !rounded-lg !px-3 !py-2 gap-1.5 justify-center ${
+        selected ? '!bg-spot !text-white !border-spot' : ''
+      } ${className}`}
+      {...props}
+    >
+      {children}
+    </Button>
+  );
+}
+
+export interface FilterSortOptionProps extends ButtonProps {
+  selected?: boolean;
+  icon?: ReactNode;
+}
+
+export function FilterSortOption({
+  selected = false,
+  icon,
+  className = '',
+  children,
+  ...props
+}: FilterSortOptionProps) {
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className={`!min-h-0 w-full !justify-start !px-3 !py-2 !text-sm !rounded-lg gap-2 [-webkit-tap-highlight-color:transparent] ${
+        selected
+          ? '!bg-spot-surface !text-spot !font-bold !border !border-spot/30 shadow-sm active:!bg-spot-surface'
+          : '!border !border-transparent !text-ink-sub hover:!bg-ground active:!bg-ground'
+      } ${className}`}
+      {...props}
+    >
+      {icon}
+      <span>{children}</span>
+      {selected && <HiCheckCircle className="h-4 w-4 text-spot ml-auto" />}
+    </Button>
+  );
+}

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -53,6 +53,9 @@ export type { CardProps } from './Card';
 export { Modal } from './Modal';
 export type { ModalProps } from './Modal';
 
+export { FilterModal, FilterOptionButton, FilterSearchInput, FilterSection, FilterSortOption } from './FilterModal';
+export type { FilterModalProps, FilterOptionButtonProps, FilterSearchInputProps, FilterSectionProps, FilterSortOptionProps } from './FilterModal';
+
 export { Dialog } from './Dialog';
 export type { DialogProps } from './Dialog';
 


### PR DESCRIPTION
## 概要
- 試飲感想一覧・カード・フォームの表示を調整
- フィルターUIを共通コンポーネント化し、豆図鑑フィルターと見た目を統一
- Toast通知、空状態、スマホ/デスクトップの試飲カード表示を整理

## 検証
- npm run lint
- npm run build

## 補足
- drip-guide 系の未コミット変更は別件としてPRに含めていません。