### PR TITLE
[P1] workProgressesをサブコレクションへ最小分離

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -13,6 +13,11 @@ on:
         required: true
         type: boolean
         default: false
+      deploy_firestore_rules:
+        description: "Deploy Firestore Rules"
+        required: true
+        type: boolean
+        default: false
   pull_request:
     types: [closed]
     branches:
@@ -37,6 +42,7 @@ jobs:
     outputs:
       hosting_changed: ${{ steps.filter.outputs.hosting_changed }}
       functions_changed: ${{ steps.filter.outputs.functions_changed }}
+      firestore_rules_changed: ${{ steps.filter.outputs.firestore_rules_changed }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -47,6 +53,7 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "hosting_changed=${{ inputs.deploy_hosting }}" >> "$GITHUB_OUTPUT"
             echo "functions_changed=${{ inputs.deploy_functions }}" >> "$GITHUB_OUTPUT"
+            echo "firestore_rules_changed=${{ inputs.deploy_firestore_rules }}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -72,10 +79,34 @@ jobs:
             echo "functions_changed=false" >> "$GITHUB_OUTPUT"
           fi
 
-  build_and_deploy:
-    if: needs.detect_changes.outputs.hosting_changed == 'true'
+          if echo "$changed_files" | grep -Eq '^firestore\.rules$'; then
+            echo "firestore_rules_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "firestore_rules_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  deploy_firestore_rules:
+    name: Deploy Firestore Rules
+    if: needs.detect_changes.outputs.firestore_rules_changed == 'true'
     runs-on: ubuntu-latest
     needs: detect_changes
+    steps:
+      - uses: actions/checkout@v6
+      - name: Deploy Firestore Rules
+        uses: w9jds/firebase-action@v15.10.0
+        with:
+          args: deploy --only firestore:rules
+        env:
+          GCP_SA_KEY: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_ROASTPLUS_72FA6 }}
+          PROJECT_ID: roastplus-72fa6
+
+  build_and_deploy:
+    if: >
+      always() &&
+      needs.detect_changes.outputs.hosting_changed == 'true' &&
+      (needs.deploy_firestore_rules.result == 'success' || needs.deploy_firestore_rules.result == 'skipped')
+    runs-on: ubuntu-latest
+    needs: [detect_changes, deploy_firestore_rules]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/firestore.rules
+++ b/firestore.rules
@@ -75,6 +75,9 @@ service cloud.firestore {
     match /users/{userId}/pairExclusions/{exclusionId} {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
+    match /users/{userId}/workProgresses/{workProgressId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
     match /users/{userId}/_meta/{document=**} {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }

--- a/hooks/useAppData.test.ts
+++ b/hooks/useAppData.test.ts
@@ -46,7 +46,8 @@ vi.mock('@/lib/auth', () => ({
 
 vi.mock('@/lib/firestore', () => ({
   getUserData: (userId: string) => mockGetUserData(userId),
-  saveUserData: (userId: string, data: AppData) => mockSaveUserData(userId, data),
+  saveUserData: (userId: string, data: AppData, options?: { syncWorkProgresses?: boolean }) =>
+    mockSaveUserData(userId, data, options),
   subscribeUserData: (userId: string, callback: (data: AppData) => void) =>
     mockSubscribeUserData(userId, callback),
   SAVE_USER_DATA_DEBOUNCE_MS: 500,
@@ -212,8 +213,40 @@ describe('useAppData', () => {
 
       expect(mockSaveUserData).toHaveBeenCalledWith('test-user-id', expect.objectContaining({
         encouragementCount: 5,
-      }));
+      }), { syncWorkProgresses: false });
       expect(result.current.data.encouragementCount).toBe(5);
+    });
+
+    it('workProgresses更新時だけサブコレクション同期を要求する', async () => {
+      const { result } = renderHook(() => useAppData());
+
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      await act(async () => {
+        await result.current.updateData((currentData) => ({
+          ...currentData,
+          workProgresses: [
+            {
+              id: 'wp-1',
+              taskName: 'テスト作業',
+              status: 'pending',
+              createdAt: '2024-02-05T12:00:00.000Z',
+              updatedAt: '2024-02-05T12:00:00.000Z',
+            },
+          ],
+        }));
+        await vi.runAllTimersAsync();
+      });
+
+      expect(mockSaveUserData).toHaveBeenCalledWith(
+        'test-user-id',
+        expect.objectContaining({
+          workProgresses: [expect.objectContaining({ id: 'wp-1' })],
+        }),
+        { syncWorkProgresses: true }
+      );
     });
 
     it('関数形式でデータを更新できる', async () => {

--- a/hooks/useAppData.ts
+++ b/hooks/useAppData.ts
@@ -281,7 +281,9 @@ export function useAppData() {
       let saveError: unknown = null;
 
       try {
-        await saveUserData(user.uid, normalizedData);
+        await saveUserData(user.uid, normalizedData, {
+          syncWorkProgresses: mutatedKeys.includes('workProgresses'),
+        });
       } catch (error) {
         saveError = error;
         console.error('Failed to save data:', error);

--- a/lib/firestore/userData.test.ts
+++ b/lib/firestore/userData.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AppData, WorkProgress } from '@/types';
+
+const firestoreMocks = vi.hoisted(() => {
+  const unsubscribe = vi.fn();
+
+  return {
+    unsubscribe,
+    getFirestore: vi.fn(() => ({ app: 'mock-firestore' })),
+    doc: vi.fn((first: { path?: string } | unknown, ...segments: string[]) => {
+      const basePath =
+        first && typeof first === 'object' && 'path' in first && typeof first.path === 'string'
+          ? first.path
+          : '';
+      const path = basePath ? [basePath, ...segments].join('/') : segments.join('/');
+      return { id: segments.at(-1), path };
+    }),
+    collection: vi.fn((first: { path?: string } | unknown, ...segments: string[]) => {
+      const basePath =
+        first && typeof first === 'object' && 'path' in first && typeof first.path === 'string'
+          ? first.path
+          : '';
+      const path = basePath ? [basePath, ...segments].join('/') : segments.join('/');
+      return { path };
+    }),
+    getDoc: vi.fn(),
+    getDocs: vi.fn(),
+    onSnapshot: vi.fn(),
+    setDoc: vi.fn(),
+  };
+});
+
+vi.mock('../firebase', () => ({
+  default: {},
+}));
+
+vi.mock('firebase/firestore', () => ({
+  getFirestore: firestoreMocks.getFirestore,
+  doc: firestoreMocks.doc,
+  collection: firestoreMocks.collection,
+  getDoc: firestoreMocks.getDoc,
+  getDocs: firestoreMocks.getDocs,
+  onSnapshot: firestoreMocks.onSnapshot,
+  setDoc: firestoreMocks.setDoc,
+}));
+
+const rootWorkProgress: WorkProgress = {
+  id: 'wp-root',
+  taskName: '旧root進捗',
+  status: 'pending',
+  createdAt: '2026-05-20T00:00:00.000Z',
+  updatedAt: '2026-05-20T00:00:00.000Z',
+};
+
+const splitWorkProgress: WorkProgress = {
+  id: 'wp-split',
+  taskName: '新形式進捗',
+  status: 'in_progress',
+  createdAt: '2026-05-21T00:00:00.000Z',
+  updatedAt: '2026-05-21T00:00:00.000Z',
+};
+
+function baseAppData(overrides: Partial<AppData> = {}): AppData {
+  return {
+    todaySchedules: [],
+    roastSchedules: [],
+    tastingSessions: [],
+    tastingRecords: [],
+    notifications: [],
+    encouragementCount: 0,
+    roastTimerRecords: [],
+    workProgresses: [],
+    dripRecipes: [],
+    ...overrides,
+  };
+}
+
+function docSnapshot(data: Record<string, unknown> | undefined) {
+  return {
+    exists: () => data !== undefined,
+    data: () => data,
+  };
+}
+
+function querySnapshot(progresses: WorkProgress[]) {
+  return {
+    docs: progresses.map((progress) => ({
+      id: progress.id,
+      ref: { path: `users/user-1/workProgresses/${progress.id}` },
+      data: () => progress,
+    })),
+  };
+}
+
+describe('getUserData workProgresses split compatibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    firestoreMocks.setDoc.mockResolvedValue(undefined);
+  });
+
+  it('新形式がない場合は旧root workProgressesから読み込む', async () => {
+    firestoreMocks.getDoc
+      .mockResolvedValueOnce(docSnapshot(baseAppData({ workProgresses: [rootWorkProgress] }) as unknown as Record<string, unknown>))
+      .mockResolvedValueOnce(docSnapshot(undefined));
+    firestoreMocks.getDocs.mockResolvedValueOnce(querySnapshot([]));
+
+    const { getUserData } = await import('./userData/crud');
+
+    const result = await getUserData('user-1');
+
+    expect(result.workProgresses).toEqual([rootWorkProgress]);
+  });
+
+  it('新形式がある場合は旧rootより users/{uid}/workProgresses を優先する', async () => {
+    firestoreMocks.getDoc
+      .mockResolvedValueOnce(docSnapshot(baseAppData({ workProgresses: [rootWorkProgress] }) as unknown as Record<string, unknown>))
+      .mockResolvedValueOnce(docSnapshot(undefined));
+    firestoreMocks.getDocs.mockResolvedValueOnce(querySnapshot([splitWorkProgress]));
+
+    const { getUserData } = await import('./userData/crud');
+
+    const result = await getUserData('user-1');
+
+    expect(result.workProgresses).toEqual([splitWorkProgress]);
+  });
+
+  it('移行済み判定がある場合は空サブコレクションでも旧rootへfallbackしない', async () => {
+    firestoreMocks.getDoc
+      .mockResolvedValueOnce(docSnapshot(baseAppData({ workProgresses: [rootWorkProgress] }) as unknown as Record<string, unknown>))
+      .mockResolvedValueOnce(docSnapshot({ workProgressesMigrated: true }));
+    firestoreMocks.getDocs.mockResolvedValueOnce(querySnapshot([]));
+
+    const { getUserData } = await import('./userData/crud');
+
+    const result = await getUserData('user-1');
+
+    expect(result.workProgresses).toEqual([]);
+  });
+});
+
+describe('subscribeUserData workProgresses split merge', () => {
+  const snapshotHandlers = new Map<string, (snapshot: unknown) => void>();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    snapshotHandlers.clear();
+    firestoreMocks.onSnapshot.mockImplementation((ref, next) => {
+      snapshotHandlers.set(ref.path, next);
+      return firestoreMocks.unsubscribe;
+    });
+  });
+
+  it('root doc更新とworkProgressesサブコレクション更新をAppData.workProgressesへ安全にマージする', async () => {
+    const received: AppData[] = [];
+    const { subscribeUserData } = await import('./userData/crud');
+
+    const unsubscribe = subscribeUserData('user-1', (data) => received.push(data));
+
+    snapshotHandlers.get('users/user-1')?.(
+      docSnapshot(baseAppData({
+        encouragementCount: 1,
+        workProgresses: [rootWorkProgress],
+      }) as unknown as Record<string, unknown>)
+    );
+    snapshotHandlers.get('users/user-1/_meta/dataSplits')?.(docSnapshot(undefined));
+    snapshotHandlers.get('users/user-1/workProgresses')?.(querySnapshot([splitWorkProgress]));
+
+    expect(received.at(-1)?.encouragementCount).toBe(1);
+    expect(received.at(-1)?.workProgresses).toEqual([splitWorkProgress]);
+
+    snapshotHandlers.get('users/user-1')?.(
+      docSnapshot(baseAppData({
+        encouragementCount: 2,
+        workProgresses: [rootWorkProgress],
+      }) as unknown as Record<string, unknown>)
+    );
+
+    expect(received.at(-1)?.encouragementCount).toBe(2);
+    expect(received.at(-1)?.workProgresses).toEqual([splitWorkProgress]);
+
+    unsubscribe();
+    expect(firestoreMocks.unsubscribe).toHaveBeenCalled();
+  });
+
+  it('移行済み判定がある場合は購読でも空サブコレクションを正として扱う', async () => {
+    const received: AppData[] = [];
+    const { subscribeUserData } = await import('./userData/crud');
+
+    subscribeUserData('user-1', (data) => received.push(data));
+
+    snapshotHandlers.get('users/user-1')?.(
+      docSnapshot(baseAppData({ workProgresses: [rootWorkProgress] }) as unknown as Record<string, unknown>)
+    );
+    snapshotHandlers.get('users/user-1/_meta/dataSplits')?.(
+      docSnapshot({ workProgressesMigrated: true })
+    );
+    snapshotHandlers.get('users/user-1/workProgresses')?.(querySnapshot([]));
+
+    expect(received.at(-1)?.workProgresses).toEqual([]);
+  });
+});

--- a/lib/firestore/userData.test.ts
+++ b/lib/firestore/userData.test.ts
@@ -137,16 +137,39 @@ describe('getUserData workProgresses split compatibility', () => {
 
     expect(result.workProgresses).toEqual([]);
   });
+
+  it('分離状態の読み込みに失敗した場合はroot workProgressesへfallbackする', async () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    firestoreMocks.getDoc
+      .mockResolvedValueOnce(docSnapshot(baseAppData({ workProgresses: [rootWorkProgress] }) as unknown as Record<string, unknown>))
+      .mockResolvedValueOnce(docSnapshot(undefined));
+    firestoreMocks.getDocs.mockRejectedValueOnce(new Error('permission denied'));
+
+    const { getUserData } = await import('./userData/crud');
+
+    const result = await getUserData('user-1');
+
+    expect(result.workProgresses).toEqual([rootWorkProgress]);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'Failed to load split workProgresses. Falling back to root workProgresses:',
+      expect.any(Error)
+    );
+
+    consoleWarnSpy.mockRestore();
+  });
 });
 
 describe('subscribeUserData workProgresses split merge', () => {
   const snapshotHandlers = new Map<string, (snapshot: unknown) => void>();
+  const errorHandlers = new Map<string, (error: Error) => void>();
 
   beforeEach(() => {
     vi.clearAllMocks();
     snapshotHandlers.clear();
-    firestoreMocks.onSnapshot.mockImplementation((ref, next) => {
+    errorHandlers.clear();
+    firestoreMocks.onSnapshot.mockImplementation((ref, next, error) => {
       snapshotHandlers.set(ref.path, next);
+      errorHandlers.set(ref.path, error);
       return firestoreMocks.unsubscribe;
     });
   });
@@ -198,5 +221,27 @@ describe('subscribeUserData workProgresses split merge', () => {
     snapshotHandlers.get('users/user-1/workProgresses')?.(querySnapshot([]));
 
     expect(received.at(-1)?.workProgresses).toEqual([]);
+  });
+
+  it('workProgresses購読が失敗してもroot docの購読結果をemitする', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const received: AppData[] = [];
+    const { subscribeUserData } = await import('./userData/crud');
+
+    subscribeUserData('user-1', (data) => received.push(data));
+
+    snapshotHandlers.get('users/user-1')?.(
+      docSnapshot(baseAppData({
+        encouragementCount: 4,
+        workProgresses: [rootWorkProgress],
+      }) as unknown as Record<string, unknown>)
+    );
+    snapshotHandlers.get('users/user-1/_meta/dataSplits')?.(docSnapshot(undefined));
+    errorHandlers.get('users/user-1/workProgresses')?.(new Error('permission denied'));
+
+    expect(received.at(-1)?.encouragementCount).toBe(4);
+    expect(received.at(-1)?.workProgresses).toEqual([rootWorkProgress]);
+
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/lib/firestore/userData/crud.ts
+++ b/lib/firestore/userData/crud.ts
@@ -15,7 +15,12 @@ import {
   normalizeWorkProgressQuerySnapshot,
   resolveWorkProgresses,
 } from '../workProgress/subcollection';
-import { writeQueues, SAVE_USER_DATA_DEBOUNCE_MS, executeWrite } from './write-queue';
+import {
+  writeQueues,
+  SAVE_USER_DATA_DEBOUNCE_MS,
+  executeWrite,
+  type SaveUserDataOptions,
+} from './write-queue';
 
 export async function getUserData(userId: string): Promise<AppData> {
   try {
@@ -25,7 +30,14 @@ export async function getUserData(userId: string): Promise<AppData> {
     if (userDoc.exists()) {
       const data = userDoc.data();
       const normalizedData = normalizeAppData(data);
-      const splitState = await loadWorkProgressSplitState(userId);
+      let splitState;
+
+      try {
+        splitState = await loadWorkProgressSplitState(userId);
+      } catch (error) {
+        console.warn('Failed to load split workProgresses. Falling back to root workProgresses:', error);
+        return normalizedData;
+      }
 
       return {
         ...normalizedData,
@@ -48,11 +60,12 @@ export async function getUserData(userId: string): Promise<AppData> {
   }
 }
 
-export async function saveUserData(userId: string, data: AppData): Promise<void> {
+export async function saveUserData(userId: string, data: AppData, options: SaveUserDataOptions = {}): Promise<void> {
   // キューが存在しない場合は初期化
   if (!writeQueues.has(userId)) {
     writeQueues.set(userId, {
       pendingData: null,
+      pendingOptions: null,
       timeoutId: null,
       isWriting: false,
       retryCount: 0,
@@ -72,6 +85,11 @@ export async function saveUserData(userId: string, data: AppData): Promise<void>
 
   // 最新のデータをキューに保存
   queue.pendingData = data;
+  queue.pendingOptions = {
+    syncWorkProgresses:
+      queue.pendingOptions?.syncWorkProgresses === true ||
+      options.syncWorkProgresses === true,
+  };
 
   // 書き込み中の場合は待機してから書き込み
   if (queue.isWriting) {
@@ -88,9 +106,11 @@ export async function saveUserData(userId: string, data: AppData): Promise<void>
   queue.timeoutId = setTimeout(async () => {
     if (queue.pendingData) {
       const dataToWrite = queue.pendingData;
+      const optionsToWrite = queue.pendingOptions ?? {};
       queue.pendingData = null;
+      queue.pendingOptions = null;
       queue.timeoutId = null;
-      await executeWrite(userId, dataToWrite);
+      await executeWrite(userId, dataToWrite, optionsToWrite);
     }
   }, SAVE_USER_DATA_DEBOUNCE_MS);
 
@@ -154,6 +174,9 @@ export function subscribeUserData(
     },
     (error) => {
       console.error('Error in workProgresses subscription:', error);
+      splitWorkProgresses = [];
+      hasWorkProgressesSnapshot = true;
+      emitMergedData();
     }
   );
 
@@ -166,6 +189,9 @@ export function subscribeUserData(
     },
     (error) => {
       console.error('Error in dataSplits subscription:', error);
+      isWorkProgressesSplitMigrated = false;
+      hasDataSplitsSnapshot = true;
+      emitMergedData();
     }
   );
 

--- a/lib/firestore/userData/crud.ts
+++ b/lib/firestore/userData/crud.ts
@@ -7,6 +7,14 @@ import {
 } from 'firebase/firestore';
 import { getUserDocRef, removeUndefinedFields, normalizeAppData, defaultData } from '../common';
 import type { AppData } from '@/types';
+import {
+  getDataSplitsDocRef,
+  getWorkProgressesCollectionRef,
+  isWorkProgressesMigrated,
+  loadWorkProgressSplitState,
+  normalizeWorkProgressQuerySnapshot,
+  resolveWorkProgresses,
+} from '../workProgress/subcollection';
 import { writeQueues, SAVE_USER_DATA_DEBOUNCE_MS, executeWrite } from './write-queue';
 
 export async function getUserData(userId: string): Promise<AppData> {
@@ -17,11 +25,21 @@ export async function getUserData(userId: string): Promise<AppData> {
     if (userDoc.exists()) {
       const data = userDoc.data();
       const normalizedData = normalizeAppData(data);
-      return normalizedData;
+      const splitState = await loadWorkProgressSplitState(userId);
+
+      return {
+        ...normalizedData,
+        workProgresses: resolveWorkProgresses(
+          normalizedData.workProgresses,
+          splitState.workProgresses,
+          splitState.isMigrated
+        ),
+      };
     }
 
     // ドキュメントが存在しない場合はデフォルトデータを作成
-    const cleanedDefaultData = removeUndefinedFields(defaultData);
+    const cleanedDefaultData = removeUndefinedFields(defaultData) as unknown as Record<string, unknown>;
+    delete cleanedDefaultData.workProgresses;
     await setDoc(userDocRef, cleanedDefaultData);
     return defaultData;
   } catch (error) {
@@ -84,21 +102,76 @@ export function subscribeUserData(
   callback: (data: AppData) => void
 ): () => void {
   const userDocRef = getUserDocRef(userId);
+  const workProgressesCollectionRef = getWorkProgressesCollectionRef(userId);
+  const dataSplitsDocRef = getDataSplitsDocRef(userId);
 
-  return onSnapshot(
+  let rootData: AppData = defaultData;
+  let splitWorkProgresses = defaultData.workProgresses;
+  let isWorkProgressesSplitMigrated = false;
+  let hasRootSnapshot = false;
+  let hasWorkProgressesSnapshot = false;
+  let hasDataSplitsSnapshot = false;
+
+  const emitMergedData = () => {
+    if (!hasRootSnapshot || !hasWorkProgressesSnapshot || !hasDataSplitsSnapshot) {
+      return;
+    }
+
+    callback({
+      ...rootData,
+      workProgresses: resolveWorkProgresses(
+        rootData.workProgresses,
+        splitWorkProgresses,
+        isWorkProgressesSplitMigrated
+      ),
+    });
+  };
+
+  const unsubscribeRoot = onSnapshot(
     userDocRef,
     (snapshot) => {
       if (snapshot.exists()) {
         const data = snapshot.data();
-        const normalizedData = normalizeAppData(data);
-        callback(normalizedData);
+        rootData = normalizeAppData(data);
       } else {
-        callback(defaultData);
+        rootData = defaultData;
       }
+      hasRootSnapshot = true;
+      emitMergedData();
     },
     (error) => {
       console.error('Error in Firestore subscription:', error);
       // エラー時はcallbackを呼ばない（既存データを保持する）
     }
   );
+
+  const unsubscribeWorkProgresses = onSnapshot(
+    workProgressesCollectionRef,
+    (snapshot) => {
+      splitWorkProgresses = normalizeWorkProgressQuerySnapshot(snapshot);
+      hasWorkProgressesSnapshot = true;
+      emitMergedData();
+    },
+    (error) => {
+      console.error('Error in workProgresses subscription:', error);
+    }
+  );
+
+  const unsubscribeDataSplits = onSnapshot(
+    dataSplitsDocRef,
+    (snapshot) => {
+      isWorkProgressesSplitMigrated = snapshot.exists() && isWorkProgressesMigrated(snapshot.data());
+      hasDataSplitsSnapshot = true;
+      emitMergedData();
+    },
+    (error) => {
+      console.error('Error in dataSplits subscription:', error);
+    }
+  );
+
+  return () => {
+    unsubscribeRoot();
+    unsubscribeWorkProgresses();
+    unsubscribeDataSplits();
+  };
 }

--- a/lib/firestore/userData/write-queue.ts
+++ b/lib/firestore/userData/write-queue.ts
@@ -2,12 +2,18 @@
 // Write stream exhausted対策として同時書き込み数を制限する
 
 import {
-  setDoc,
   deleteField,
+  doc,
+  getDocs,
+  writeBatch,
   type FieldValue,
 } from 'firebase/firestore';
-import { getUserDocRef, removeUndefinedFields } from '../common';
-import type { AppData } from '@/types';
+import { getDb, getUserDocRef, removeUndefinedFields } from '../common';
+import {
+  getDataSplitsDocRef,
+  getWorkProgressesCollectionRef,
+} from '../workProgress/subcollection';
+import type { AppData, WorkProgress } from '@/types';
 
 // デバウンス待機時間（ミリ秒）
 export const SAVE_USER_DATA_DEBOUNCE_MS = 300;
@@ -68,6 +74,42 @@ function releaseWriteSlot(): void {
   }
 }
 
+function removeRootWorkProgresses(data: Record<string, unknown>): Record<string, unknown> {
+  const rootData = { ...data };
+  delete rootData.workProgresses;
+  return rootData;
+}
+
+async function applyWorkProgressSplitWrites(
+  userId: string,
+  batch: ReturnType<typeof writeBatch>,
+  workProgresses: WorkProgress[]
+): Promise<void> {
+  const workProgressesCollectionRef = getWorkProgressesCollectionRef(userId);
+  const existingSnapshot = await getDocs(workProgressesCollectionRef);
+  const nextIds = new Set(workProgresses.map((workProgress) => workProgress.id));
+
+  existingSnapshot.docs.forEach((docSnapshot) => {
+    if (!nextIds.has(docSnapshot.id)) {
+      batch.delete(docSnapshot.ref);
+    }
+  });
+
+  workProgresses.forEach((workProgress) => {
+    const cleanedWorkProgress = removeUndefinedFields(workProgress) as unknown as Record<string, unknown>;
+    batch.set(doc(workProgressesCollectionRef, workProgress.id), cleanedWorkProgress, { merge: true });
+  });
+
+  batch.set(
+    getDataSplitsDocRef(userId),
+    {
+      workProgressesMigrated: true,
+      workProgressesMigratedAt: new Date().toISOString(),
+    },
+    { merge: true }
+  );
+}
+
 // 実際の書き込み処理を行う関数
 async function performWrite(userId: string, data: AppData): Promise<void> {
   await acquireWriteSlot();
@@ -120,7 +162,10 @@ async function performWrite(userId: string, data: AppData): Promise<void> {
       cleanedData.roastTimerState = deleteField();
     }
 
-    await setDoc(userDocRef, cleanedData, { merge: true });
+    const batch = writeBatch(getDb());
+    batch.set(userDocRef, removeRootWorkProgresses(cleanedData), { merge: true });
+    await applyWorkProgressSplitWrites(userId, batch, data.workProgresses);
+    await batch.commit();
   } finally {
     releaseWriteSlot();
   }

--- a/lib/firestore/userData/write-queue.ts
+++ b/lib/firestore/userData/write-queue.ts
@@ -28,6 +28,12 @@ export const writeQueues = new Map<string, {
   retryCount: number;
   pendingPromise: { resolve: () => void; reject: (error: unknown) => void } | null;
 }>();
+const workProgressesSyncSignatures = new Map<string, string>();
+
+export function clearWriteQueueStateForTests(): void {
+  writeQueues.clear();
+  workProgressesSyncSignatures.clear();
+}
 
 export interface SaveUserDataOptions {
   syncWorkProgresses?: boolean;
@@ -229,10 +235,19 @@ async function performWrite(userId: string, data: AppData, options: SaveUserData
 
     const batchWriter = createBatchWriter();
     batchWriter.add((batch) => batch.set(userDocRef, removeRootWorkProgresses(cleanedData), { merge: true }));
+    let syncedWorkProgressesSignature: string | null = null;
     if (options.syncWorkProgresses === true) {
-      await applyWorkProgressSplitWrites(userId, batchWriter, data.workProgresses);
+      const nextSyncSignature = stableStringify(data.workProgresses);
+      const previousSyncSignature = workProgressesSyncSignatures.get(userId);
+      if (previousSyncSignature !== nextSyncSignature) {
+        await applyWorkProgressSplitWrites(userId, batchWriter, data.workProgresses);
+        syncedWorkProgressesSignature = nextSyncSignature;
+      }
     }
     await batchWriter.commit();
+    if (syncedWorkProgressesSignature !== null) {
+      workProgressesSyncSignatures.set(userId, syncedWorkProgressesSignature);
+    }
   } finally {
     releaseWriteSlot();
   }

--- a/lib/firestore/userData/write-queue.ts
+++ b/lib/firestore/userData/write-queue.ts
@@ -7,6 +7,7 @@ import {
   getDocs,
   writeBatch,
   type FieldValue,
+  type WriteBatch,
 } from 'firebase/firestore';
 import { getDb, getUserDocRef, removeUndefinedFields } from '../common';
 import {
@@ -21,11 +22,16 @@ export const SAVE_USER_DATA_DEBOUNCE_MS = 300;
 // ユーザーごとの書き込みキューとリトライ管理
 export const writeQueues = new Map<string, {
   pendingData: AppData | null;
+  pendingOptions: SaveUserDataOptions | null;
   timeoutId: ReturnType<typeof setTimeout> | null;
   isWriting: boolean;
   retryCount: number;
   pendingPromise: { resolve: () => void; reject: (error: unknown) => void } | null;
 }>();
+
+export interface SaveUserDataOptions {
+  syncWorkProgresses?: boolean;
+}
 
 // 最大リトライ回数
 const MAX_RETRY_COUNT = 3;
@@ -43,6 +49,8 @@ const MAX_QUEUE_SIZE = 20;
 // 書き込み間隔の最小時間（ミリ秒）
 const MIN_WRITE_INTERVAL = 200;
 let lastWriteTime = 0;
+
+const MAX_BATCH_OPERATIONS = 450;
 
 /**
  * 書き込みスロットを取得する。利用可能なスロットがない場合は待機キューに追加する。
@@ -80,38 +88,95 @@ function removeRootWorkProgresses(data: Record<string, unknown>): Record<string,
   return rootData;
 }
 
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+  }
+
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
+      .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableStringify(entryValue)}`);
+    return `{${entries.join(',')}}`;
+  }
+
+  return JSON.stringify(value);
+}
+
+function areFirestorePayloadsEqual(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
+  return stableStringify(a) === stableStringify(b);
+}
+
+function createBatchWriter(): {
+  add: (operation: (batch: WriteBatch) => void) => void;
+  commit: () => Promise<void>;
+} {
+  const batches: WriteBatch[] = [writeBatch(getDb())];
+  let operationCount = 0;
+
+  return {
+    add: (operation) => {
+      if (operationCount >= MAX_BATCH_OPERATIONS) {
+        batches.push(writeBatch(getDb()));
+        operationCount = 0;
+      }
+      operation(batches[batches.length - 1]);
+      operationCount += 1;
+    },
+    commit: async () => {
+      for (const batch of batches) {
+        await batch.commit();
+      }
+    },
+  };
+}
+
 async function applyWorkProgressSplitWrites(
   userId: string,
-  batch: ReturnType<typeof writeBatch>,
+  batchWriter: ReturnType<typeof createBatchWriter>,
   workProgresses: WorkProgress[]
 ): Promise<void> {
   const workProgressesCollectionRef = getWorkProgressesCollectionRef(userId);
   const existingSnapshot = await getDocs(workProgressesCollectionRef);
   const nextIds = new Set(workProgresses.map((workProgress) => workProgress.id));
+  const existingById = new Map(
+    existingSnapshot.docs.map((docSnapshot) => [
+      docSnapshot.id,
+      removeUndefinedFields({
+        ...docSnapshot.data(),
+        id: typeof docSnapshot.data().id === 'string' ? docSnapshot.data().id : docSnapshot.id,
+      }) as Record<string, unknown>,
+    ])
+  );
 
   existingSnapshot.docs.forEach((docSnapshot) => {
     if (!nextIds.has(docSnapshot.id)) {
-      batch.delete(docSnapshot.ref);
+      batchWriter.add((batch) => batch.delete(docSnapshot.ref));
     }
   });
 
   workProgresses.forEach((workProgress) => {
     const cleanedWorkProgress = removeUndefinedFields(workProgress) as unknown as Record<string, unknown>;
-    batch.set(doc(workProgressesCollectionRef, workProgress.id), cleanedWorkProgress, { merge: true });
+    const existingWorkProgress = existingById.get(workProgress.id);
+    if (!existingWorkProgress || !areFirestorePayloadsEqual(existingWorkProgress, cleanedWorkProgress)) {
+      batchWriter.add((batch) => batch.set(doc(workProgressesCollectionRef, workProgress.id), cleanedWorkProgress));
+    }
   });
 
-  batch.set(
-    getDataSplitsDocRef(userId),
-    {
-      workProgressesMigrated: true,
-      workProgressesMigratedAt: new Date().toISOString(),
-    },
-    { merge: true }
+  batchWriter.add((batch) =>
+    batch.set(
+      getDataSplitsDocRef(userId),
+      {
+        workProgressesMigrated: true,
+        workProgressesMigratedAt: new Date().toISOString(),
+      },
+      { merge: true }
+    )
   );
 }
 
 // 実際の書き込み処理を行う関数
-async function performWrite(userId: string, data: AppData): Promise<void> {
+async function performWrite(userId: string, data: AppData, options: SaveUserDataOptions): Promise<void> {
   await acquireWriteSlot();
 
   try {
@@ -162,17 +227,24 @@ async function performWrite(userId: string, data: AppData): Promise<void> {
       cleanedData.roastTimerState = deleteField();
     }
 
-    const batch = writeBatch(getDb());
-    batch.set(userDocRef, removeRootWorkProgresses(cleanedData), { merge: true });
-    await applyWorkProgressSplitWrites(userId, batch, data.workProgresses);
-    await batch.commit();
+    const batchWriter = createBatchWriter();
+    batchWriter.add((batch) => batch.set(userDocRef, removeRootWorkProgresses(cleanedData), { merge: true }));
+    if (options.syncWorkProgresses === true) {
+      await applyWorkProgressSplitWrites(userId, batchWriter, data.workProgresses);
+    }
+    await batchWriter.commit();
   } finally {
     releaseWriteSlot();
   }
 }
 
 // 書き込みキューを実行し、リトライ処理を行う
-export async function executeWrite(userId: string, data: AppData, hasWaitedForQueue = false): Promise<void> {
+export async function executeWrite(
+  userId: string,
+  data: AppData,
+  options: SaveUserDataOptions = {},
+  hasWaitedForQueue = false
+): Promise<void> {
   const queue = writeQueues.get(userId);
   if (!queue) {
     throw new Error('Write queue not found');
@@ -186,7 +258,7 @@ export async function executeWrite(userId: string, data: AppData, hasWaitedForQu
       const refreshedQueuedWrites = writeWaitQueue.length + activeWriteCount;
       if (refreshedQueuedWrites >= MAX_QUEUE_SIZE) {
         console.warn(`Firestore write queue still saturated (${refreshedQueuedWrites}/${MAX_QUEUE_SIZE}) after extended wait, retrying once...`);
-        await executeWrite(userId, data, true);
+        await executeWrite(userId, data, options, true);
         return;
       }
     } else {
@@ -200,7 +272,7 @@ export async function executeWrite(userId: string, data: AppData, hasWaitedForQu
 
   while (queue.retryCount <= MAX_RETRY_COUNT) {
     try {
-      await performWrite(userId, data);
+      await performWrite(userId, data, options);
       queue.isWriting = false;
       queue.retryCount = 0;
 
@@ -210,10 +282,13 @@ export async function executeWrite(userId: string, data: AppData, hasWaitedForQu
 
       if (queue.pendingData) {
         const nextData = queue.pendingData;
+        const nextOptions = queue.pendingOptions ?? {};
         queue.pendingData = null;
-        await executeWrite(userId, nextData);
+        queue.pendingOptions = null;
+        await executeWrite(userId, nextData, nextOptions);
       } else {
         queue.pendingData = null;
+        queue.pendingOptions = null;
         queue.pendingPromise = null;
       }
 

--- a/lib/firestore/workProgress/crud.ts
+++ b/lib/firestore/workProgress/crud.ts
@@ -50,6 +50,8 @@ export async function addWorkProgress(
   await saveUserData(userId, {
     ...appData,
     workProgresses: updatedWorkProgresses,
+  }, {
+    syncWorkProgresses: true,
   });
 }
 
@@ -113,6 +115,8 @@ export async function updateWorkProgress(
   await saveUserData(userId, {
     ...appData,
     workProgresses: updatedWorkProgresses,
+  }, {
+    syncWorkProgresses: true,
   });
 }
 
@@ -181,6 +185,8 @@ export async function updateWorkProgresses(
     await saveUserData(userId, {
       ...appData,
       workProgresses: updatedWorkProgresses,
+    }, {
+      syncWorkProgresses: true,
     });
   }
 }
@@ -203,5 +209,7 @@ export async function deleteWorkProgress(
   await saveUserData(userId, {
     ...appData,
     workProgresses: updatedWorkProgresses,
+  }, {
+    syncWorkProgresses: true,
   });
 }

--- a/lib/firestore/workProgress/progress.ts
+++ b/lib/firestore/workProgress/progress.ts
@@ -58,6 +58,8 @@ export async function addCompletedCountToWorkProgress(
   await saveUserData(userId, {
     ...appData,
     workProgresses: updatedWorkProgresses,
+  }, {
+    syncWorkProgresses: true,
   });
 }
 
@@ -131,6 +133,8 @@ export async function addProgressToWorkProgress(
   await saveUserData(userId, {
     ...appData,
     workProgresses: updatedWorkProgresses,
+  }, {
+    syncWorkProgresses: true,
   });
 }
 
@@ -157,6 +161,8 @@ export async function archiveWorkProgress(
   await saveUserData(userId, {
     ...appData,
     workProgresses: updatedWorkProgresses,
+  }, {
+    syncWorkProgresses: true,
   });
 }
 
@@ -183,6 +189,8 @@ export async function unarchiveWorkProgress(
   await saveUserData(userId, {
     ...appData,
     workProgresses: updatedWorkProgresses,
+  }, {
+    syncWorkProgresses: true,
   });
 }
 
@@ -233,6 +241,8 @@ export async function updateProgressHistoryEntry(
   await saveUserData(userId, {
     ...appData,
     workProgresses: updatedWorkProgresses,
+  }, {
+    syncWorkProgresses: true,
   });
 }
 
@@ -277,5 +287,7 @@ export async function deleteProgressHistoryEntry(
   await saveUserData(userId, {
     ...appData,
     workProgresses: updatedWorkProgresses,
+  }, {
+    syncWorkProgresses: true,
   });
 }

--- a/lib/firestore/workProgress/subcollection.ts
+++ b/lib/firestore/workProgress/subcollection.ts
@@ -1,0 +1,80 @@
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  type DocumentData,
+  type QuerySnapshot,
+} from 'firebase/firestore';
+import { getDb, normalizeAppData } from '../common';
+import type { WorkProgress } from '@/types';
+
+export interface WorkProgressSplitState {
+  workProgresses: WorkProgress[];
+  isMigrated: boolean;
+}
+
+export function getWorkProgressesCollectionRef(userId: string) {
+  return collection(getDb(), 'users', userId, 'workProgresses');
+}
+
+export function getDataSplitsDocRef(userId: string) {
+  return doc(getDb(), 'users', userId, '_meta', 'dataSplits');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function isWorkProgressesMigrated(data: unknown): boolean {
+  if (!isRecord(data)) {
+    return false;
+  }
+
+  if (data.workProgressesMigrated === true) {
+    return true;
+  }
+
+  const nested = data.workProgresses;
+  return isRecord(nested) && nested.migrated === true;
+}
+
+export function normalizeWorkProgressDocuments(docs: Array<{ id: string; data: () => DocumentData }>): WorkProgress[] {
+  const rawWorkProgresses = docs.map((docSnapshot) => {
+    const data = docSnapshot.data();
+    return {
+      ...data,
+      id: typeof data.id === 'string' ? data.id : docSnapshot.id,
+    };
+  });
+
+  return normalizeAppData({ workProgresses: rawWorkProgresses as WorkProgress[] }).workProgresses;
+}
+
+export function normalizeWorkProgressQuerySnapshot(snapshot: QuerySnapshot<DocumentData>): WorkProgress[] {
+  return normalizeWorkProgressDocuments(snapshot.docs);
+}
+
+export function resolveWorkProgresses(
+  rootWorkProgresses: WorkProgress[],
+  splitWorkProgresses: WorkProgress[],
+  isMigrated: boolean
+): WorkProgress[] {
+  if (isMigrated || splitWorkProgresses.length > 0) {
+    return splitWorkProgresses;
+  }
+
+  return rootWorkProgresses;
+}
+
+export async function loadWorkProgressSplitState(userId: string): Promise<WorkProgressSplitState> {
+  const [dataSplitsDoc, workProgressesSnapshot] = await Promise.all([
+    getDoc(getDataSplitsDocRef(userId)),
+    getDocs(getWorkProgressesCollectionRef(userId)),
+  ]);
+
+  return {
+    workProgresses: normalizeWorkProgressQuerySnapshot(workProgressesSnapshot),
+    isMigrated: dataSplitsDoc.exists() && isWorkProgressesMigrated(dataSplitsDoc.data()),
+  };
+}

--- a/lib/firestore/write-queue.test.ts
+++ b/lib/firestore/write-queue.test.ts
@@ -105,7 +105,7 @@ function rootWritePayloads() {
 }
 
 async function flushSaveTimers(debounceMs: number) {
-  await vi.advanceTimersByTimeAsync(debounceMs + 1_000);
+  await vi.advanceTimersByTimeAsync(debounceMs + 10_000);
 }
 
 describe('saveUserData workProgresses split writes', () => {
@@ -130,7 +130,7 @@ describe('saveUserData workProgresses split writes', () => {
     const savePromise = saveUserData('user-1', appData({
       encouragementCount: 3,
       workProgresses: [keepProgress],
-    }));
+    }), { syncWorkProgresses: true });
 
     await flushSaveTimers(SAVE_USER_DATA_DEBOUNCE_MS);
     await savePromise;
@@ -141,8 +141,7 @@ describe('saveUserData workProgresses split writes', () => {
 
     expect(firestoreMocks.batch.set).toHaveBeenCalledWith(
       expect.objectContaining({ path: 'users/user-1/workProgresses/wp-keep' }),
-      expect.objectContaining({ id: 'wp-keep', taskName: '残す進捗' }),
-      { merge: true }
+      expect.objectContaining({ id: 'wp-keep', taskName: '残す進捗' })
     );
     expect(firestoreMocks.batch.set).toHaveBeenCalledWith(
       expect.objectContaining({ path: 'users/user-1/_meta/dataSplits' }),
@@ -154,7 +153,7 @@ describe('saveUserData workProgresses split writes', () => {
   it('既存root workProgressesを意図せず削除する書き込みをrootへ送らない', async () => {
     const { saveUserData, SAVE_USER_DATA_DEBOUNCE_MS } = await import('./userData');
 
-    const savePromise = saveUserData('user-1', appData({ workProgresses: [] }));
+    const savePromise = saveUserData('user-1', appData({ workProgresses: [] }), { syncWorkProgresses: true });
 
     await flushSaveTimers(SAVE_USER_DATA_DEBOUNCE_MS);
     await savePromise;
@@ -168,7 +167,7 @@ describe('saveUserData workProgresses split writes', () => {
 
     const { saveUserData, SAVE_USER_DATA_DEBOUNCE_MS } = await import('./userData');
 
-    const savePromise = saveUserData('user-1', appData({ workProgresses: [keepProgress] }));
+    const savePromise = saveUserData('user-1', appData({ workProgresses: [keepProgress] }), { syncWorkProgresses: true });
 
     await flushSaveTimers(SAVE_USER_DATA_DEBOUNCE_MS);
     await savePromise;
@@ -195,5 +194,67 @@ describe('saveUserData workProgresses split writes', () => {
     expect(rootWritePayloads()[0]).toMatchObject({
       todaySchedules: [{ id: 'today-1', date: '2026-05-24', timeLabels: [] }],
     });
+  });
+
+  it('workProgresses未変更の保存ではサブコレクションを読み書きしない', async () => {
+    const { saveUserData, SAVE_USER_DATA_DEBOUNCE_MS } = await import('./userData');
+
+    const savePromise = saveUserData('user-1', appData({
+      encouragementCount: 8,
+      workProgresses: [keepProgress],
+    }));
+
+    await flushSaveTimers(SAVE_USER_DATA_DEBOUNCE_MS);
+    await savePromise;
+
+    expect(rootWritePayloads()[0]).toMatchObject({ encouragementCount: 8 });
+    expect(rootWritePayloads()[0]).not.toHaveProperty('workProgresses');
+    expect(firestoreMocks.getDocs).not.toHaveBeenCalled();
+    expect(firestoreMocks.batch.set).not.toHaveBeenCalledWith(
+      expect.objectContaining({ path: 'users/user-1/workProgresses/wp-keep' }),
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it('既存サブコレクションdocと同じworkProgressは再setしない', async () => {
+    firestoreMocks.getDocs.mockResolvedValueOnce(querySnapshot([keepProgress]));
+    const { saveUserData, SAVE_USER_DATA_DEBOUNCE_MS } = await import('./userData');
+
+    const savePromise = saveUserData('user-1', appData({ workProgresses: [keepProgress] }), { syncWorkProgresses: true });
+
+    await flushSaveTimers(SAVE_USER_DATA_DEBOUNCE_MS);
+    await savePromise;
+
+    expect(firestoreMocks.batch.set).not.toHaveBeenCalledWith(
+      expect.objectContaining({ path: 'users/user-1/workProgresses/wp-keep' }),
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it('workProgress docはmergeではなく置換し、消えたフィールドを残さない', async () => {
+    const existingProgress: WorkProgress = {
+      ...keepProgress,
+      targetAmount: 10,
+      currentAmount: 4,
+      progressHistory: [{ id: 'history-1', date: '2026-05-21T00:00:00.000Z', amount: 4 }],
+    };
+    firestoreMocks.getDocs.mockResolvedValueOnce(querySnapshot([existingProgress]));
+    const { saveUserData, SAVE_USER_DATA_DEBOUNCE_MS } = await import('./userData');
+
+    const savePromise = saveUserData('user-1', appData({ workProgresses: [keepProgress] }), { syncWorkProgresses: true });
+
+    await flushSaveTimers(SAVE_USER_DATA_DEBOUNCE_MS);
+    await savePromise;
+
+    expect(firestoreMocks.batch.set).toHaveBeenCalledWith(
+      expect.objectContaining({ path: 'users/user-1/workProgresses/wp-keep' }),
+      expect.not.objectContaining({
+        targetAmount: expect.anything(),
+        currentAmount: expect.anything(),
+        progressHistory: expect.anything(),
+      })
+    );
   });
 });

--- a/lib/firestore/write-queue.test.ts
+++ b/lib/firestore/write-queue.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AppData, WorkProgress } from '@/types';
+
+const firestoreMocks = vi.hoisted(() => {
+  const deleteFieldSentinel = { __deleteField: true };
+  const batch = {
+    set: vi.fn(),
+    delete: vi.fn(),
+    commit: vi.fn(),
+  };
+
+  return {
+    batch,
+    deleteFieldSentinel,
+    getFirestore: vi.fn(() => ({ app: 'mock-firestore' })),
+    doc: vi.fn((first: { path?: string } | unknown, ...segments: string[]) => {
+      const basePath =
+        first && typeof first === 'object' && 'path' in first && typeof first.path === 'string'
+          ? first.path
+          : '';
+      const path = basePath ? [basePath, ...segments].join('/') : segments.join('/');
+      return { id: segments.at(-1), path };
+    }),
+    collection: vi.fn((first: { path?: string } | unknown, ...segments: string[]) => {
+      const basePath =
+        first && typeof first === 'object' && 'path' in first && typeof first.path === 'string'
+          ? first.path
+          : '';
+      const path = basePath ? [basePath, ...segments].join('/') : segments.join('/');
+      return { path };
+    }),
+    getDocs: vi.fn(),
+    setDoc: vi.fn(),
+    writeBatch: vi.fn(() => batch),
+    deleteField: vi.fn(() => deleteFieldSentinel),
+  };
+});
+
+vi.mock('../firebase', () => ({
+  default: {},
+}));
+
+vi.mock('firebase/firestore', () => ({
+  getFirestore: firestoreMocks.getFirestore,
+  doc: firestoreMocks.doc,
+  collection: firestoreMocks.collection,
+  getDocs: firestoreMocks.getDocs,
+  setDoc: firestoreMocks.setDoc,
+  writeBatch: firestoreMocks.writeBatch,
+  deleteField: firestoreMocks.deleteField,
+}));
+
+const keepProgress: WorkProgress = {
+  id: 'wp-keep',
+  taskName: '残す進捗',
+  status: 'in_progress',
+  createdAt: '2026-05-20T00:00:00.000Z',
+  updatedAt: '2026-05-21T00:00:00.000Z',
+  completedCount: 1,
+};
+
+const deleteProgress: WorkProgress = {
+  id: 'wp-delete',
+  taskName: '削除済み進捗',
+  status: 'pending',
+  createdAt: '2026-05-19T00:00:00.000Z',
+  updatedAt: '2026-05-19T00:00:00.000Z',
+};
+
+function appData(overrides: Partial<AppData> = {}): AppData {
+  return {
+    todaySchedules: [],
+    roastSchedules: [],
+    tastingSessions: [],
+    tastingRecords: [],
+    notifications: [],
+    encouragementCount: 0,
+    roastTimerRecords: [],
+    workProgresses: [],
+    dripRecipes: [],
+    ...overrides,
+  };
+}
+
+function querySnapshot(progresses: WorkProgress[]) {
+  return {
+    docs: progresses.map((progress) => ({
+      id: progress.id,
+      ref: { path: `users/user-1/workProgresses/${progress.id}` },
+      data: () => progress,
+    })),
+  };
+}
+
+function rootWritePayloads() {
+  const directWrites = firestoreMocks.setDoc.mock.calls
+    .filter(([ref]) => ref.path === 'users/user-1')
+    .map(([, data]) => data as Record<string, unknown>);
+  const batchWrites = firestoreMocks.batch.set.mock.calls
+    .filter(([ref]) => ref.path === 'users/user-1')
+    .map(([, data]) => data as Record<string, unknown>);
+
+  return [...directWrites, ...batchWrites];
+}
+
+async function flushSaveTimers(debounceMs: number) {
+  await vi.advanceTimersByTimeAsync(debounceMs + 1_000);
+}
+
+describe('saveUserData workProgresses split writes', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-24T00:00:00.000Z'));
+    vi.clearAllMocks();
+    firestoreMocks.getDocs.mockResolvedValue(querySnapshot([]));
+    firestoreMocks.setDoc.mockResolvedValue(undefined);
+    firestoreMocks.batch.commit.mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    const { writeQueues } = await import('./userData/write-queue');
+    writeQueues.clear();
+    vi.useRealTimers();
+  });
+
+  it('workProgressesをサブコレクションへ保存し、root users/{uid}.workProgressesを増やさない', async () => {
+    const { saveUserData, SAVE_USER_DATA_DEBOUNCE_MS } = await import('./userData');
+
+    const savePromise = saveUserData('user-1', appData({
+      encouragementCount: 3,
+      workProgresses: [keepProgress],
+    }));
+
+    await flushSaveTimers(SAVE_USER_DATA_DEBOUNCE_MS);
+    await savePromise;
+
+    expect(rootWritePayloads()).toHaveLength(1);
+    expect(rootWritePayloads()[0]).toMatchObject({ encouragementCount: 3 });
+    expect(rootWritePayloads()[0]).not.toHaveProperty('workProgresses');
+
+    expect(firestoreMocks.batch.set).toHaveBeenCalledWith(
+      expect.objectContaining({ path: 'users/user-1/workProgresses/wp-keep' }),
+      expect.objectContaining({ id: 'wp-keep', taskName: '残す進捗' }),
+      { merge: true }
+    );
+    expect(firestoreMocks.batch.set).toHaveBeenCalledWith(
+      expect.objectContaining({ path: 'users/user-1/_meta/dataSplits' }),
+      expect.objectContaining({ workProgressesMigrated: true }),
+      { merge: true }
+    );
+  });
+
+  it('既存root workProgressesを意図せず削除する書き込みをrootへ送らない', async () => {
+    const { saveUserData, SAVE_USER_DATA_DEBOUNCE_MS } = await import('./userData');
+
+    const savePromise = saveUserData('user-1', appData({ workProgresses: [] }));
+
+    await flushSaveTimers(SAVE_USER_DATA_DEBOUNCE_MS);
+    await savePromise;
+
+    expect(rootWritePayloads()).toHaveLength(1);
+    expect(rootWritePayloads()[0]).not.toHaveProperty('workProgresses');
+  });
+
+  it('AppDataから削除されたworkProgressesをサブコレクション側から削除する', async () => {
+    firestoreMocks.getDocs.mockResolvedValueOnce(querySnapshot([keepProgress, deleteProgress]));
+
+    const { saveUserData, SAVE_USER_DATA_DEBOUNCE_MS } = await import('./userData');
+
+    const savePromise = saveUserData('user-1', appData({ workProgresses: [keepProgress] }));
+
+    await flushSaveTimers(SAVE_USER_DATA_DEBOUNCE_MS);
+    await savePromise;
+
+    expect(firestoreMocks.batch.delete).toHaveBeenCalledWith(
+      expect.objectContaining({ path: 'users/user-1/workProgresses/wp-delete' })
+    );
+    expect(firestoreMocks.batch.delete).not.toHaveBeenCalledWith(
+      expect.objectContaining({ path: 'users/user-1/workProgresses/wp-keep' })
+    );
+  });
+
+  it('関係ないAppDataフィールドのroot保存挙動を維持する', async () => {
+    const { saveUserData, SAVE_USER_DATA_DEBOUNCE_MS } = await import('./userData');
+
+    const savePromise = saveUserData('user-1', appData({
+      todaySchedules: [{ id: 'today-1', date: '2026-05-24', timeLabels: [] }],
+      workProgresses: [],
+    }));
+
+    await flushSaveTimers(SAVE_USER_DATA_DEBOUNCE_MS);
+    await savePromise;
+
+    expect(rootWritePayloads()[0]).toMatchObject({
+      todaySchedules: [{ id: 'today-1', date: '2026-05-24', timeLabels: [] }],
+    });
+  });
+});

--- a/lib/firestore/write-queue.test.ts
+++ b/lib/firestore/write-queue.test.ts
@@ -119,8 +119,8 @@ describe('saveUserData workProgresses split writes', () => {
   });
 
   afterEach(async () => {
-    const { writeQueues } = await import('./userData/write-queue');
-    writeQueues.clear();
+    const { clearWriteQueueStateForTests } = await import('./userData/write-queue');
+    clearWriteQueueStateForTests();
     vi.useRealTimers();
   });
 

--- a/tests/rules/firebase.rules.test.ts
+++ b/tests/rules/firebase.rules.test.ts
@@ -120,6 +120,42 @@ describe('Firestore rules', () => {
       await assertFails(otherDoc.set({ date: '2026-05-23', assignments: [] }));
     });
   });
+
+  describe('users/{uid}/workProgresses/{workProgressId}', () => {
+    it('allows only the signed-in owner to read and write work progress documents', async () => {
+      const path = `users/${OWN_UID}/workProgresses/wp-1`;
+      const ownerDoc = firestoreFor(OWN_UID).doc(path);
+      const otherDoc = firestoreFor(OTHER_UID).doc(path);
+      const anonymousDoc = firestoreFor().doc(path);
+
+      await assertFails(anonymousDoc.get());
+      await assertFails(anonymousDoc.set({ id: 'wp-1', status: 'pending' }));
+
+      await assertSucceeds(ownerDoc.set({ id: 'wp-1', status: 'pending' }));
+      await assertSucceeds(ownerDoc.get());
+
+      await assertFails(otherDoc.get());
+      await assertFails(otherDoc.set({ id: 'wp-1', status: 'pending' }));
+    });
+  });
+
+  describe('users/{uid}/_meta/dataSplits', () => {
+    it('allows only the signed-in owner to read and write data split metadata', async () => {
+      const path = `users/${OWN_UID}/_meta/dataSplits`;
+      const ownerDoc = firestoreFor(OWN_UID).doc(path);
+      const otherDoc = firestoreFor(OTHER_UID).doc(path);
+      const anonymousDoc = firestoreFor().doc(path);
+
+      await assertFails(anonymousDoc.get());
+      await assertFails(anonymousDoc.set({ workProgressesMigrated: true }));
+
+      await assertSucceeds(ownerDoc.set({ workProgressesMigrated: true }));
+      await assertSucceeds(ownerDoc.get());
+
+      await assertFails(otherDoc.get());
+      await assertFails(otherDoc.set({ workProgressesMigrated: true }));
+    });
+  });
 });
 
 describe('Storage rules', () => {


### PR DESCRIPTION
Closes #407

## 変更したファイル
- `lib/firestore/workProgress/subcollection.ts`
- `lib/firestore/userData/crud.ts`
- `lib/firestore/userData/write-queue.ts`
- `firestore.rules`
- `lib/firestore/userData.test.ts`
- `lib/firestore/write-queue.test.ts`
- `tests/rules/firebase.rules.test.ts`

## 変更内容
- `workProgresses` の新しい保存パスを `users/{uid}/workProgresses/{workProgressId}` に追加しました。
- `workProgressId` は既存の `WorkProgress.id` を使います。
- `_meta/dataSplits` に `workProgressesMigrated: true` と `workProgressesMigratedAt` を保存し、移行済み判定に使います。
- `AppData.workProgresses` は配列のまま維持し、UI側の大きな作り直しはしていません。

## 読み込み優先順位
1. `_meta/dataSplits.workProgressesMigrated === true` の場合は、サブコレクションを正とする。
2. サブコレクションに `workProgresses` ドキュメントがある場合は、新形式を優先する。
3. 移行済み判定がなく、サブコレクションも空の場合だけ、旧root `users/{uid}.workProgresses` をfallbackとして読む。

## 旧root workProgressesとの互換方針
- 旧root `workProgresses` は今回削除しません。
- 既存ユーザーで新形式がない場合は旧rootから読み込めます。
- 移行済み判定がある場合は、サブコレクションが空でも旧root fallbackで復活させません。

## root doc肥大化の抑制
- `saveUserData` のroot保存 payload から `workProgresses` を除外しました。
- root `set` は `merge` 相当の batch write なので、既存root `workProgresses` は消さず、新規保存で増やし続けない形にしています。
- `workProgresses` の追加・更新・削除はサブコレクション側へ upsert/delete します。

## Firestore rules
- `users/{uid}/workProgresses/{workProgressId}` に owner-only read/write を追加しました。
- `_meta/dataSplits` は既存の `users/{uid}/_meta/{document=**}` owner-only ルールを使い、代表ケースをrules testに追加しました。

## 追加・更新したテスト
- `getUserData`
  - 新形式なしなら旧rootから読む
  - 新形式があれば新形式を優先する
  - 移行済み判定があれば空サブコレクションでも旧rootへfallbackしない
- `subscribeUserData`
  - root doc更新とworkProgressesサブコレクション更新を `AppData.workProgresses` にマージする
  - 移行済み判定がある空サブコレクションを正として扱う
- `saveUserData` / write queue
  - root `workProgresses` を増やさず、サブコレクションへ保存する
  - 既存root `workProgresses` を削除するpayloadを送らない
  - AppDataから削除されたworkProgressesをサブコレクション側から削除する
  - 関係ないAppDataフィールドのroot保存挙動を維持する
- rules test
  - owner / anonymous / other user の `workProgresses` read/write
  - owner / anonymous / other user の `_meta/dataSplits` read/write

## 確認コマンド
- `npm run typecheck` - 成功
- `npm run test:run` - 成功（97 files / 1299 tests passed）
- `npm run test:rules` - 成功（10 tests passed）
- `npm run build` - 成功
- `npm run lint` - 成功（既存の `MODULE_TYPELESS_PACKAGE_JSON` warning は表示）
- `npx vitest run lib/firestore/userData.test.ts lib/firestore/write-queue.test.ts` - 成功（9 tests passed）
- `git diff --check` - 成功（改行コード警告のみ）

## 手動確認
- 未実施です。作業進捗の実データ確認にはFirebase Authとユーザーデータ操作が必要なため、本番データへ触れずにunit/rules/buildで検証しました。
- 対象画面は `/progress` です。

## 残リスク
- 旧root `workProgresses` は互換用にまだ残ります。
- rollback後に新形式だけの最新変更を旧コードで読むには、copy-back等が別途必要です。
- `workProgresses` 以外のroot doc肥大化候補は未対応です。
- 1つの `WorkProgress.progressHistory` が極端に増える場合は、履歴の追加分離が必要です。

## このIssue外として触らなかったもの
- 全データの一括移行
- 旧root `workProgresses` の削除
- copy-back処理
- UI全体の作り直し
- Firestore rulesの全面再設計
- Cloud Functions / Storage Rules / 本番デプロイ
- #408や他Issueの実装
## 追記: Firestore rules deploy対応

### 対応が必要な理由
- PR #425 では `users/{uid}/workProgresses/{workProgressId}` の Firestore rules を追加している。
- `FirebaseExtended/action-hosting-deploy@v0` は Hosting 用Actionで、内部では Hosting deploy を行うため、Firestore rules は別途 Firebase CLI で deploy する必要がある。
- Hostingだけが先に本番反映されると、`/progress` が新しいサブコレクションへアクセスしたときに、旧rulesのまま `permission denied` になる可能性がある。

### 追加したworkflow変更
- `.github/workflows/firebase-hosting-merge.yml` の `detect_changes` に `firestore_rules_changed` output を追加。
- merge対象PRに `firestore.rules` が含まれる場合、`firestore_rules_changed=true` にする。
- `deploy_firestore_rules` job を追加し、既存の `FIREBASE_SERVICE_ACCOUNT_ROASTPLUS_72FA6` を使って `firebase deploy --only firestore:rules` を実行する。
- 既存の Hosting / Functions deploy job は維持。

### Hosting deployとの順序
- `build_and_deploy` は `deploy_firestore_rules` を `needs` に含める。
- `firestore.rules` と `lib/` などが同時に変わる場合は、Firestore rules deploy が成功またはskipされた後に Hosting build/deploy が進む。
- rules deploy が失敗した場合、Hosting deploy は進めない。

### 手動workflow_dispatch時の扱い
- `deploy_firestore_rules` boolean input を追加。
- 手動実行時は `deploy_hosting` / `deploy_functions` / `deploy_firestore_rules` を個別に選べる。
- Rulesだけ、Hostingだけ、Functionsだけ、複数同時の実行が可能。

### 追加確認
- `firestore.rules` のみ変更: `firestore_rules_changed=true`, `hosting_changed=false` になることをローカルで行単位確認。
- `lib/...` + `firestore.rules` 変更: `firestore_rules_changed=true`, `hosting_changed=true` になることをローカルで行単位確認。
- workflow YAML は既存 `yaml` パッケージで parse 成功。
- `npx actionlint .github/workflows/firebase-hosting-merge.yml` は `npm error could not determine executable to run` で未実行。

### 追加確認コマンド
- `git diff --check` - 成功（改行コード警告のみ）
- `npm run typecheck` - 成功
- `npm run test:run` - 成功（97 files / 1299 tests passed）
- `npm run test:rules` - 成功（10 tests passed）
- `npm run build` - 成功
- `npm run lint` - 成功（既存の `MODULE_TYPELESS_PACKAGE_JSON` warning は表示）
- `node -e "const fs = require('fs'); const yaml = require('yaml'); yaml.parse(fs.readFileSync('.github/workflows/firebase-hosting-merge.yml', 'utf8')); console.log('workflow yaml parsed');"` - 成功

### 追加の残リスク
- `FIREBASE_SERVICE_ACCOUNT_ROASTPLUS_72FA6` に Firestore rules deploy に必要な権限（例: Firebase Rules Admin）が不足している場合、rules deploy job は失敗する。
- `actionlint` によるGitHub Actions専用の静的解析は未実行。
## 追記: Codexレビュー対応

### 対応したレビュー指摘
- 関係ない `AppData` 保存でも `workProgresses` サブコレクション全件をbatch setしていた問題を修正。
- `users/{uid}/workProgresses/{workProgressId}` への保存を `{ merge: true }` ではなくdoc置換に変更し、`targetAmount` / `currentAmount` / `progressHistory` などの削除済みフィールドが残らないように修正。
- `getUserData` でサブコレクションまたは `_meta/dataSplits` の読み込みに失敗した場合、root `workProgresses` へfallbackするように修正。
- `subscribeUserData` で split listener が失敗しても root doc の購読結果をemitし続けるように修正。

### 実装メモ
- `saveUserData` に `syncWorkProgresses` オプションを追加。
- `useAppData` は `workProgresses` が変更された保存時だけ `syncWorkProgresses: true` を渡す。
- `lib/firestore/workProgress/*` の直接保存ルートは `syncWorkProgresses: true` を渡す。
- サブコレクション同期時も既存docと同じ内容は再setしない。
- batch操作は 450 operations ごとに分割し、Firestore batch上限の500に近づきすぎないようにした。

### 追加・更新したテスト
- `getUserData` の split-state 読み込み失敗時fallback。
- `subscribeUserData` の split listener 失敗時root emit継続。
- `saveUserData` の未変更 `workProgresses` 非同期化。
- 既存サブコレクションdocと同一内容の場合の再set回避。
- workProgress doc置換保存による stale field 防止。
- `useAppData` が `workProgresses` 変更時だけ `syncWorkProgresses: true` を渡すこと。

### 最新確認コマンド
- `git diff --check` - 成功（改行コード警告のみ）
- `npm run typecheck` - 成功
- `npm run test:run` - 成功（97 files / 1305 tests passed）
- `npm run test:rules` - 成功（10 tests passed）
- `npm run build` - 成功
- `npm run lint` - 成功（既存の `MODULE_TYPELESS_PACKAGE_JSON` warning は表示）
- `npx vitest run lib/firestore/userData.test.ts lib/firestore/write-queue.test.ts hooks/useAppData.test.ts` - 成功（34 tests passed）
