### PR TITLE
fix: App Checkを有効化

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your-project.firebasestorage.app
 NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=123456789012
 NEXT_PUBLIC_FIREBASE_APP_ID=1:123456789012:web:abcdef1234567890
 
+# App Check / reCAPTCHA v3
+NEXT_PUBLIC_RECAPTCHA_SITE_KEY=your_recaptcha_site_key
+
 # Developer mode
 NEXT_PUBLIC_DEVELOPER_EMAILS=developer@example.com,admin@example.com
 

--- a/functions/src/ocr-schedule.ts
+++ b/functions/src/ocr-schedule.ts
@@ -24,6 +24,7 @@ export const ocrScheduleFromImage = onCall(
     timeoutSeconds: 300, // 5分
     memory: '512MiB',
     secrets: ['OPENAI_API_KEY'], // Google Vision API Keyは不要になったため削除
+    enforceAppCheck: true,
   },
   async (request) => {
     // 認証チェック

--- a/functions/src/tasting-analysis.ts
+++ b/functions/src/tasting-analysis.ts
@@ -23,6 +23,7 @@ export const analyzeTastingSession = onCall(
     timeoutSeconds: 60,
     memory: '256MiB',
     secrets: ['OPENAI_API_KEY'],
+    enforceAppCheck: true,
   },
   async (request): Promise<TastingAnalysisResponse> => {
     // 認証チェック

--- a/lib/appCheck.test.ts
+++ b/lib/appCheck.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockInitializeAppCheck = vi.fn();
+const mockReCaptchaV3Provider = vi.fn(function MockProvider(this: { siteKey: string }, siteKey: string) {
+  this.siteKey = siteKey;
+});
+
+vi.mock('firebase/app-check', () => ({
+  initializeAppCheck: (...args: unknown[]) => mockInitializeAppCheck(...args),
+  ReCaptchaV3Provider: mockReCaptchaV3Provider,
+}));
+
+describe('initializeRoastPlusAppCheck', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    Object.defineProperty(window, '__ROASTPLUS_APP_CHECK_INITIALIZED__', {
+      configurable: true,
+      value: false,
+      writable: true,
+    });
+  });
+
+  it('サイトキーがある場合はApp Checkを初期化する', async () => {
+    const { initializeRoastPlusAppCheck } = await import('./appCheck');
+    const app = {};
+
+    initializeRoastPlusAppCheck(app, { siteKey: 'site-key' });
+
+    expect(mockReCaptchaV3Provider).toHaveBeenCalledWith('site-key');
+    expect(mockInitializeAppCheck).toHaveBeenCalledWith(app, {
+      provider: expect.objectContaining({ siteKey: 'site-key' }),
+      isTokenAutoRefreshEnabled: true,
+    });
+    expect(window.__ROASTPLUS_APP_CHECK_INITIALIZED__).toBe(true);
+  });
+
+  it('Functions Emulator利用時は初期化しない', async () => {
+    vi.stubEnv('NEXT_PUBLIC_FIREBASE_FUNCTIONS_EMULATOR', 'true');
+    const { initializeRoastPlusAppCheck } = await import('./appCheck');
+
+    initializeRoastPlusAppCheck({}, { siteKey: 'site-key' });
+
+    expect(mockInitializeAppCheck).not.toHaveBeenCalled();
+  });
+
+  it('すでに初期化済みなら二重初期化しない', async () => {
+    window.__ROASTPLUS_APP_CHECK_INITIALIZED__ = true;
+    const { initializeRoastPlusAppCheck } = await import('./appCheck');
+
+    initializeRoastPlusAppCheck({}, { siteKey: 'site-key' });
+
+    expect(mockInitializeAppCheck).not.toHaveBeenCalled();
+  });
+});

--- a/lib/appCheck.ts
+++ b/lib/appCheck.ts
@@ -1,0 +1,43 @@
+import type { FirebaseApp } from 'firebase/app';
+import { initializeAppCheck, ReCaptchaV3Provider } from 'firebase/app-check';
+
+const DEFAULT_RECAPTCHA_SITE_KEY = '6Ld3s_csAAAAAE_z_o109tYNXPrIcuHiEpQ1LdkT';
+
+interface AppCheckOptions {
+  siteKey?: string;
+}
+
+declare global {
+  interface Window {
+    __ROASTPLUS_APP_CHECK_INITIALIZED__?: boolean;
+  }
+}
+
+function getRecaptchaSiteKey(siteKey?: string): string {
+  return (siteKey ?? process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY ?? DEFAULT_RECAPTCHA_SITE_KEY).trim();
+}
+
+export function initializeRoastPlusAppCheck(app: FirebaseApp, options: AppCheckOptions = {}): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  if (process.env.NEXT_PUBLIC_FIREBASE_FUNCTIONS_EMULATOR === 'true') {
+    return;
+  }
+
+  if (window.__ROASTPLUS_APP_CHECK_INITIALIZED__) {
+    return;
+  }
+
+  const siteKey = getRecaptchaSiteKey(options.siteKey);
+  if (!siteKey) {
+    return;
+  }
+
+  initializeAppCheck(app, {
+    provider: new ReCaptchaV3Provider(siteKey),
+    isTokenAutoRefreshEnabled: true,
+  });
+  window.__ROASTPLUS_APP_CHECK_INITIALIZED__ = true;
+}

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -2,6 +2,7 @@ import { initializeApp, getApps } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { connectFunctionsEmulator, getFunctions } from 'firebase/functions';
 import { getFirestore } from 'firebase/firestore';
+import { initializeRoastPlusAppCheck } from './appCheck';
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -22,6 +23,8 @@ declare global {
 }
 
 const functionsInstance = getFunctions(app);
+
+initializeRoastPlusAppCheck(app);
 
 if (
   typeof window !== 'undefined' &&


### PR DESCRIPTION
## 概要
- Firebase App Check を reCAPTCHA v3 で初期化
- OCR / テイスティング分析の callable Functions に App Check 強制を追加
- reCAPTCHA サイトキー用の環境変数例を追加

## 補足
- サイトキーは公開前提の値です
- シークレットキーは Firebase Console 側だけで扱い、コードには含めません

## 検証
- npm run lint
- npm run test:run
- npm run build
- npm --prefix functions run build