### PR TITLE
fix: FunctionsのAdmin初期化を修正

### DIFF
--- a/functions/src/rate-limit-admin.test.ts
+++ b/functions/src/rate-limit-admin.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGetApps, mockGetApp, mockInitializeApp, mockGetFirestore, mockRunTransaction } = vi.hoisted(() => ({
+  mockGetApps: vi.fn(),
+  mockGetApp: vi.fn(),
+  mockInitializeApp: vi.fn(),
+  mockGetFirestore: vi.fn(),
+  mockRunTransaction: vi.fn(),
+}));
+
+vi.mock('firebase-admin/app', () => ({
+  getApps: mockGetApps,
+  getApp: mockGetApp,
+  initializeApp: mockInitializeApp,
+}));
+
+vi.mock('firebase-admin/firestore', () => ({
+  FieldValue: {
+    increment: (value: number) => ({ type: 'increment', value }),
+    serverTimestamp: () => ({ type: 'serverTimestamp' }),
+  },
+  getFirestore: mockGetFirestore,
+}));
+
+describe('assertDailyUsageLimit admin app initialization', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    const doc = {};
+    const collection = vi.fn(() => ({
+      doc: vi.fn(() => doc),
+    }));
+    const tx = {
+      get: vi.fn(async () => ({
+        exists: false,
+        get: vi.fn(),
+      })),
+      set: vi.fn(),
+    };
+
+    mockRunTransaction.mockImplementation(async (callback: (transaction: typeof tx) => Promise<void>) => {
+      await callback(tx);
+    });
+    mockGetFirestore.mockImplementation((app?: unknown) => {
+      if (!app) {
+        throw new Error('The default Firebase app does not exist.');
+      }
+      return {
+        collection,
+        runTransaction: mockRunTransaction,
+      };
+    });
+  });
+
+  it('デフォルト以外のAdmin appだけが存在してもデフォルトappを初期化してFirestoreを使う', async () => {
+    const namedApp = { name: 'named' };
+    const defaultApp = { name: '[DEFAULT]' };
+    mockGetApps.mockReturnValue([namedApp]);
+    mockGetApp.mockImplementation(() => {
+      const error = new Error('The default Firebase app does not exist.') as Error & { code?: string };
+      error.code = 'app/no-app';
+      throw error;
+    });
+    mockInitializeApp.mockReturnValue(defaultApp);
+
+    const { assertDailyUsageLimit } = await import('./rate-limit');
+
+    await expect(
+      assertDailyUsageLimit({
+        uid: 'user-id',
+        functionName: 'ocrScheduleFromImage',
+        limit: 30,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(mockInitializeApp).toHaveBeenCalledTimes(1);
+    expect(mockGetFirestore).toHaveBeenCalledWith(defaultApp);
+  });
+});

--- a/functions/src/rate-limit-helpers.ts
+++ b/functions/src/rate-limit-helpers.ts
@@ -1,5 +1,26 @@
 const DEFAULT_TIME_ZONE = 'Asia/Tokyo';
 
+interface DefaultAdminAppDependencies<TApp> {
+  getApp: () => TApp;
+  initializeApp: () => TApp;
+}
+
+export function getDefaultAdminApp<TApp>({
+  getApp,
+  initializeApp,
+}: DefaultAdminAppDependencies<TApp>): TApp {
+  try {
+    return getApp();
+  } catch (error) {
+    const appError = error as { code?: string };
+    if (appError.code !== 'app/no-app') {
+      throw error;
+    }
+
+    return initializeApp();
+  }
+}
+
 export function getUsageWindowId(date = new Date(), timeZone = DEFAULT_TIME_ZONE): string {
   return new Intl.DateTimeFormat('en-CA', { timeZone }).format(date);
 }

--- a/functions/src/rate-limit.test.ts
+++ b/functions/src/rate-limit.test.ts
@@ -1,4 +1,5 @@
-import { getUsageDocId, getUsageWindowId } from './rate-limit-helpers';
+import { describe, expect, it, vi } from 'vitest';
+import { getDefaultAdminApp, getUsageDocId, getUsageWindowId } from './rate-limit-helpers';
 
 describe('getUsageWindowId', () => {
   it('指定したタイムゾーンの日付キーを返す', () => {
@@ -15,5 +16,40 @@ describe('getUsageDocId', () => {
     expect(getUsageDocId('user/abc@example.com', 'ocrScheduleFromImage', date)).toBe(
       'user%2Fabc%40example.com_ocrScheduleFromImage_2026-05-22'
     );
+  });
+});
+
+describe('getDefaultAdminApp', () => {
+  it('デフォルトAdmin appがない場合だけ初期化する', () => {
+    const defaultApp = { name: '[DEFAULT]' };
+    const getApp = vi.fn(() => {
+      const error = new Error('The default Firebase app does not exist.') as Error & { code?: string };
+      error.code = 'app/no-app';
+      throw error;
+    });
+    const initializeApp = vi.fn(() => defaultApp);
+
+    expect(getDefaultAdminApp({ getApp, initializeApp })).toBe(defaultApp);
+    expect(initializeApp).toHaveBeenCalledTimes(1);
+  });
+
+  it('デフォルトAdmin appがある場合は既存appを使う', () => {
+    const defaultApp = { name: '[DEFAULT]' };
+    const getApp = vi.fn(() => defaultApp);
+    const initializeApp = vi.fn();
+
+    expect(getDefaultAdminApp({ getApp, initializeApp })).toBe(defaultApp);
+    expect(initializeApp).not.toHaveBeenCalled();
+  });
+
+  it('app/no-app以外のエラーは握りつぶさない', () => {
+    const error = new Error('permission denied');
+    const getApp = vi.fn(() => {
+      throw error;
+    });
+    const initializeApp = vi.fn();
+
+    expect(() => getDefaultAdminApp({ getApp, initializeApp })).toThrow(error);
+    expect(initializeApp).not.toHaveBeenCalled();
   });
 });

--- a/functions/src/rate-limit.ts
+++ b/functions/src/rate-limit.ts
@@ -1,4 +1,4 @@
-import { getApps, initializeApp } from 'firebase-admin/app';
+import { getApp, initializeApp } from 'firebase-admin/app';
 import { FieldValue, getFirestore } from 'firebase-admin/firestore';
 import { getUsageDocId, getUsageWindowId } from './rate-limit-helpers';
 
@@ -20,10 +20,16 @@ export class DailyUsageLimitExceededError extends Error {
 }
 
 function getAdminDb() {
-  if (getApps().length === 0) {
-    initializeApp();
+  try {
+    return getFirestore(getApp());
+  } catch (error) {
+    const appError = error as { code?: string };
+    if (appError.code !== 'app/no-app') {
+      throw error;
+    }
+
+    return getFirestore(initializeApp());
   }
-  return getFirestore();
 }
 
 export async function assertDailyUsageLimit({

--- a/functions/src/rate-limit.ts
+++ b/functions/src/rate-limit.ts
@@ -1,6 +1,6 @@
-import { getApps, initializeApp } from 'firebase-admin/app';
+import { getApp, initializeApp } from 'firebase-admin/app';
 import { FieldValue, getFirestore } from 'firebase-admin/firestore';
-import { getUsageDocId, getUsageWindowId } from './rate-limit-helpers';
+import { getDefaultAdminApp, getUsageDocId, getUsageWindowId } from './rate-limit-helpers';
 
 interface DailyUsageLimitOptions {
   uid: string;
@@ -20,10 +20,7 @@ export class DailyUsageLimitExceededError extends Error {
 }
 
 function getAdminDb() {
-  if (getApps().length === 0) {
-    initializeApp();
-  }
-  return getFirestore();
+  return getFirestore(getDefaultAdminApp({ getApp, initializeApp }));
 }
 
 export async function assertDailyUsageLimit({


### PR DESCRIPTION
## 概要
- OCR利用回数確認でFirestore接続前にdefault Admin appを確実に初期化
- default以外のAdmin appだけが存在する場合の再現テストを追加

## 原因
Cloud Functionsログで App Check は VALID でしたが、利用回数確認時に firebase-admin が app/no-app で失敗していました。

## 検証
- npm run test:run -- functions/src/rate-limit-admin.test.ts
- npm run lint
- npm --prefix functions run build
- npm run test:run
- npm run build