### PR TITLE
fix: 担当表の権限エラーとSW応答処理を修正

### DIFF
--- a/app/assignment/lib/firebase/assignment.test.ts
+++ b/app/assignment/lib/firebase/assignment.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    getAuth: vi.fn(),
+    setDoc: vi.fn(),
+    getDoc: vi.fn(),
+    doc: vi.fn(),
+    serverTimestamp: vi.fn(),
+}));
+
+vi.mock('firebase/auth', () => ({
+    getAuth: mocks.getAuth,
+}));
+
+vi.mock('firebase/firestore', () => ({
+    doc: mocks.doc,
+    getDoc: mocks.getDoc,
+    getDocs: vi.fn(),
+    onSnapshot: vi.fn(),
+    query: vi.fn(),
+    orderBy: vi.fn(),
+    setDoc: mocks.setDoc,
+    serverTimestamp: mocks.serverTimestamp,
+    where: vi.fn(),
+    limit: vi.fn(),
+    runTransaction: vi.fn(),
+}));
+
+vi.mock('@/lib/firebase', () => ({
+    db: {},
+}));
+
+import { getServerTodayDate } from './assignment';
+
+describe('getServerTodayDate', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-05-23T10:00:00.000Z'));
+        mocks.getAuth.mockReturnValue({ currentUser: { uid: 'user-1' } });
+        mocks.doc.mockReturnValue({ path: 'users/user-1/_meta/serverTime' });
+        mocks.serverTimestamp.mockReturnValue('server-timestamp');
+        mocks.getDoc.mockResolvedValue({
+            data: () => ({ now: { toDate: () => new Date('2026-05-23T01:00:00.000Z') } }),
+        });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.clearAllMocks();
+    });
+
+    it('Firestore書き込み権限がなくてもローカル日付を返す', async () => {
+        mocks.setDoc.mockRejectedValue(new Error('Missing or insufficient permissions.'));
+
+        await expect(getServerTodayDate()).resolves.toBe('2026-05-23');
+        expect(mocks.setDoc).not.toHaveBeenCalled();
+    });
+});

--- a/app/assignment/lib/firebase/assignment.ts
+++ b/app/assignment/lib/firebase/assignment.ts
@@ -1,13 +1,10 @@
 import {
     doc,
-    getDoc,
     getDocs,
     onSnapshot,
     query,
     orderBy,
-    setDoc,
     serverTimestamp,
-    Timestamp,
     where,
     limit,
     runTransaction
@@ -25,19 +22,7 @@ import {
 } from './helpers';
 
 export const getServerTodayDate = async (timeZone: string = "Asia/Tokyo"): Promise<string> => {
-    // Use a dedicated meta document to fetch server-resolved timestamp
-    const auth = (await import('firebase/auth')).getAuth();
-    const userId = auth.currentUser?.uid;
-    if (!userId) {
-        return new Intl.DateTimeFormat('en-CA', { timeZone }).format(new Date());
-    }
-
-    const metaRef = doc(db, 'users', userId, '_meta', 'serverTime');
-    await setDoc(metaRef, { now: serverTimestamp() }, { merge: true });
-    const snap = await getDoc(metaRef);
-    const ts = snap.data()?.now as Timestamp | undefined;
-    const date = ts?.toDate() ?? new Date();
-    return new Intl.DateTimeFormat('en-CA', { timeZone }).format(date);
+    return new Intl.DateTimeFormat('en-CA', { timeZone }).format(new Date());
 };
 
 export const mutateAssignmentDay = async (

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for PWA
-const CACHE_NAME = 'roast-plus-v4';
-const RUNTIME_CACHE = 'roast-plus-runtime-v4';
+const CACHE_NAME = 'roast-plus-v5';
+const RUNTIME_CACHE = 'roast-plus-runtime-v5';
 
 // キャッシュするリソース
 const PRECACHE_URLS = [
@@ -32,6 +32,31 @@ function getHtmlPath(url) {
   
   // その他のルートパスはindex.htmlを追加
   return `${pathname}/index.html`;
+}
+
+function putInRuntimeCache(requests, response) {
+  if (!response || response.status !== 200) {
+    return Promise.resolve();
+  }
+
+  const cacheEntries = requests.map((request) => ({
+    request,
+    response: response.clone(),
+  }));
+
+  return caches.open(RUNTIME_CACHE)
+    .then((cache) => Promise.all(
+      cacheEntries.map(({ request, response }) => cache.put(request, response))
+    ))
+    .catch((error) => {
+      console.error('Service Worker cache put failed:', error);
+    });
+}
+
+function getNavigationFallback() {
+  return caches.match('/index.html')
+    .then((cachedResponse) => cachedResponse || caches.match('/'))
+    .then((cachedResponse) => cachedResponse || Response.error());
 }
 
 // インストール時の処理
@@ -111,21 +136,13 @@ self.addEventListener('fetch', (event) => {
           .then((response) => {
             // レスポンスが有効な場合、元のリクエストとHTMLファイルパスの両方をキャッシュに保存
             if (response && response.status === 200) {
-              const responseToCache = response.clone();
-              caches.open(RUNTIME_CACHE).then((cache) => {
-                cache.put(event.request, responseToCache.clone());
-                cache.put(htmlRequest, responseToCache);
-              });
+              putInRuntimeCache([event.request, htmlRequest], response);
               return response;
             }
             // 404の場合は、元のリクエストを試す（Firebase Hostingのrewritesが適用される可能性がある）
             return fetch(event.request).then((originalResponse) => {
               if (originalResponse && originalResponse.status === 200) {
-                const responseToCache = originalResponse.clone();
-                caches.open(RUNTIME_CACHE).then((cache) => {
-                  cache.put(event.request, responseToCache);
-                  cache.put(htmlRequest, responseToCache.clone());
-                });
+                putInRuntimeCache([event.request, htmlRequest], originalResponse);
               }
               return originalResponse;
             });
@@ -142,7 +159,7 @@ self.addEventListener('fetch', (event) => {
                   return originalCached;
                 }
                 // それでも見つからない場合は、index.htmlを返す（SPAフォールバック）
-                return caches.match('/index.html') || caches.match('/');
+                return getNavigationFallback();
               });
             });
           })
@@ -157,10 +174,7 @@ self.addEventListener('fetch', (event) => {
       .then((response) => {
         // レスポンスが有効な場合、キャッシュに保存
         if (response && response.status === 200) {
-          const responseToCache = response.clone();
-          caches.open(RUNTIME_CACHE).then((cache) => {
-            cache.put(event.request, responseToCache);
-          });
+          putInRuntimeCache([event.request], response);
         }
         return response;
       })
@@ -180,14 +194,14 @@ self.addEventListener('fetch', (event) => {
                   return htmlCachedResponse;
                 }
                 // それでも見つからない場合は、index.htmlを返す（SPAフォールバック）
-                return caches.match('/index.html') || caches.match('/');
+                return getNavigationFallback();
               });
             }
             // HTMLファイルパスが同じ場合は、index.htmlを返す（SPAフォールバック）
-            return caches.match('/index.html') || caches.match('/');
+            return getNavigationFallback();
           }
           
-          return null;
+          return Response.error();
         });
       })
   );

--- a/public/sw.test.ts
+++ b/public/sw.test.ts
@@ -2,11 +2,17 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import vm from 'node:vm';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 interface ServiceWorkerContext {
   __getHtmlPath: (url: string) => string;
+  __putInRuntimeCache: (requests: Request[], response: Response) => Promise<void>;
+  __getNavigationFallback: () => Promise<Response>;
   __PRECACHE_URLS: string[];
+  caches: {
+    open?: () => Promise<{ put: (request: Request, response: Response) => Promise<void> }>;
+    match?: () => Promise<Response | undefined>;
+  };
 }
 
 function loadServiceWorkerContext(): ServiceWorkerContext {
@@ -14,6 +20,11 @@ function loadServiceWorkerContext(): ServiceWorkerContext {
   const context = {
     URL,
     Request,
+    Response,
+    caches: {
+      open: () => Promise.resolve({ put: () => Promise.resolve() }),
+      match: () => Promise.resolve(undefined),
+    },
     self: {
       location: { origin: 'https://example.test' },
       addEventListener: () => undefined,
@@ -25,6 +36,8 @@ function loadServiceWorkerContext(): ServiceWorkerContext {
   vm.runInNewContext(
     `${source}
 globalThis.__getHtmlPath = getHtmlPath;
+globalThis.__putInRuntimeCache = putInRuntimeCache;
+globalThis.__getNavigationFallback = getNavigationFallback;
 globalThis.__PRECACHE_URLS = PRECACHE_URLS;`,
     context
   );
@@ -46,5 +59,33 @@ describe('PWA Service Worker navigation paths', () => {
 
     expect(__PRECACHE_URLS).toContain('/settings/index.html');
     expect(__PRECACHE_URLS).not.toContain('/settings.html');
+  });
+});
+
+describe('PWA Service Worker runtime cache', () => {
+  it('同じResponseを複数URLへ保存してもbodyを使い回さない', async () => {
+    const put = vi.fn().mockImplementation(async (_request: Request, response: Response) => {
+      await response.text();
+    });
+    const context = loadServiceWorkerContext();
+
+    context.caches = { open: () => Promise.resolve({ put }) };
+
+    const originalResponse = new Response('assignment html');
+    const cachePromise = context.__putInRuntimeCache(
+      [new Request('https://example.test/assignment'), new Request('https://example.test/assignment/index.html')],
+      originalResponse
+    );
+
+    await originalResponse.text();
+    await cachePromise;
+    expect(put).toHaveBeenCalledTimes(2);
+  });
+
+  it('キャッシュが空でもナビゲーションフォールバックはResponseを返す', async () => {
+    const context = loadServiceWorkerContext();
+    context.caches = { match: () => Promise.resolve(undefined) };
+
+    await expect(context.__getNavigationFallback()).resolves.toBeInstanceOf(Response);
   });
 });


### PR DESCRIPTION
## Summary
- 担当表の日付取得でFirestore書き込みに依存しないようにして、権限エラーで開けなくなる経路を除去
- Service WorkerのResponse clone処理を修正し、同じResponse bodyを使い回さないように変更
- ナビゲーションフォールバックが必ずResponseを返すように修正
- Service Workerキャッシュ名をv5へ更新

## Test Plan
- npm run test:run -- app/assignment/lib/firebase/assignment.test.ts public/sw.test.ts
- npm run test:run -- app/assignment public/sw.test.ts
- npm run test:run
- npm run lint
- npm run build