### PR TITLE
[P1] 問い合わせフォームの悪用対策

### DIFF
--- a/app/contact/page.test.tsx
+++ b/app/contact/page.test.tsx
@@ -86,6 +86,26 @@ describe('ContactPage', () => {
     expect(screen.getByRole('button', { name: '送信中...' })).toBeDisabled();
   });
 
+  it('trim済みの内容を送信する', async () => {
+    render(<ContactPage />);
+
+    fillContactForm({
+      name: '   ',
+      email: '  test@example.com  ',
+      message: '  お問い合わせ内容の詳細です。  ',
+    });
+    fireEvent.click(screen.getByRole('button', { name: '送信する' }));
+
+    await waitFor(() => {
+      expect(mocks.sendContactEmail).toHaveBeenCalledWith({
+        name: '',
+        email: 'test@example.com',
+        type: 'question',
+        message: 'お問い合わせ内容の詳細です。',
+      });
+    });
+  });
+
   it('cooldown中の再送信を拒否する', async () => {
     localStorage.setItem(CONTACT_FORM_COOLDOWN_STORAGE_KEY, String(Date.now()));
     render(<ContactPage />);

--- a/app/contact/page.test.tsx
+++ b/app/contact/page.test.tsx
@@ -1,0 +1,101 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CONTACT_FORM_COOLDOWN_STORAGE_KEY } from '@/lib/contactForm';
+
+import ContactPage from './page';
+
+const mocks = vi.hoisted(() => ({
+  isEmailJSConfigured: vi.fn(() => true),
+  sendContactEmail: vi.fn(),
+}));
+
+vi.mock('@/lib/emailjs', () => ({
+  CONTACT_TYPES: [
+    { value: 'question', label: '機能に関するご質問' },
+    { value: 'bug', label: '不具合のご報告' },
+    { value: 'request', label: 'ご要望・ご提案' },
+    { value: 'other', label: 'その他' },
+  ],
+  isEmailJSConfigured: mocks.isEmailJSConfigured,
+  sendContactEmail: mocks.sendContactEmail,
+}));
+
+function fillContactForm({
+  name = '山田 太郎',
+  email = 'test@example.com',
+  message = 'お問い合わせ内容の詳細です。',
+}: {
+  name?: string;
+  email?: string;
+  message?: string;
+} = {}) {
+  fireEvent.change(screen.getByLabelText('お名前（任意）'), {
+    target: { value: name },
+  });
+  fireEvent.change(screen.getByLabelText('メールアドレス（必須）'), {
+    target: { value: email },
+  });
+  fireEvent.change(screen.getByLabelText('お問い合わせ内容（必須）'), {
+    target: { value: message },
+  });
+}
+
+describe('ContactPage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    mocks.isEmailJSConfigured.mockReturnValue(true);
+    mocks.sendContactEmail.mockResolvedValue(undefined);
+  });
+
+  it('不正なメールアドレスでは送信しない', async () => {
+    render(<ContactPage />);
+
+    fillContactForm({ email: 'invalid-email' });
+    fireEvent.click(screen.getByRole('button', { name: '送信する' }));
+
+    expect(await screen.findByText('有効なメールアドレスを入力してください')).toBeInTheDocument();
+    expect(mocks.sendContactEmail).not.toHaveBeenCalled();
+  });
+
+  it('短すぎる本文では送信しない', async () => {
+    render(<ContactPage />);
+
+    fillContactForm({ message: '短い' });
+    fireEvent.click(screen.getByRole('button', { name: '送信する' }));
+
+    expect(await screen.findByText('お問い合わせ内容は10文字以上で入力してください')).toBeInTheDocument();
+    expect(mocks.sendContactEmail).not.toHaveBeenCalled();
+  });
+
+  it('送信中の二重送信を防ぐ', async () => {
+    mocks.sendContactEmail.mockReturnValue(new Promise(() => undefined));
+    render(<ContactPage />);
+
+    fillContactForm();
+    const form = screen.getByRole('button', { name: '送信する' }).closest('form');
+    expect(form).not.toBeNull();
+
+    fireEvent.submit(form!);
+    fireEvent.submit(form!);
+
+    await waitFor(() => {
+      expect(mocks.sendContactEmail).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.getByRole('button', { name: '送信中...' })).toBeDisabled();
+  });
+
+  it('cooldown中の再送信を拒否する', async () => {
+    localStorage.setItem(CONTACT_FORM_COOLDOWN_STORAGE_KEY, String(Date.now()));
+    render(<ContactPage />);
+
+    fillContactForm();
+    fireEvent.click(screen.getByRole('button', { name: '送信する' }));
+
+    expect(
+      await screen.findByText(/少し時間をおいて再度お試しください/)
+    ).toBeInTheDocument();
+    expect(mocks.sendContactEmail).not.toHaveBeenCalled();
+  });
+});

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,10 +1,15 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { HiMail, HiExclamationCircle } from 'react-icons/hi';
 import { ContactSuccessScreen } from '@/components/contact/ContactSuccessScreen';
 import { ContactFormFields } from '@/components/contact/ContactFormFields';
 import { Button, Card, FloatingNav } from '@/components/ui';
+import {
+  getStoredContactCooldownWaitSeconds,
+  storeContactSuccessTimestamp,
+  validateContactForm,
+} from '@/lib/contactForm';
 import {
   sendContactEmail,
   isEmailJSConfigured,
@@ -14,6 +19,7 @@ import {
 type FormStatus = 'idle' | 'sending' | 'success' | 'error';
 
 export default function ContactPage() {
+  const isSubmittingRef = useRef(false);
   const [formData, setFormData] = useState<ContactFormData>({
     name: '',
     email: '',
@@ -22,34 +28,47 @@ export default function ContactPage() {
   });
   const [status, setStatus] = useState<FormStatus>('idle');
   const [errorMessage, setErrorMessage] = useState('');
-  const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
+  const [validationErrors, setValidationErrors] = useState<
+    Partial<Record<keyof ContactFormData, string>>
+  >({});
 
   const validateForm = (): boolean => {
-    const errors: Record<string, string> = {};
+    const result = validateContactForm(formData);
+    setValidationErrors(result.errors);
+    return result.isValid;
+  };
 
-    // メールアドレスの検証
-    if (!formData.email.trim()) {
-      errors.email = 'メールアドレスを入力してください';
-    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
-      errors.email = '有効なメールアドレスを入力してください';
+  const getCooldownStorage = (): Storage | null => {
+    if (typeof window === 'undefined') {
+      return null;
     }
 
-    // お問い合わせ内容の検証
-    if (!formData.message.trim()) {
-      errors.message = 'お問い合わせ内容を入力してください';
-    } else if (formData.message.trim().length < 10) {
-      errors.message = 'お問い合わせ内容は10文字以上で入力してください';
+    try {
+      return window.localStorage;
+    } catch {
+      return null;
     }
-
-    setValidationErrors(errors);
-    return Object.keys(errors).length === 0;
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    if (isSubmittingRef.current) {
+      return;
+    }
+
     setErrorMessage('');
 
     if (!validateForm()) {
+      return;
+    }
+
+    const waitSeconds = getStoredContactCooldownWaitSeconds(getCooldownStorage());
+    if (waitSeconds > 0) {
+      setStatus('error');
+      setErrorMessage(
+        `送信が続いています。少し時間をおいて再度お試しください（約${waitSeconds}秒後に送信できます）。`
+      );
       return;
     }
 
@@ -59,10 +78,12 @@ export default function ContactPage() {
       return;
     }
 
+    isSubmittingRef.current = true;
     setStatus('sending');
 
     try {
       await sendContactEmail(formData);
+      storeContactSuccessTimestamp(getCooldownStorage());
       setStatus('success');
       setFormData({
         name: '',
@@ -73,6 +94,8 @@ export default function ContactPage() {
     } catch (error) {
       setStatus('error');
       setErrorMessage(error instanceof Error ? error.message : '送信に失敗しました');
+    } finally {
+      isSubmittingRef.current = false;
     }
   };
 
@@ -80,12 +103,13 @@ export default function ContactPage() {
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
   ) => {
     const { name, value } = e.target;
+    const fieldName = name as keyof ContactFormData;
     setFormData((prev) => ({ ...prev, [name]: value }));
     // 入力時にそのフィールドのエラーをクリア
-    if (validationErrors[name]) {
+    if (validationErrors[fieldName]) {
       setValidationErrors((prev) => {
         const newErrors = { ...prev };
-        delete newErrors[name];
+        delete newErrors[fieldName];
         return newErrors;
       });
     }
@@ -121,7 +145,7 @@ export default function ContactPage() {
               </div>
             )}
 
-            <form onSubmit={handleSubmit} className="space-y-6">
+            <form onSubmit={handleSubmit} className="space-y-6" noValidate>
               <ContactFormFields
                 formData={formData}
                 validationErrors={validationErrors}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -7,6 +7,7 @@ import { ContactFormFields } from '@/components/contact/ContactFormFields';
 import { Button, Card, FloatingNav } from '@/components/ui';
 import {
   getStoredContactCooldownWaitSeconds,
+  normalizeContactFormData,
   storeContactSuccessTimestamp,
   validateContactForm,
 } from '@/lib/contactForm';
@@ -32,8 +33,8 @@ export default function ContactPage() {
     Partial<Record<keyof ContactFormData, string>>
   >({});
 
-  const validateForm = (): boolean => {
-    const result = validateContactForm(formData);
+  const validateForm = (data: ContactFormData): boolean => {
+    const result = validateContactForm(data);
     setValidationErrors(result.errors);
     return result.isValid;
   };
@@ -59,7 +60,9 @@ export default function ContactPage() {
 
     setErrorMessage('');
 
-    if (!validateForm()) {
+    const normalizedFormData = normalizeContactFormData(formData);
+
+    if (!validateForm(normalizedFormData)) {
       return;
     }
 
@@ -82,7 +85,7 @@ export default function ContactPage() {
     setStatus('sending');
 
     try {
-      await sendContactEmail(formData);
+      await sendContactEmail(normalizedFormData);
       storeContactSuccessTimestamp(getCooldownStorage());
       setStatus('success');
       setFormData({

--- a/components/contact/ContactFormFields.tsx
+++ b/components/contact/ContactFormFields.tsx
@@ -1,11 +1,12 @@
 'use client';
 
+import { CONTACT_FORM_LIMITS } from '@/lib/contactForm';
 import { CONTACT_TYPES, ContactFormData } from '@/lib/emailjs';
 import { Input, Select, Textarea } from '@/components/ui';
 
 interface ContactFormFieldsProps {
   formData: ContactFormData;
-  validationErrors: Record<string, string>;
+  validationErrors: Partial<Record<keyof ContactFormData, string>>;
   onInputChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => void;
 }
 
@@ -14,6 +15,8 @@ export function ContactFormFields({
   validationErrors,
   onInputChange,
 }: ContactFormFieldsProps) {
+  const isMessageAtLimit = formData.message.length >= CONTACT_FORM_LIMITS.messageMax;
+
   return (
     <>
       {/* お名前 */}
@@ -25,6 +28,8 @@ export function ContactFormFields({
         value={formData.name}
         onChange={onInputChange}
         placeholder="山田 太郎"
+        maxLength={CONTACT_FORM_LIMITS.name}
+        error={validationErrors.name}
       />
 
       {/* メールアドレス */}
@@ -36,6 +41,7 @@ export function ContactFormFields({
         value={formData.email}
         onChange={onInputChange}
         placeholder="example@email.com"
+        maxLength={CONTACT_FORM_LIMITS.email}
         error={validationErrors.email}
       />
 
@@ -53,16 +59,27 @@ export function ContactFormFields({
       />
 
       {/* お問い合わせ内容 */}
-      <Textarea
-        label="お問い合わせ内容（必須）"
-        id="message"
-        name="message"
-        value={formData.message}
-        onChange={onInputChange}
-        rows={6}
-        placeholder="お問い合わせ内容をご記入ください"
-        error={validationErrors.message}
-      />
+      <div>
+        <Textarea
+          label="お問い合わせ内容（必須）"
+          id="message"
+          name="message"
+          value={formData.message}
+          onChange={onInputChange}
+          rows={6}
+          placeholder="お問い合わせ内容をご記入ください"
+          maxLength={CONTACT_FORM_LIMITS.messageMax}
+          error={validationErrors.message}
+        />
+        <p
+          className={`mt-1 text-right text-sm ${
+            isMessageAtLimit ? 'text-warning' : 'text-ink-muted'
+          }`}
+          aria-live="polite"
+        >
+          {formData.message.length} / {CONTACT_FORM_LIMITS.messageMax}文字
+        </p>
+      </div>
     </>
   );
 }

--- a/lib/contactForm.test.ts
+++ b/lib/contactForm.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ContactFormData } from './emailjs';
+import {
+  CONTACT_FORM_COOLDOWN_MS,
+  CONTACT_FORM_LIMITS,
+  getContactCooldownWaitSeconds,
+  getStoredContactCooldownWaitSeconds,
+  storeContactSuccessTimestamp,
+  validateContactForm,
+} from './contactForm';
+
+const createValidFormData = (
+  overrides: Partial<ContactFormData> = {}
+): ContactFormData => ({
+  name: '山田 太郎',
+  email: 'test@example.com',
+  type: 'question',
+  message: 'お問い合わせ内容の詳細です。',
+  ...overrides,
+});
+
+describe('validateContactForm', () => {
+  it('長すぎる名前を拒否する', () => {
+    const result = validateContactForm(
+      createValidFormData({ name: 'あ'.repeat(CONTACT_FORM_LIMITS.name + 1) })
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors.name).toBe(
+      `お名前は${CONTACT_FORM_LIMITS.name}文字以内で入力してください`
+    );
+  });
+
+  it('不正なメールアドレスを拒否する', () => {
+    const result = validateContactForm(
+      createValidFormData({ email: 'invalid-email' })
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors.email).toBe('有効なメールアドレスを入力してください');
+  });
+
+  it('長すぎるメールアドレスを拒否する', () => {
+    const result = validateContactForm(
+      createValidFormData({
+        email: `${'a'.repeat(CONTACT_FORM_LIMITS.email - '@example.com'.length + 1)}@example.com`,
+      })
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors.email).toBe(
+      `メールアドレスは${CONTACT_FORM_LIMITS.email}文字以内で入力してください`
+    );
+  });
+
+  it('短すぎる本文を拒否する', () => {
+    const result = validateContactForm(createValidFormData({ message: '短い' }));
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors.message).toBe(
+      `お問い合わせ内容は${CONTACT_FORM_LIMITS.messageMin}文字以上で入力してください`
+    );
+  });
+
+  it('長すぎる本文を拒否する', () => {
+    const result = validateContactForm(
+      createValidFormData({
+        message: 'あ'.repeat(CONTACT_FORM_LIMITS.messageMax + 1),
+      })
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors.message).toBe(
+      `お問い合わせ内容は${CONTACT_FORM_LIMITS.messageMax}文字以内で入力してください`
+    );
+  });
+
+  it('有効な内容を受け付ける', () => {
+    const result = validateContactForm(createValidFormData());
+
+    expect(result.isValid).toBe(true);
+    expect(result.errors).toEqual({});
+  });
+});
+
+describe('getContactCooldownWaitSeconds', () => {
+  it('cooldown中は残り秒数を返す', () => {
+    const now = 1_000_000;
+    const lastSuccessAt = now - 30_000;
+
+    expect(getContactCooldownWaitSeconds(lastSuccessAt, now)).toBe(
+      Math.ceil((CONTACT_FORM_COOLDOWN_MS - 30_000) / 1000)
+    );
+  });
+
+  it('cooldown経過後は0秒を返す', () => {
+    const now = 1_000_000;
+    const lastSuccessAt = now - CONTACT_FORM_COOLDOWN_MS - 1;
+
+    expect(getContactCooldownWaitSeconds(lastSuccessAt, now)).toBe(0);
+  });
+});
+
+describe('contact cooldown storage helpers', () => {
+  it('保存済みの送信成功時刻からcooldown残り秒数を返す', () => {
+    const now = 1_000_000;
+    const storage = {
+      getItem: () => String(now - 10_000),
+    };
+
+    expect(getStoredContactCooldownWaitSeconds(storage, now)).toBe(
+      Math.ceil((CONTACT_FORM_COOLDOWN_MS - 10_000) / 1000)
+    );
+  });
+
+  it('localStorageが読めない環境では送信を妨げない', () => {
+    const storage = {
+      getItem: () => {
+        throw new Error('storage unavailable');
+      },
+    };
+
+    expect(getStoredContactCooldownWaitSeconds(storage)).toBe(0);
+  });
+
+  it('localStorageが書けない環境でも例外を投げない', () => {
+    const storage = {
+      setItem: () => {
+        throw new Error('storage unavailable');
+      },
+    };
+
+    expect(() => storeContactSuccessTimestamp(storage)).not.toThrow();
+  });
+});

--- a/lib/contactForm.test.ts
+++ b/lib/contactForm.test.ts
@@ -6,6 +6,7 @@ import {
   CONTACT_FORM_LIMITS,
   getContactCooldownWaitSeconds,
   getStoredContactCooldownWaitSeconds,
+  normalizeContactFormData,
   storeContactSuccessTimestamp,
   validateContactForm,
 } from './contactForm';
@@ -81,6 +82,30 @@ describe('validateContactForm', () => {
 
     expect(result.isValid).toBe(true);
     expect(result.errors).toEqual({});
+  });
+});
+
+describe('normalizeContactFormData', () => {
+  it('name、email、messageの前後空白だけを取り除き、typeは変更しない', () => {
+    expect(
+      normalizeContactFormData(
+        createValidFormData({
+          name: '  山田 太郎  ',
+          email: '  test@example.com  ',
+          type: 'bug',
+          message: '  お問い合わせ内容の詳細です。  ',
+        })
+      )
+    ).toEqual({
+      name: '山田 太郎',
+      email: 'test@example.com',
+      type: 'bug',
+      message: 'お問い合わせ内容の詳細です。',
+    });
+  });
+
+  it('空白だけの名前は空文字へ正規化する', () => {
+    expect(normalizeContactFormData(createValidFormData({ name: '   ' })).name).toBe('');
   });
 });
 

--- a/lib/contactForm.ts
+++ b/lib/contactForm.ts
@@ -1,0 +1,100 @@
+import type { ContactFormData } from './emailjs';
+
+export const CONTACT_FORM_LIMITS = {
+  name: 50,
+  email: 254,
+  messageMin: 10,
+  messageMax: 1500,
+} as const;
+
+export const CONTACT_FORM_COOLDOWN_MS = 2 * 60 * 1000;
+export const CONTACT_FORM_COOLDOWN_STORAGE_KEY = 'roastplus-contact-last-success-at';
+
+export interface ContactFormValidationResult {
+  isValid: boolean;
+  errors: Partial<Record<keyof ContactFormData, string>>;
+}
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function validateContactForm(
+  formData: ContactFormData
+): ContactFormValidationResult {
+  const errors: Partial<Record<keyof ContactFormData, string>> = {};
+  const trimmedName = formData.name.trim();
+  const trimmedEmail = formData.email.trim();
+  const trimmedMessage = formData.message.trim();
+
+  if (trimmedName.length > CONTACT_FORM_LIMITS.name) {
+    errors.name = `お名前は${CONTACT_FORM_LIMITS.name}文字以内で入力してください`;
+  }
+
+  if (!trimmedEmail) {
+    errors.email = 'メールアドレスを入力してください';
+  } else if (trimmedEmail.length > CONTACT_FORM_LIMITS.email) {
+    errors.email = `メールアドレスは${CONTACT_FORM_LIMITS.email}文字以内で入力してください`;
+  } else if (!EMAIL_PATTERN.test(trimmedEmail)) {
+    errors.email = '有効なメールアドレスを入力してください';
+  }
+
+  if (!trimmedMessage) {
+    errors.message = 'お問い合わせ内容を入力してください';
+  } else if (trimmedMessage.length < CONTACT_FORM_LIMITS.messageMin) {
+    errors.message = `お問い合わせ内容は${CONTACT_FORM_LIMITS.messageMin}文字以上で入力してください`;
+  } else if (trimmedMessage.length > CONTACT_FORM_LIMITS.messageMax) {
+    errors.message = `お問い合わせ内容は${CONTACT_FORM_LIMITS.messageMax}文字以内で入力してください`;
+  }
+
+  return {
+    isValid: Object.keys(errors).length === 0,
+    errors,
+  };
+}
+
+export function getContactCooldownWaitSeconds(
+  lastSuccessAt: number | null,
+  now = Date.now()
+): number {
+  if (!lastSuccessAt || !Number.isFinite(lastSuccessAt)) {
+    return 0;
+  }
+
+  const elapsedMs = now - lastSuccessAt;
+  const remainingMs = CONTACT_FORM_COOLDOWN_MS - elapsedMs;
+
+  return remainingMs > 0 ? Math.ceil(remainingMs / 1000) : 0;
+}
+
+export function getStoredContactCooldownWaitSeconds(
+  storage: Pick<Storage, 'getItem'> | null | undefined,
+  now = Date.now()
+): number {
+  if (!storage) {
+    return 0;
+  }
+
+  try {
+    const storedValue = storage.getItem(CONTACT_FORM_COOLDOWN_STORAGE_KEY);
+    return getContactCooldownWaitSeconds(
+      storedValue ? Number(storedValue) : null,
+      now
+    );
+  } catch {
+    return 0;
+  }
+}
+
+export function storeContactSuccessTimestamp(
+  storage: Pick<Storage, 'setItem'> | null | undefined,
+  now = Date.now()
+): void {
+  if (!storage) {
+    return;
+  }
+
+  try {
+    storage.setItem(CONTACT_FORM_COOLDOWN_STORAGE_KEY, String(now));
+  } catch {
+    // localStorageが使えない環境ではcooldown保存だけを諦める。
+  }
+}

--- a/lib/contactForm.ts
+++ b/lib/contactForm.ts
@@ -17,31 +17,40 @@ export interface ContactFormValidationResult {
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+export function normalizeContactFormData(
+  formData: ContactFormData
+): ContactFormData {
+  return {
+    ...formData,
+    name: formData.name.trim(),
+    email: formData.email.trim(),
+    message: formData.message.trim(),
+  };
+}
+
 export function validateContactForm(
   formData: ContactFormData
 ): ContactFormValidationResult {
   const errors: Partial<Record<keyof ContactFormData, string>> = {};
-  const trimmedName = formData.name.trim();
-  const trimmedEmail = formData.email.trim();
-  const trimmedMessage = formData.message.trim();
+  const normalizedFormData = normalizeContactFormData(formData);
 
-  if (trimmedName.length > CONTACT_FORM_LIMITS.name) {
+  if (normalizedFormData.name.length > CONTACT_FORM_LIMITS.name) {
     errors.name = `お名前は${CONTACT_FORM_LIMITS.name}文字以内で入力してください`;
   }
 
-  if (!trimmedEmail) {
+  if (!normalizedFormData.email) {
     errors.email = 'メールアドレスを入力してください';
-  } else if (trimmedEmail.length > CONTACT_FORM_LIMITS.email) {
+  } else if (normalizedFormData.email.length > CONTACT_FORM_LIMITS.email) {
     errors.email = `メールアドレスは${CONTACT_FORM_LIMITS.email}文字以内で入力してください`;
-  } else if (!EMAIL_PATTERN.test(trimmedEmail)) {
+  } else if (!EMAIL_PATTERN.test(normalizedFormData.email)) {
     errors.email = '有効なメールアドレスを入力してください';
   }
 
-  if (!trimmedMessage) {
+  if (!normalizedFormData.message) {
     errors.message = 'お問い合わせ内容を入力してください';
-  } else if (trimmedMessage.length < CONTACT_FORM_LIMITS.messageMin) {
+  } else if (normalizedFormData.message.length < CONTACT_FORM_LIMITS.messageMin) {
     errors.message = `お問い合わせ内容は${CONTACT_FORM_LIMITS.messageMin}文字以上で入力してください`;
-  } else if (trimmedMessage.length > CONTACT_FORM_LIMITS.messageMax) {
+  } else if (normalizedFormData.message.length > CONTACT_FORM_LIMITS.messageMax) {
     errors.message = `お問い合わせ内容は${CONTACT_FORM_LIMITS.messageMax}文字以内で入力してください`;
   }
 


### PR DESCRIPTION
Closes #406

## 追加した対策
- 名前、メールアドレス、本文の最大文字数を定数化し、maxLength属性と送信前バリデーションの両方で確認。
- HTML標準のメール検証に任せず、noValidateで既存の日本語エラーメッセージを表示。
- 送信中は既存Buttonのloading/disabledに加え、useRefの送信中ガードで二重送信を防止。
- 送信成功時刻をlocalStorageへ保存し、cooldown中の再送信をクライアント側で拒否。
- localStorageの読み書きが失敗してもフォーム全体は壊れないようにtry/catchで保護。

## 設定した文字数上限
- 名前: 50文字
- メールアドレス: 254文字
- 本文: 10文字以上、1500文字以内
- 本文は 0 / 1500 形式の文字数カウンターを表示し、上限到達時に色で分かるようにしています。

## cooldown時間と理由
- cooldown: 2分
- 60秒より少し強く、5分ほど正当な問い合わせを妨げにくい中間値として設定しました。
- 送信成功後だけ記録するため、失敗時の再試行導線は残しています。

## 二重送信防止の方法
- Buttonのloading/disabledで通常の再クリックを防止。
- 連続submitイベントに備え、isSubmittingRefで送信処理自体の再入を拒否。

## 追加したテスト
- lib/contactForm.test.ts
  - 長すぎる名前の拒否
  - 不正なメールアドレスの拒否
  - 長すぎるメールアドレスの拒否
  - 短すぎる本文の拒否
  - 長すぎる本文の拒否
  - cooldown残り秒数計算
  - localStorage読み書き失敗時に壊れないこと
- app/contact/page.test.tsx
  - 不正メールで送信しないこと
  - 短すぎる本文で送信しないこと
  - 送信中の二重送信が1回に抑えられること
  - cooldown中の再送信が拒否されること

## 手動確認
- /contact で空欄送信時に日本語エラーが出ることを確認。
- /contact で不正メール時に日本語エラーが出ることを確認。
- /contact で本文1600文字入力が1500文字までに制限され、カウンターが 1500 / 1500文字 になることを確認。
- EmailJS送信先をPlaywrightでモックし、送信中にボタンがdisabledになることを確認。
- モック送信成功後、短時間の再送信がcooldownエラーになることを確認。
- localStorage上の成功時刻を121秒前にして、cooldown経過後相当では再送信できることを確認。

## 確認コマンド
- npm run typecheck - 成功
- npm run test:run - 成功（95 files / 1287 tests）
- npm run build - 成功
- npm run lint - 成功（既存のMODULE_TYPELESS_PACKAGE_JSON警告のみ）

## クライアント側対策の限界
- localStorageベースのcooldownは、ブラウザ変更、localStorage削除、直接リクエストには耐えられません。
- 今回はIssue指定どおり、問い合わせ基盤の全面移行なしでできる最小対策に限定しています。

## 将来必要なら別Issueにすべき対策
- Captcha導入
- Cloud Functions化
- サーバー側rate limit

## このIssue外として触らなかったもの
- EmailJS設定値、シークレット、テンプレート設定
- 問い合わせ基盤の全面移行
- Cloud Functions実装
- Captcha実装
- Firebase rules
- public配下
- UI全体の作り直し

## 追加修正

- 送信前に name / email / message を trim 済みデータへ正規化。
- validateContactForm と sendContactEmail の両方で同じ正規化済みデータを使うように修正。
- type は変更しない。
- 空白だけの名前は空文字になり、既存の EmailJS 側処理で「匿名」扱いになる。

## 追加・更新したテスト

- normalizeContactFormData が name / email / message の前後空白だけを trim し、type を維持すること。
- 空白だけの名前が空文字になること。
- 空白付きメール、空白だけの名前、前後空白付き本文が trim 済みで sendContactEmail に渡ること。

## 確認コマンド

- npm run typecheck - 成功
- npm run test:run - 成功（95 files / 1290 tests）
- npm run build - 成功
- npm run lint - 成功