### PR TITLE
fix: 開発者モードをパスワードで有効化する

### DIFF
--- a/hooks/useDeveloperMode.test.ts
+++ b/hooks/useDeveloperMode.test.ts
@@ -1,0 +1,36 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { useDeveloperMode } from './useDeveloperMode';
+
+describe('useDeveloperMode', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('4869 の入力で開発者モードを有効化できる', () => {
+    const { result } = renderHook(() => useDeveloperMode());
+
+    let success = false;
+    act(() => {
+      success = result.current.enableDeveloperMode('4869');
+    });
+
+    expect(success).toBe(true);
+    expect(result.current.isEnabled).toBe(true);
+    expect(localStorage.getItem('roastplus_developer_mode')).toBe('true');
+  });
+
+  it('4869 以外の入力では開発者モードを有効化できない', () => {
+    const { result } = renderHook(() => useDeveloperMode());
+
+    let success = true;
+    act(() => {
+      success = result.current.enableDeveloperMode('wrong-password');
+    });
+
+    expect(success).toBe(false);
+    expect(result.current.isEnabled).toBe(false);
+    expect(localStorage.getItem('roastplus_developer_mode')).toBeNull();
+  });
+});

--- a/hooks/useDeveloperMode.ts
+++ b/hooks/useDeveloperMode.ts
@@ -1,94 +1,35 @@
 'use client';
 
 import { useState, useCallback, useEffect } from 'react';
-import { getIdTokenResult, type User } from 'firebase/auth';
-import { useAuth } from '@/lib/auth';
 
+const DEVELOPER_MODE_PASSWORD = '4869';
 const STORAGE_KEY = 'roastplus_developer_mode';
-const DEVELOPER_EMAIL_ALLOWLIST = new Set(
-  (process.env.NEXT_PUBLIC_DEVELOPER_EMAILS || '')
-    .split(',')
-    .map((email) => email.trim().toLowerCase())
-    .filter((email) => email.length > 0)
-);
-
-function hasDeveloperClaim(user: User): Promise<boolean> {
-  return getIdTokenResult(user)
-    .then((token) => {
-      const { claims } = token;
-      return (
-        claims.developerMode === true ||
-        claims.developer === true ||
-        claims.isDeveloper === true
-      );
-    })
-    .catch(() => false);
-}
-
-async function isAuthorizedDeveloperUser(user: User): Promise<boolean> {
-  const email = user.email?.toLowerCase();
-  if (DEVELOPER_EMAIL_ALLOWLIST.size > 0 && email && DEVELOPER_EMAIL_ALLOWLIST.has(email)) {
-    return true;
-  }
-
-  return hasDeveloperClaim(user);
-}
 
 export function useDeveloperMode() {
-  const { user, loading: authLoading } = useAuth();
   const [isEnabled, setIsEnabled] = useState(false);
-  const [canUseDeveloperMode, setCanUseDeveloperMode] = useState(false);
   const [isLoading, setIsLoading] = useState<boolean>(typeof window === 'undefined');
-
-  const refreshPermissions = useCallback(async () => {
-    if (typeof window === 'undefined') {
-      return;
-    }
-
-    if (!user) {
-      setCanUseDeveloperMode(false);
-      setIsEnabled(false);
-      localStorage.removeItem(STORAGE_KEY);
-      setIsLoading(false);
-      return;
-    }
-
-    const isAllowed = await isAuthorizedDeveloperUser(user);
-    setCanUseDeveloperMode(isAllowed);
-    if (isAllowed) {
-      setIsEnabled(localStorage.getItem(STORAGE_KEY) === 'true');
-    } else {
-      localStorage.removeItem(STORAGE_KEY);
-      setIsEnabled(false);
-    }
-    setIsLoading(false);
-  }, [user]);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
       return;
     }
 
-    if (authLoading) {
-      return;
-    }
-
     queueMicrotask(() => {
-      void refreshPermissions();
+      setIsEnabled(localStorage.getItem(STORAGE_KEY) === 'true');
+      setIsLoading(false);
     });
-  }, [authLoading, refreshPermissions]);
+  }, []);
 
   // 開発者モードを有効化
-  const enableDeveloperMode = useCallback((_password?: string): boolean => {
-    void _password;
-    if (!canUseDeveloperMode || typeof window === 'undefined') {
+  const enableDeveloperMode = useCallback((password?: string): boolean => {
+    if (password !== DEVELOPER_MODE_PASSWORD || typeof window === 'undefined') {
       return false;
     }
 
     localStorage.setItem(STORAGE_KEY, 'true');
     setIsEnabled(true);
     return true;
-  }, [canUseDeveloperMode]);
+  }, []);
 
   // 開発者モードを無効化
   const disableDeveloperMode = useCallback(() => {


### PR DESCRIPTION
## Summary
- 開発者モードを 4869 の入力で有効化する挙動に戻しました。
- 4869 と誤入力のテストを追加しました。

## Test Plan
- npm run test:run
- npm run build（Firebase公開設定はダミー環境変数を指定）