### PR TITLE
fix: workProgresses の過剰同期を抑制（#425 フォローアップ）

### DIFF
--- a/lib/firestore/userData/write-queue.ts
+++ b/lib/firestore/userData/write-queue.ts
@@ -28,6 +28,12 @@ export const writeQueues = new Map<string, {
   retryCount: number;
   pendingPromise: { resolve: () => void; reject: (error: unknown) => void } | null;
 }>();
+const workProgressesSyncSignatures = new Map<string, string>();
+
+export function clearWriteQueueStateForTests(): void {
+  writeQueues.clear();
+  workProgressesSyncSignatures.clear();
+}
 
 export interface SaveUserDataOptions {
   syncWorkProgresses?: boolean;
@@ -229,10 +235,19 @@ async function performWrite(userId: string, data: AppData, options: SaveUserData
 
     const batchWriter = createBatchWriter();
     batchWriter.add((batch) => batch.set(userDocRef, removeRootWorkProgresses(cleanedData), { merge: true }));
+    let syncedWorkProgressesSignature: string | null = null;
     if (options.syncWorkProgresses === true) {
-      await applyWorkProgressSplitWrites(userId, batchWriter, data.workProgresses);
+      const nextSyncSignature = stableStringify(data.workProgresses);
+      const previousSyncSignature = workProgressesSyncSignatures.get(userId);
+      if (previousSyncSignature !== nextSyncSignature) {
+        await applyWorkProgressSplitWrites(userId, batchWriter, data.workProgresses);
+        syncedWorkProgressesSignature = nextSyncSignature;
+      }
     }
     await batchWriter.commit();
+    if (syncedWorkProgressesSignature !== null) {
+      workProgressesSyncSignatures.set(userId, syncedWorkProgressesSignature);
+    }
   } finally {
     releaseWriteSlot();
   }

--- a/lib/firestore/write-queue.test.ts
+++ b/lib/firestore/write-queue.test.ts
@@ -119,8 +119,8 @@ describe('saveUserData workProgresses split writes', () => {
   });
 
   afterEach(async () => {
-    const { writeQueues } = await import('./userData/write-queue');
-    writeQueues.clear();
+    const { clearWriteQueueStateForTests } = await import('./userData/write-queue');
+    clearWriteQueueStateForTests();
     vi.useRealTimers();
   });
 


### PR DESCRIPTION
### Motivation
- 結論：`saveUserData(..., { syncWorkProgresses: true })` が関係ない root フィールド更新でも毎回サブコレクション全件の読み書きを行い、Firestore バッチ上限や不要な書き込みを招く問題を修正するための対応です。 

### Description
- `lib/firestore/userData/write-queue.ts` にユーザー単位の `workProgresses` 同期シグネチャキャッシュを追加し、前回同期時と内容が同一なら `applyWorkProgressSplitWrites` をスキップするようにしました。 
- 同期済みシグネチャは `batch.commit()` 成功後にのみ更新して、途中失敗で不整合にならないようにしました。 
- テスト用にキューとシグネチャをリセットする `clearWriteQueueStateForTests()` を `lib/firestore/userData/write-queue.ts` へ追加し、既存テストを `lib/firestore/write-queue.test.ts` 側で利用するように更新しました。 
- レビューで上がった残り2件（split-state読み込み失敗時の root フォールバック、doc のマージではなく置換で消えたフィールドが残る問題）は既存実装／テストにより担保されていることを確認しました。 

### Testing
- 単体テストを実行して修正の回帰がないことを確認しました：`npx vitest run lib/firestore/write-queue.test.ts lib/firestore/userData.test.ts` は両ファイルとも成功しました。 
- 変更前にテストでタイムアウトしていたケースは、同期スキップロジック導入後に解消され、全テストが通過しています。 
- 追加の手動検証は未実施で、影響範囲は `saveUserData` のサブコレクション同期ロジックとテスト後処理に限定しています。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12017ed13c83319ab83ff18a4fef88)