### PR TITLE
[P1] PWA Service Workerのprecache修正

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for PWA
-const CACHE_NAME = 'roast-plus-v5';
-const RUNTIME_CACHE = 'roast-plus-runtime-v5';
+const CACHE_NAME = 'roast-plus-v6';
+const RUNTIME_CACHE = 'roast-plus-runtime-v6';
 
 // キャッシュするリソース
 const PRECACHE_URLS = [
@@ -11,7 +11,6 @@ const PRECACHE_URLS = [
   '/login/index.html',
   '/notifications/index.html',
   '/android-chrome-192x192.png',
-  '/android-chrome-512x512.png',
 ];
 
 // Next.jsの静的エクスポートでは、ルートパス（/assignment）は実際には/assignment/index.htmlとして生成される

--- a/public/sw.test.ts
+++ b/public/sw.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import vm from 'node:vm';
 
@@ -45,6 +45,19 @@ globalThis.__PRECACHE_URLS = PRECACHE_URLS;`,
   return context as typeof context & ServiceWorkerContext;
 }
 
+function resolvePrecachePath(url: string): string {
+  if (url === '/' || url === '/index.html') {
+    return join(process.cwd(), 'app', 'page.tsx');
+  }
+
+  if (url.endsWith('/index.html')) {
+    const routePath = url.replace(/^\//, '').replace(/\/index\.html$/, '');
+    return join(process.cwd(), 'app', routePath, 'page.tsx');
+  }
+
+  return join(process.cwd(), 'public', url.replace(/^\//, ''));
+}
+
 describe('PWA Service Worker navigation paths', () => {
   it('静的エクスポートされたページのindex.htmlへ変換する', () => {
     const { __getHtmlPath } = loadServiceWorkerContext();
@@ -59,6 +72,31 @@ describe('PWA Service Worker navigation paths', () => {
 
     expect(__PRECACHE_URLS).toContain('/settings/index.html');
     expect(__PRECACHE_URLS).not.toContain('/settings.html');
+  });
+
+  it('事前キャッシュURLは実在するNext.jsページまたはpublicファイルを指す', () => {
+    const { __PRECACHE_URLS } = loadServiceWorkerContext();
+
+    const missingPaths = __PRECACHE_URLS
+      .map((url) => ({ url, filePath: resolvePrecachePath(url) }))
+      .filter(({ filePath }) => !existsSync(filePath));
+
+    expect(missingPaths).toEqual([]);
+  });
+
+  it('manifestのicon参照はpublic配下の実ファイルを指す', () => {
+    const manifest = JSON.parse(
+      readFileSync(join(process.cwd(), 'public', 'site.webmanifest'), 'utf8')
+    ) as { icons: Array<{ src: string }> };
+
+    const missingIcons = manifest.icons
+      .map((icon) => ({
+        src: icon.src,
+        filePath: join(process.cwd(), 'public', icon.src.replace(/^\//, '')),
+      }))
+      .filter(({ filePath }) => !existsSync(filePath));
+
+    expect(missingIcons).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## 概要
Closes #404

## 失敗リスクの原因
- `public/sw.js` の `PRECACHE_URLS` に `/android-chrome-512x512.png` が含まれていました。
- しかし `public` 配下にも `out` 配下にも同ファイルは存在せず、Service Worker install時の `cache.addAll(PRECACHE_URLS)` が失敗するリスクがありました。

## 修正したprecache対象
- 既存の実在するprecache対象は維持しました。
  - `/`
  - `/index.html`
  - `/assignment/index.html`
  - `/settings/index.html`
  - `/login/index.html`
  - `/notifications/index.html`
  - `/android-chrome-192x192.png`

## 削除または変更したパス
- `PRECACHE_URLS` から存在しない `/android-chrome-512x512.png` を削除しました。
- `CACHE_NAME` と `RUNTIME_CACHE` を `v5` から `v6` に更新しました。

## manifestとの整合性確認結果
- `public/site.webmanifest` のiconsは36/48/72/96/128/144/152/192pxのみで、すべて実ファイルが存在します。
- `app/layout.tsx` のfavicon、192pxアイコン、apple touch icon参照も実ファイルと整合しています。
- ビルド後の `out` 配下でも、precache対象とmanifest iconsがすべて存在することを確認しました。

## CACHE_NAME変更
- 変更ありです。
- precache内容を変えたため、既存ユーザー環境で古いprecache名と混在しないように `roast-plus-v6` / `roast-plus-runtime-v6` へ更新しました。

## 追加したテストまたは検証方法
- `public/sw.test.ts` に以下を追加しました。
  - `PRECACHE_URLS` の各URLが、Next.jsページ元ファイルまたは `public` 配下の実ファイルに対応すること
  - manifest iconsの参照先が `public` 配下に実在すること
- 修正前に追加テストが `/android-chrome-512x512.png` 欠落で失敗することを確認済みです。

## 実行した確認コマンドと結果
- `npm run test:run -- public/sw.test.ts` 修正前: 1 failed（`/android-chrome-512x512.png` 欠落）
- `npm run test:run -- public/sw.test.ts` 修正後: 6 passed
- `npm run typecheck`: passed
- `npm run test:run`: 93 files / 1272 tests passed
- `npm run build`: passed
- `npm run lint`: passed（既存のESM警告のみ）
- ビルド後 `out` のprecache URL実在確認: all true
- ビルド後 `out` のmanifest icon実在確認: all true

## 残っているリスク
- 既存ユーザーの古いService Workerは、ブラウザの更新タイミングまで残る可能性があります。
- 一時的なネットワーク失敗など、ファイル欠落以外の `cache.addAll` 失敗要因は今回の範囲外です。

## このIssue外として触らなかった問題
- PWA全体の作り直し、`next-pwa` 導入、runtime cacheの全面改修は行っていません。
- #405 Firebase Rules、#406 問い合わせフォーム、#407 root user doc、#408 品質ゲートには触っていません。