### PR TITLE
[P1] デプロイ前品質ゲートを強化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,14 +3,20 @@ name: CI
 on:
   pull_request:
     branches: [main]
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
-      - "AGENTS.md"
-      - "CLAUDE.md"
-      - "DESIGN.md"
 
 jobs:
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -92,6 +92,17 @@ jobs:
     needs: detect_changes
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+      - run: npm ci
+      - name: Test Firestore Rules
+        run: npm run test:rules
       - name: Deploy Firestore Rules
         uses: w9jds/firebase-action@v15.10.0
         with:
@@ -113,7 +124,15 @@ jobs:
         with:
           node-version: 24
           cache: npm
-      - run: npm ci && npm run build
+      - run: npm ci
+      - name: Typecheck
+        run: npm run typecheck
+      - name: Lint
+        run: npm run lint
+      - name: Unit Tests
+        run: npm run test:run
+      - name: Build
+        run: npm run build
         env:
           NEXT_PUBLIC_FIREBASE_API_KEY: ${{ secrets.NEXT_PUBLIC_FIREBASE_API_KEY }}
           NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: ${{ secrets.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN }}


### PR DESCRIPTION
Closes #408

## 変更したworkflow
- `.github/workflows/ci.yml`
- `.github/workflows/firebase-hosting-merge.yml`

## 追加・変更した品質ゲート
- PR向けCIに `Typecheck` job を追加し、`npm run typecheck` を実行します。
- PR向けCIの `paths-ignore` を外し、branch protection の required checks にしやすい形にしました。
- Hosting deploy 前に `npm run typecheck` / `npm run lint` / `npm run test:run` / `npm run build` を順番に実行します。
- Firestore rules deploy 前に Java 21 をセットアップし、`npm run test:rules` を実行します。
- `package.json` のscript追加はしていません。既存scriptで必要な品質ゲートを表現できるためです。

## PR時に実行されるcheck
- `Typecheck`: `npm run typecheck`
- `Lint`: `npm run lint`
- `Unit Tests`: `npm run test:run`
- `Build`: `npm run build`

## Hosting deploy前に実行されるcheck
`build_and_deploy` job 内で、以下がすべて成功した場合だけ `FirebaseExtended/action-hosting-deploy@v0` に進みます。

- `npm run typecheck`
- `npm run lint`
- `npm run test:run`
- `npm run build`

## Firestore rules変更時の扱い
- `firestore.rules` 変更時は `deploy_firestore_rules` job が動きます。
- `npm run test:rules` が成功した場合だけ `firebase deploy --only firestore:rules` に進みます。
- `lib` などHosting対象と `firestore.rules` が同時に変わる場合、Firestore rules deploy 成功後に Hosting deploy の品質ゲートへ進みます。

## Functions deployへの影響
- `deploy_functions` job と Functionsコードは変更していません。
- `functions/` または `firebase.json` 変更時の既存判定、`cd functions && npm ci && npm run build`、Functions deploy の流れは維持しています。

## workflow_dispatch時の扱い
- Hostingだけ実行: `deploy_hosting=true` の場合、Hosting品質ゲート4コマンドが成功した場合だけ Hosting deploy に進みます。
- Firestore rulesだけ実行: `deploy_firestore_rules=true` の場合、`npm run test:rules` 成功後に rules deploy へ進み、Hosting deploy は実行されません。
- Hosting + Firestore rules: `test:rules` と rules deploy 成功後、Hosting品質ゲート4コマンドが成功した場合だけ Hosting deploy に進みます。
- Functionsだけ実行: 既存どおり Functions build/deploy のみが対象です。

## 変更パターン別の動き
- `lib/` 配下のみ変更: PR CI 4チェック実行。merge後は Hosting品質ゲート4コマンド成功後に Hosting deploy。
- `firestore.rules` のみ変更: PR CI 4チェック実行。merge後は `test:rules` 成功後に Firestore rules deploy。Hosting deploy はスキップ。
- `lib/` + `firestore.rules` 変更: PR CI 4チェック実行。merge後は `test:rules` + rules deploy 成功後に Hosting品質ゲート、成功時のみ Hosting deploy。
- docsのみ変更: PR CI 4チェック実行。merge後の deploy workflow は既存の `paths-ignore` によりスキップ。

## branch protectionで必須にすべきcheck候補
GitHub設定は変更していません。main保護で required checks にする候補は以下です。

- `Typecheck`
- `Lint`
- `Unit Tests`
- `Build`

## 実行した確認コマンドと結果
- `npm run typecheck` - 成功
- `npm run lint` - 成功（既存の Node module type 警告あり、終了コード0）
- `npm run test:run` - 成功（97 files / 1305 tests）
- `npm run build` - 成功
- `npm run test:rules` - 成功（1 file / 10 tests。Firebase emulatorの既存警告あり、終了コード0）
- YAML parse確認 - 成功（`.github/workflows/ci.yml` / `.github/workflows/firebase-hosting-merge.yml`）
- `actionlint -version` - 未実行扱い。ローカル環境に `actionlint` が未インストールでした。

## GitHub Actions上で確認すべきこと
- PRで `Typecheck` / `Lint` / `Unit Tests` / `Build` が成功すること。
- main merge後、Hosting deploy 前に4コマンドが実行されること。
- `firestore.rules` 変更時、rules deploy 前に `npm run test:rules` が実行されること。
- GitHub Actions上の secrets / `NEXT_PUBLIC_*` が不足していないこと。

## 残リスク
- CI時間が長くなる可能性があります。
- secrets不足や環境変数不足で build/deploy が落ちる可能性があります。
- branch protection自体は手動設定が必要です。
- `actionlint` はローカル未導入のため未実行です。

## このIssue外として触らなかったもの
- Firebase本番への手動deploy
- GitHub repository settings / branch protection の直接変更
- Firestore rules本体
- Functionsコード
- `public/` 配下
- 依存関係の更新
