### PR TITLE
fix: 担当表の読み込み停止を防ぐ

### DIFF
--- a/app/assignment/hooks/useAssignmentData.test.ts
+++ b/app/assignment/hooks/useAssignmentData.test.ts
@@ -1,0 +1,89 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+import { useAssignmentData } from './useAssignmentData';
+import type { ShuffleSettings, TableSettings } from '@/types';
+
+const mocks = vi.hoisted(() => ({
+    fetchTeams: vi.fn(),
+    fetchMembers: vi.fn(),
+    fetchTaskLabels: vi.fn(),
+    subscribeLatestAssignmentDay: vi.fn(),
+    subscribeShuffleEvent: vi.fn(),
+    subscribeTableSettings: vi.fn(),
+    fetchRecentAssignments: vi.fn(),
+    mutateAssignmentDay: vi.fn(),
+    getServerTodayDate: vi.fn(),
+    subscribeManager: vi.fn(),
+    subscribePairExclusions: vi.fn(),
+    subscribeShuffleSettings: vi.fn(),
+}));
+
+vi.mock('../lib/firebase', () => ({
+    fetchTeams: mocks.fetchTeams,
+    fetchMembers: mocks.fetchMembers,
+    fetchTaskLabels: mocks.fetchTaskLabels,
+    subscribeLatestAssignmentDay: mocks.subscribeLatestAssignmentDay,
+    subscribeShuffleEvent: mocks.subscribeShuffleEvent,
+    subscribeTableSettings: mocks.subscribeTableSettings,
+    fetchRecentAssignments: mocks.fetchRecentAssignments,
+    mutateAssignmentDay: mocks.mutateAssignmentDay,
+    getServerTodayDate: mocks.getServerTodayDate,
+    subscribeManager: mocks.subscribeManager,
+    subscribePairExclusions: mocks.subscribePairExclusions,
+    subscribeShuffleSettings: mocks.subscribeShuffleSettings,
+    DEFAULT_SHUFFLE_SETTINGS: { crossTeamShuffle: false, priority: {} },
+}));
+
+describe('useAssignmentData', () => {
+    const unsubscribe = vi.fn();
+
+    beforeEach(() => {
+        mocks.fetchTeams.mockResolvedValue([]);
+        mocks.fetchMembers.mockResolvedValue([]);
+        mocks.fetchTaskLabels.mockResolvedValue([]);
+        mocks.fetchRecentAssignments.mockResolvedValue([]);
+        mocks.mutateAssignmentDay.mockResolvedValue({ assignments: [], changed: false });
+        mocks.getServerTodayDate.mockResolvedValue('2026-05-23');
+        mocks.subscribeLatestAssignmentDay.mockImplementation((_userId, callback) => {
+            callback(null);
+            return unsubscribe;
+        });
+        mocks.subscribeTableSettings.mockImplementation((_userId, callback) => {
+            callback({ colWidths: { taskLabel: 160, note: 160, teams: {} }, rowHeights: {}, headerLabels: {} } as TableSettings);
+            return unsubscribe;
+        });
+        mocks.subscribeManager.mockImplementation((_userId, callback) => {
+            callback(null);
+            return unsubscribe;
+        });
+        mocks.subscribePairExclusions.mockImplementation((_userId, callback) => {
+            callback([]);
+            return unsubscribe;
+        });
+        mocks.subscribeShuffleSettings.mockImplementation((_userId, callback) => {
+            callback({ crossTeamShuffle: false, priority: {} } as ShuffleSettings);
+            return unsubscribe;
+        });
+        mocks.subscribeShuffleEvent.mockImplementation(() => unsubscribe);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('マスターデータ取得が失敗しても読み込み中のままにしない', async () => {
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const error = new Error('permission denied');
+        mocks.fetchTeams.mockRejectedValue(error);
+
+        const { result } = renderHook(() => useAssignmentData('user-1', false));
+
+        await waitFor(() => {
+            expect(result.current.isLoading).toBe(false);
+        });
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to load assignment master data:', error);
+        consoleErrorSpy.mockRestore();
+    });
+});

--- a/app/assignment/hooks/useAssignmentData.ts
+++ b/app/assignment/hooks/useAssignmentData.ts
@@ -14,6 +14,8 @@ import {
     DEFAULT_SHUFFLE_SETTINGS,
 } from '../lib/firebase';
 
+const getLocalTodayDate = () => new Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Tokyo' }).format(new Date());
+
 export function useAssignmentData(userId: string | null, authLoading: boolean) {
     // マスタデータ
     const [teams, setTeams] = useState<Team[]>([]);
@@ -53,23 +55,36 @@ export function useAssignmentData(userId: string | null, authLoading: boolean) {
         let cancelled = false;
 
         const bootstrap = async () => {
-            const date = await getServerTodayDate();
+            let date = getLocalTodayDate();
+            try {
+                date = await getServerTodayDate();
+            } catch (error) {
+                console.error('Failed to get server today date:', error);
+            }
+
             if (!cancelled) {
                 setTodayDate(date);
             }
 
-            const [t, m, l] = await Promise.all([
-                fetchTeams(userId),
-                fetchMembers(userId),
-                fetchTaskLabels(userId)
-            ]);
+            try {
+                const [t, m, l] = await Promise.all([
+                    fetchTeams(userId),
+                    fetchMembers(userId),
+                    fetchTaskLabels(userId)
+                ]);
 
-            if (cancelled) return;
+                if (cancelled) return;
 
-            setTeams(t);
-            setMembers(m);
-            setTaskLabels(l);
-            setIsMasterLoaded(true);
+                setTeams(t);
+                setMembers(m);
+                setTaskLabels(l);
+            } catch (error) {
+                console.error('Failed to load assignment master data:', error);
+            } finally {
+                if (!cancelled) {
+                    setIsMasterLoaded(true);
+                }
+            }
         };
 
         bootstrap();

--- a/app/assignment/lib/firebase/assignment.ts
+++ b/app/assignment/lib/firebase/assignment.ts
@@ -88,13 +88,20 @@ export const updateAssignmentDay = async (userId: string, date: string, assignme
 export const subscribeAssignmentDay = (userId: string, date: string, callback: (data: AssignmentDay | null) => void) => {
     const assignmentDaysCol = getAssignmentDaysCollection(userId);
     const docRef = doc(assignmentDaysCol, date);
-    return onSnapshot(docRef, (snap) => {
-        if (snap.exists()) {
-            callback({ ...snap.data(), date: snap.id } as AssignmentDay);
-        } else {
+    return onSnapshot(
+        docRef,
+        (snap) => {
+            if (snap.exists()) {
+                callback({ ...snap.data(), date: snap.id } as AssignmentDay);
+            } else {
+                callback(null);
+            }
+        },
+        (error) => {
+            console.error('Failed to subscribe assignment day:', error);
             callback(null);
         }
-    });
+    );
 };
 
 export const subscribeLatestAssignmentDay = (
@@ -106,26 +113,33 @@ export const subscribeLatestAssignmentDay = (
     const latestQuery = query(assignmentDaysCol, orderBy('updatedAt', 'desc'), limit(1));
     let initializing = false;
 
-    return onSnapshot(latestQuery, async (snap) => {
-        if (!snap.empty) {
-            const docSnap = snap.docs[0];
-            callback({ ...docSnap.data(), date: docSnap.id } as AssignmentDay);
-            return;
-        }
-
-        callback(null);
-
-        if (options?.onEmpty && !initializing) {
-            initializing = true;
-            try {
-                await options.onEmpty();
-            } catch (error) {
-                console.error('Failed to initialize first assignment day:', error);
-            } finally {
-                initializing = false;
+    return onSnapshot(
+        latestQuery,
+        async (snap) => {
+            if (!snap.empty) {
+                const docSnap = snap.docs[0];
+                callback({ ...docSnap.data(), date: docSnap.id } as AssignmentDay);
+                return;
             }
+
+            callback(null);
+
+            if (options?.onEmpty && !initializing) {
+                initializing = true;
+                try {
+                    await options.onEmpty();
+                } catch (error) {
+                    console.error('Failed to initialize first assignment day:', error);
+                } finally {
+                    initializing = false;
+                }
+            }
+        },
+        (error) => {
+            console.error('Failed to subscribe latest assignment day:', error);
+            callback(null);
         }
-    });
+    );
 };
 
 export const fetchRecentAssignments = async (userId: string, endDate: string, days: number): Promise<AssignmentDay[]> => {

--- a/app/assignment/page.test.tsx
+++ b/app/assignment/page.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import AssignmentPage from './page';
+
+const mocks = vi.hoisted(() => ({
+    useAuth: vi.fn(),
+    useAssignmentData: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+    useAuth: () => mocks.useAuth(),
+}));
+
+vi.mock('@/hooks/useDeveloperMode', () => ({
+    useDeveloperMode: () => ({ isEnabled: false, isLoading: false }),
+}));
+
+vi.mock('@/app/login/page', () => ({
+    default: () => <div>ログイン画面</div>,
+}));
+
+vi.mock('@/components/Loading', () => ({
+    Loading: () => <div>読み込み中...</div>,
+}));
+
+vi.mock('./hooks', () => ({
+    useAssignmentData: () => mocks.useAssignmentData(),
+    useShuffleExecution: () => ({ handleShuffle: vi.fn() }),
+    useAssignmentHandlers: () => ({
+        handleUpdateTableSettings: vi.fn(),
+        handleUpdateMember: vi.fn(),
+        handleUpdateMemberName: vi.fn(),
+        handleUpdateMemberExclusion: vi.fn(),
+        handleSwapAssignments: vi.fn(),
+        handleAddMember: vi.fn(),
+        handleDeleteMember: vi.fn(),
+        handleUpdateTaskLabel: vi.fn(),
+        handleAddTaskLabel: vi.fn(),
+        handleDeleteTaskLabel: vi.fn(),
+        handleAddTeam: vi.fn(),
+        handleDeleteTeam: vi.fn(),
+        handleUpdateTeam: vi.fn(),
+    }),
+}));
+
+vi.mock('./components/assignment-table', () => ({
+    AssignmentTable: () => <div>担当表</div>,
+}));
+
+vi.mock('./components/RouletteOverlay', () => ({
+    RouletteOverlay: () => null,
+}));
+
+vi.mock('./components/ManagerDialog', () => ({
+    ManagerDialog: () => null,
+}));
+
+vi.mock('./components/AssignmentSettingsModal', () => ({
+    AssignmentSettingsModal: () => null,
+}));
+
+vi.mock('./lib/firebase', () => ({
+    setManager: vi.fn(),
+    deleteManager: vi.fn(),
+    addPairExclusion: vi.fn(),
+    deletePairExclusion: vi.fn(),
+    updateShuffleSettings: vi.fn(),
+}));
+
+describe('AssignmentPage', () => {
+    beforeEach(() => {
+        mocks.useAuth.mockReturnValue({ user: { uid: 'user-1' }, loading: false });
+        mocks.useAssignmentData.mockReturnValue({
+            teams: [],
+            setTeams: vi.fn(),
+            members: [],
+            setMembers: vi.fn(),
+            taskLabels: [],
+            setTaskLabels: vi.fn(),
+            tableSettings: null,
+            manager: null,
+            setManagerState: vi.fn(),
+            pairExclusions: [],
+            shuffleSettings: { crossTeamShuffle: false, priority: {} },
+            todayDate: '2026-05-23',
+            setTodayDate: vi.fn(),
+            activeDate: '2026-05-23',
+            setActiveDate: vi.fn(),
+            isRouletteVisible: false,
+            isLocalShuffling: false,
+            setIsLocalShuffling: vi.fn(),
+            isShuffleDisabled: false,
+            displayAssignments: [],
+            isLoading: false,
+        });
+    });
+
+    it('未ログイン時は読み込み中のままにせずログイン画面を表示する', () => {
+        mocks.useAuth.mockReturnValue({ user: null, loading: false });
+        mocks.useAssignmentData.mockReturnValue({
+            teams: [],
+            setTeams: vi.fn(),
+            members: [],
+            setMembers: vi.fn(),
+            taskLabels: [],
+            setTaskLabels: vi.fn(),
+            tableSettings: null,
+            manager: null,
+            setManagerState: vi.fn(),
+            pairExclusions: [],
+            shuffleSettings: { crossTeamShuffle: false, priority: {} },
+            todayDate: '',
+            setTodayDate: vi.fn(),
+            activeDate: '',
+            setActiveDate: vi.fn(),
+            isRouletteVisible: false,
+            isLocalShuffling: false,
+            setIsLocalShuffling: vi.fn(),
+            isShuffleDisabled: true,
+            displayAssignments: [],
+            isLoading: true,
+        });
+
+        render(<AssignmentPage />);
+
+        expect(screen.getByText('ログイン画面')).toBeInTheDocument();
+        expect(screen.queryByText('読み込み中...')).not.toBeInTheDocument();
+    });
+});

--- a/app/assignment/page.tsx
+++ b/app/assignment/page.tsx
@@ -6,6 +6,7 @@ import { RouletteOverlay } from './components/RouletteOverlay';
 import { ManagerDialog } from './components/ManagerDialog';
 import { AssignmentSettingsModal } from './components/AssignmentSettingsModal';
 import { Loading } from '@/components/Loading';
+import LoginPage from '@/app/login/page';
 import { useDeveloperMode } from '@/hooks/useDeveloperMode';
 import { useAuth } from '@/lib/auth';
 import { setManager, deleteManager, addPairExclusion, deletePairExclusion, updateShuffleSettings } from './lib/firebase';
@@ -49,6 +50,10 @@ export default function AssignmentPage() {
         setTeams: data.setTeams,
         setTaskLabels: data.setTaskLabels,
     });
+
+    if (!authLoading && !user) {
+        return <LoginPage />;
+    }
 
     if (data.isLoading) {
         return <Loading />;


### PR DESCRIPTION
## Summary
- 担当表の初期データ取得エラー時に読み込み中のまま止まらないよう修正
- Firestore購読エラー時も担当表のロード状態を解除できるよう修正
- 未ログイン時は担当表ページでログイン画面を表示

## Test Plan
- npm run test:run -- app/assignment/hooks/useAssignmentData.test.ts app/assignment/page.test.tsx
- npm run test:run -- app/assignment
- npm run test:run
- npm run lint
- npm run build