### PR TITLE
[P1] 時計E2E失敗の修正

### DIFF
--- a/e2e/pages/clock.spec.ts
+++ b/e2e/pages/clock.spec.ts
@@ -1,6 +1,11 @@
 import { expect, test, type Page } from '@playwright/test';
 
 const CLOCK_URL = `${process.env.E2E_BASE_URL ?? 'http://localhost:3000'}/clock`;
+const CHIME_ALERT_COLORS = {
+  break: 'rgb(8, 145, 178)',
+  work: 'rgb(217, 119, 6)',
+  cleanup: 'rgb(75, 85, 99)',
+} as const;
 
 async function freezeTime(page: Page, iso: string) {
   await page.addInitScript((fixedIso) => {
@@ -97,17 +102,19 @@ test.describe('時計 作業チャイム', () => {
     const breakLabel = page.getByText('10:45 休憩開始');
     await expect(breakLabel).toBeVisible();
     await expect(page.getByText('休憩時間です')).toBeVisible();
-    await expect(breakLabel).toHaveCSS('color', 'rgb(22, 163, 74)');
+    await expect(breakLabel).toHaveCSS('color', CHIME_ALERT_COLORS.break);
 
     await page.goto(`${CLOCK_URL}?previewChime=work`);
     const workLabel = page.getByText('10:00 作業開始');
     await expect(workLabel).toBeVisible();
     await expect(page.getByText('作業開始です')).toBeVisible();
-    await expect(workLabel).toHaveCSS('color', 'rgb(217, 119, 6)');
+    await expect(workLabel).toHaveCSS('color', CHIME_ALERT_COLORS.work);
 
     await page.goto(`${CLOCK_URL}?previewChime=cleanup`);
-    await expect(page.getByText('16:35 掃除開始')).toBeVisible();
+    const cleanupLabel = page.getByText('16:35 掃除開始');
+    await expect(cleanupLabel).toBeVisible();
     await expect(page.getByText('掃除開始です')).toBeVisible();
+    await expect(cleanupLabel).toHaveCSS('color', CHIME_ALERT_COLORS.cleanup);
   });
 
   test('previewChimeの中央表示は約5秒で自動的に閉じる', async ({ page }) => {


### PR DESCRIPTION
## 概要
Closes #403

## 失敗していたE2Eの内容
- `npm run test:e2e` の `e2e/pages/clock.spec.ts` で、`previewChime=break` の `10:45 休憩開始` の文字色期待値が不一致になっていた。
- 期待値: `rgb(22, 163, 74)`
- 実際の表示色: `rgb(8, 145, 178)`

## 原因
- `WorkChimeAlert` の休憩通知色は後続変更で `#0891b2` に更新されていたが、E2Eの期待値が旧実装色 `#16a34a` のまま残っていた。
- そのため、UI表示は出ているが色assertionだけが失敗していた。

## 修正方針
- 時計機能やUI実装は変更せず、E2E期待値を現行の実装色に合わせた。
- 休憩、作業、掃除の中央通知色がテストから読み取れるよう、色期待値を定数化し、掃除開始の色assertionも追加した。

## 変更したファイル
- `e2e/pages/clock.spec.ts`

## 確認コマンドと結果
- `npx playwright test e2e/pages/clock.spec.ts`: 成功（5 passed）
- `npm run test:e2e`: 成功（195 passed / 22 skipped）
- `npm run typecheck`: 成功
- `npm run test:run`: 成功（93 files / 1270 tests passed）
- `npm run build`: 成功
- `npm run lint`: 成功（既存の `MODULE_TYPELESS_PACKAGE_JSON` 警告のみ）

## 残っているリスク
- 中央通知色は現在の実装色に固定で検証しているため、今後UI側の色仕様を変更する場合はE2E期待値も同時に更新する必要がある。

## このIssue外として触らなかった問題
- #404 PWA Service Worker
- #405 Firebase Rules
- #406 問い合わせフォーム
- #407 root user doc
- #408 品質ゲート
- 既存のアクセシビリティ出力に表示されるcolor-contrastログ
- ESLint実行時の `MODULE_TYPELESS_PACKAGE_JSON` 警告