### PR TITLE
chore: 欠点豆図鑑表示名に変更

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -83,7 +83,7 @@ const ACTIONS: Action[] = [
   },
   {
     key: 'defect-beans',
-    title: 'コーヒー豆図鑑',
+    title: '欠点豆図鑑',
     description: '欠点豆の知識を共有',
     href: '/defect-beans',
     icon: RiBookFill,

--- a/lib/homeFeatures.ts
+++ b/lib/homeFeatures.ts
@@ -21,7 +21,7 @@ export const HOME_FEATURES = [
   },
   {
     key: 'defect-beans',
-    title: 'コーヒー豆図鑑',
+    title: '欠点豆図鑑',
     description: '欠点豆の知識を共有',
   },
   {


### PR DESCRIPTION
## 変更内容
- ホーム画面のアクションカードタイトル『コーヒー豆図鑑』を『欠点豆図鑑』に変更
- homeFeatures の表示名も同様に変更

## 検証
- npm run lint
- npm run build