### PR TITLE
feat(clock): 作業チャイムのテスト機能を追加

### DIFF
--- a/app/clock/page.tsx
+++ b/app/clock/page.tsx
@@ -99,6 +99,7 @@ export default function ClockPage() {
     activeChime,
     isAudioEnabled,
     enableAudio,
+    testWorkChime,
     updateSettings: updateWorkChimeSettings,
     dismissActiveChime,
   } = useWorkChime(now);
@@ -113,6 +114,11 @@ export default function ClockPage() {
     return () => window.clearTimeout(timer);
   }, [previewChime]);
   const displayedChime = previewChime ?? activeChime;
+
+  const handleTestWorkChime = useCallback((kind: WorkChimeKind) => {
+    setShowSettings(false);
+    testWorkChime(kind);
+  }, [testWorkChime]);
 
   const colors = getThemeColors(settings.theme);
   const fontFamily = getFontFamily(settings.fontKey);
@@ -256,6 +262,7 @@ export default function ClockPage() {
         onUpdate={updateSettings}
         onWorkChimeUpdate={updateWorkChimeSettings}
         onEnableWorkChimeAudio={enableAudio}
+        onTestWorkChime={handleTestWorkChime}
         onReset={resetSettings}
         onClose={() => setShowSettings(false)}
       />

--- a/components/clock/ClockSettingsModal.test.tsx
+++ b/components/clock/ClockSettingsModal.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ClockSettingsModal } from './ClockSettingsModal';
+import { DEFAULT_CLOCK_SETTINGS } from '@/lib/clockSettings';
+import { DEFAULT_WORK_CHIME_SETTINGS, type WorkChimeKind } from '@/lib/workChime';
+
+vi.mock('framer-motion', () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: {
+    div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+      <div {...props}>{children}</div>
+    ),
+  },
+}));
+
+describe('ClockSettingsModal', () => {
+  const defaultProps = {
+    show: true,
+    settings: DEFAULT_CLOCK_SETTINGS,
+    workChimeSettings: DEFAULT_WORK_CHIME_SETTINGS,
+    isWorkChimeAudioEnabled: true,
+    onUpdate: vi.fn(),
+    onWorkChimeUpdate: vi.fn(),
+    onEnableWorkChimeAudio: vi.fn(),
+    onTestWorkChime: vi.fn<(kind: WorkChimeKind) => void>(),
+    onReset: vi.fn(),
+    onClose: vi.fn(),
+  };
+
+  it('作業チャイムのテストボタンを表示する', () => {
+    render(<ClockSettingsModal {...defaultProps} />);
+
+    expect(screen.getByRole('button', { name: '休憩開始をテスト' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '作業開始をテスト' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '掃除開始をテスト' })).toBeInTheDocument();
+    expect(screen.getByText('音声アナウンス（未実装）')).toBeInTheDocument();
+  });
+
+  it('テストボタンから該当するチャイム種別を通知する', () => {
+    const onTestWorkChime = vi.fn<(kind: WorkChimeKind) => void>();
+
+    render(<ClockSettingsModal {...defaultProps} onTestWorkChime={onTestWorkChime} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '休憩開始をテスト' }));
+    fireEvent.click(screen.getByRole('button', { name: '作業開始をテスト' }));
+    fireEvent.click(screen.getByRole('button', { name: '掃除開始をテスト' }));
+
+    expect(onTestWorkChime).toHaveBeenNthCalledWith(1, 'break');
+    expect(onTestWorkChime).toHaveBeenNthCalledWith(2, 'work-start');
+    expect(onTestWorkChime).toHaveBeenNthCalledWith(3, 'cleanup-start');
+  });
+});

--- a/components/clock/ClockSettingsModal.tsx
+++ b/components/clock/ClockSettingsModal.tsx
@@ -12,7 +12,7 @@ import {
   getThemeColors,
   getFontFamily,
 } from '@/lib/clockSettings';
-import type { WorkChimeSettings } from '@/lib/workChime';
+import type { WorkChimeKind, WorkChimeSettings } from '@/lib/workChime';
 
 interface ClockSettingsModalProps {
   show: boolean;
@@ -22,6 +22,7 @@ interface ClockSettingsModalProps {
   onUpdate: (patch: Partial<ClockSettings>) => void;
   onWorkChimeUpdate: (patch: Partial<WorkChimeSettings>) => void;
   onEnableWorkChimeAudio: () => void;
+  onTestWorkChime: (kind: WorkChimeKind) => void;
   onReset: () => void;
   onClose: () => void;
 }
@@ -37,6 +38,7 @@ export function ClockSettingsModal({
   onUpdate,
   onWorkChimeUpdate,
   onEnableWorkChimeAudio,
+  onTestWorkChime,
   onReset,
   onClose,
 }: ClockSettingsModalProps) {
@@ -288,10 +290,55 @@ export function ClockSettingsModal({
                     </div>
                   )}
 
+                  <div className="py-3 px-1">
+                    <div className="flex items-center justify-between gap-3">
+                      <div>
+                        <span className="text-sm font-medium block" style={{ color: themeColors.text }}>
+                          テスト再生
+                        </span>
+                        <span className="text-xs" style={{ color: themeColors.uiText }}>
+                          画面表示と音を確認します
+                        </span>
+                      </div>
+                    </div>
+                    <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-3">
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        size="sm"
+                        onClick={() => onTestWorkChime('break')}
+                        aria-label="休憩開始をテスト"
+                        className="w-full !px-3"
+                      >
+                        休憩開始
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        size="sm"
+                        onClick={() => onTestWorkChime('work-start')}
+                        aria-label="作業開始をテスト"
+                        className="w-full !px-3"
+                      >
+                        作業開始
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        size="sm"
+                        onClick={() => onTestWorkChime('cleanup-start')}
+                        aria-label="掃除開始をテスト"
+                        className="w-full !px-3"
+                      >
+                        掃除開始
+                      </Button>
+                    </div>
+                  </div>
+
                   <div className="flex items-center justify-between py-3 px-1 min-h-[44px]">
                     <div>
                       <span className="text-sm font-medium block" style={{ color: themeColors.text }}>
-                        音声アナウンス
+                        音声アナウンス（未実装）
                       </span>
                       <span className="text-xs" style={{ color: themeColors.uiText }}>
                         初期値はOFFです

--- a/components/clock/WorkChimeAlert.test.tsx
+++ b/components/clock/WorkChimeAlert.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { WorkChimeAlert } from './WorkChimeAlert';
+import type { ThemeColors } from '@/lib/clockSettings';
+import type { DueWorkChime } from '@/lib/workChime';
+
+const colors: ThemeColors = {
+  bg: '#ffffff',
+  text: '#211714',
+  accent: '#d97706',
+  accentSub: 'rgba(217, 119, 6, 0.7)',
+  dateText: 'rgba(33, 23, 20, 0.6)',
+  uiText: '#6b7280',
+  uiBg: 'rgba(0, 0, 0, 0.05)',
+};
+
+const breakChime: DueWorkChime = {
+  period: {
+    id: 'test-break',
+    start: '02:41',
+    end: '02:41',
+    kind: 'break',
+  },
+  time: '02:41',
+  kind: 'break',
+  label: '休憩開始',
+  playKey: 'test-break',
+  message: '休憩時間です',
+};
+
+describe('WorkChimeAlert', () => {
+  it('チャイムの時刻、種別、メッセージを表示する', () => {
+    render(<WorkChimeAlert chime={breakChime} colors={colors} onClose={vi.fn()} />);
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getByText('02:41 休憩開始')).toBeInTheDocument();
+    expect(screen.getByText('休憩時間です')).toBeInTheDocument();
+  });
+
+  it('閉じるボタンで通知を閉じる', () => {
+    const onClose = vi.fn();
+    render(<WorkChimeAlert chime={breakChime} colors={colors} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '作業チャイム表示を閉じる' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('チャイムがないときは表示しない', () => {
+    render(<WorkChimeAlert chime={null} colors={colors} onClose={vi.fn()} />);
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+});

--- a/components/clock/WorkChimeAlert.tsx
+++ b/components/clock/WorkChimeAlert.tsx
@@ -16,35 +16,26 @@ export function WorkChimeAlert({ chime, colors, onClose }: WorkChimeAlertProps) 
   if (!chime) return null;
 
   const accentColor = chime.kind === 'break'
-    ? '#16a34a'
+    ? '#0891b2'
     : chime.kind === 'cleanup-start'
       ? '#4b5563'
       : '#d97706';
-  const softAccent = chime.kind === 'break'
-    ? 'rgba(22, 163, 74, 0.14)'
-    : chime.kind === 'cleanup-start'
-      ? 'rgba(75, 85, 99, 0.14)'
-      : 'rgba(217, 119, 6, 0.16)';
 
   return (
     <div
-      className="absolute inset-0 z-30 grid place-items-center px-5 py-16 backdrop-blur-[2px]"
+      className="absolute inset-0 z-30 grid place-items-center px-5 py-16 backdrop-blur-[1px]"
       style={{ backgroundColor: `${colors.bg}b8` }}
     >
       <div
-        className="relative flex min-h-[300px] w-full max-w-4xl flex-col items-center justify-center overflow-hidden rounded-[18px] border px-8 py-12 text-center shadow-2xl sm:min-h-[330px] sm:px-14"
+        className="relative flex min-h-[290px] w-full max-w-4xl flex-col items-center justify-center overflow-hidden rounded-lg border border-t-[8px] px-8 py-12 text-center shadow-[0_16px_38px_rgba(33,23,20,0.10)] sm:min-h-[330px] sm:px-14"
         style={{
           backgroundColor: colors.bg,
           borderColor: colors.uiBg,
-          boxShadow: '0 18px 64px rgba(33, 23, 20, 0.16)',
+          borderTopColor: accentColor,
         }}
         role="status"
         aria-live="polite"
       >
-        <div
-          className="absolute left-7 right-7 top-6 h-[5px] rounded-full"
-          style={{ backgroundColor: accentColor }}
-        />
         <div className="absolute right-5 top-5">
           <IconButton
             variant="ghost"
@@ -56,13 +47,13 @@ export function WorkChimeAlert({ chime, colors, onClose }: WorkChimeAlertProps) 
           </IconButton>
         </div>
         <div
-          className="rounded-full px-5 py-1.5 text-2xl font-black sm:text-4xl"
-          style={{ backgroundColor: softAccent, color: accentColor }}
+          className="text-[clamp(1.75rem,4.2vw,2.875rem)] font-black leading-tight"
+          style={{ color: accentColor, fontFeatureSettings: '"tnum"' }}
         >
           {chime.time} {chime.label}
         </div>
         <div
-          className="mt-5 whitespace-nowrap text-[clamp(4.5rem,9.8vw,8rem)] font-black leading-[1.04]"
+          className="mt-5 text-[clamp(3.875rem,10vw,7.25rem)] font-black leading-[1.02]"
           style={{ color: colors.text }}
         >
           {chime.message}

--- a/hooks/useWorkChime.test.tsx
+++ b/hooks/useWorkChime.test.tsx
@@ -104,4 +104,33 @@ describe('useWorkChime', () => {
 
     expect(result.current.activeChime).toBeNull();
   });
+
+  it('テスト用チャイムは通知を表示して音を鳴らす', () => {
+    const { result } = renderHook(() => useWorkChime(localDate(10, 40)));
+
+    act(() => {
+      result.current.testWorkChime('work-start');
+    });
+
+    expect(playWorkChimeMock).toHaveBeenCalledWith('work-start', { volume: 0.8 });
+    expect(result.current.isAudioEnabled).toBe(true);
+    expect(result.current.activeChime?.label).toBe('作業開始');
+    expect(result.current.activeChime?.message).toBe('作業開始です');
+  });
+
+  it('テスト用チャイムも5秒後に通知を消す', () => {
+    const { result } = renderHook(() => useWorkChime(localDate(10, 40)));
+
+    act(() => {
+      result.current.testWorkChime('break');
+    });
+
+    expect(result.current.activeChime).not.toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(result.current.activeChime).toBeNull();
+  });
 });

--- a/hooks/useWorkChime.ts
+++ b/hooks/useWorkChime.ts
@@ -7,11 +7,13 @@ import {
   getCurrentWorkChimePeriod,
   getDueWorkChime,
   getNextWorkChime,
+  getWorkChimeMessage,
   getWorkChimeSettings,
   setWorkChimeSettings,
   type CurrentWorkChimePeriod,
   type DueWorkChime,
   type NextWorkChime,
+  type WorkChimeKind,
   type WorkChimeSettings,
 } from '@/lib/workChime';
 
@@ -22,12 +24,20 @@ interface UseWorkChimeReturn {
   activeChime: DueWorkChime | null;
   isAudioEnabled: boolean;
   enableAudio: () => void;
+  testWorkChime: (kind: WorkChimeKind) => void;
   updateSettings: (patch: Partial<WorkChimeSettings>) => void;
   dismissActiveChime: () => void;
 }
 
 function loadInitialSettings(): WorkChimeSettings {
   return getWorkChimeSettings();
+}
+
+function getTestChimeLabel(kind: WorkChimeKind): string {
+  if (kind === 'break') return '休憩開始';
+  if (kind === 'cleanup-start') return '掃除開始';
+  if (kind === 'work-resume') return '作業再開';
+  return '作業開始';
 }
 
 export function useWorkChime(now: Date | null): UseWorkChimeReturn {
@@ -57,6 +67,40 @@ export function useWorkChime(now: Date | null): UseWorkChimeReturn {
       return next;
     });
   }, []);
+
+  const testWorkChime = useCallback((kind: WorkChimeKind) => {
+    const testTime = now ?? new Date();
+    const hours = String(testTime.getHours()).padStart(2, '0');
+    const minutes = String(testTime.getMinutes()).padStart(2, '0');
+    const time = `${hours}:${minutes}`;
+    const chime: DueWorkChime = {
+      period: {
+        id: `test-${kind}`,
+        start: time,
+        end: time,
+        kind: kind === 'break' ? 'break' : kind === 'cleanup-start' ? 'cleanup' : 'work',
+      },
+      time,
+      kind,
+      label: getTestChimeLabel(kind),
+      playKey: `test-${kind}-${Date.now()}`,
+      message: getWorkChimeMessage(kind),
+    };
+
+    if (timerRef.current) clearTimeout(timerRef.current);
+
+    setIsAudioEnabled(true);
+    setActiveChime(chime);
+
+    if (settings.soundEnabled) {
+      playWorkChime(kind, { volume: settings.volume });
+    }
+
+    timerRef.current = setTimeout(() => {
+      setActiveChime(null);
+      timerRef.current = null;
+    }, 5000);
+  }, [now, settings.soundEnabled, settings.volume]);
 
   const currentPeriod = now ? getCurrentWorkChimePeriod(now, settings) : null;
   const nextChime = now ? getNextWorkChime(now, settings) : null;
@@ -94,6 +138,7 @@ export function useWorkChime(now: Date | null): UseWorkChimeReturn {
     activeChime,
     isAudioEnabled,
     enableAudio,
+    testWorkChime,
     updateSettings,
     dismissActiveChime,
   };


### PR DESCRIPTION
## Summary
- 時計設定に休憩開始・作業開始・掃除開始の作業チャイムテストボタンを追加
- テスト実行時に実際の中央通知表示とチャイム音を確認できるように変更
- 作業チャイム通知の見た目をA案ベースに整理し、休憩色を青緑に変更
- 未実装の音声アナウンス表示を明示

## Test Plan
- [x] npm run test:run
- [x] npm run build