### PR TITLE
chore: Gitleaksによる秘密情報スキャンを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,21 @@ on:
     branches: [main]
 
 jobs:
+  secrets-scan:
+    name: Secrets Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run Gitleaks on PR commits
+        run: |
+          docker run --rm \
+            -v "$PWD:/repo" \
+            -w /repo \
+            ghcr.io/gitleaks/gitleaks:v8.30.0 \
+            git --redact --no-banner --log-opts="origin/${{ github.base_ref }}..HEAD"
+
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest
@@ -87,3 +102,4 @@ jobs:
           NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: ${{ secrets.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET }}
           NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID }}
           NEXT_PUBLIC_FIREBASE_APP_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_APP_ID }}
+          NEXT_PUBLIC_RECAPTCHA_SITE_KEY: ${{ secrets.NEXT_PUBLIC_RECAPTCHA_SITE_KEY }}

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -140,6 +140,7 @@ jobs:
           NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: ${{ secrets.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET }}
           NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID }}
           NEXT_PUBLIC_FIREBASE_APP_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_APP_ID }}
+          NEXT_PUBLIC_RECAPTCHA_SITE_KEY: ${{ secrets.NEXT_PUBLIC_RECAPTCHA_SITE_KEY }}
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,9 @@
 npx lint-staged
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "gitleaks is required for secret scanning. Install it before committing."
+  echo "Windows: winget install Gitleaks.Gitleaks"
+  exit 1
+fi
+
+npm run secrets:scan:staged

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,6 +198,7 @@ npm run test:run
 npm run test:rules
 npm run test:coverage
 npm run test:e2e
+npm run secrets:scan
 ```
 
 ### SDD の運用方針
@@ -246,6 +247,8 @@ TDD が必要な変更では、受け入れ条件をテストに対応づけて�
 - UI/E2E変更では必要に応じて npm run test:e2e を実行する。
 - functions/ を変更した場合は、Functions側の build/test も確認する。
 - Lint は Husky pre-commit でも実行されるが、必要に応じて npm run lint を手動実行する。
+- 秘密情報の混入確認には Gitleaks を使い、手動確認では npm run secrets:scan を実行する。
+- pre-commit では Husky 経由で npm run secrets:scan:staged が実行される。
 - ロジック変更では、既存テストを優先して更新・追加する。
 - 検証できない場合は、未検証の理由とユーザーが実行すべきコマンドを報告する。
 

--- a/lib/appCheck.test.ts
+++ b/lib/appCheck.test.ts
@@ -43,6 +43,25 @@ describe('initializeRoastPlusAppCheck', () => {
     expect(window.__ROASTPLUS_APP_CHECK_INITIALIZED__).toBe(true);
   });
 
+  it('環境変数のサイトキーでApp Checkを初期化する', async () => {
+    vi.stubEnv('NEXT_PUBLIC_RECAPTCHA_SITE_KEY', 'env-site-key');
+    const { initializeRoastPlusAppCheck } = await import('./appCheck');
+
+    initializeRoastPlusAppCheck(mockFirebaseApp);
+
+    expect(mockReCaptchaV3Provider).toHaveBeenCalledWith('env-site-key');
+    expect(mockInitializeAppCheck).toHaveBeenCalled();
+  });
+
+  it('サイトキーがない場合は初期化しない', async () => {
+    const { initializeRoastPlusAppCheck } = await import('./appCheck');
+
+    initializeRoastPlusAppCheck(mockFirebaseApp);
+
+    expect(mockInitializeAppCheck).not.toHaveBeenCalled();
+    expect(window.__ROASTPLUS_APP_CHECK_INITIALIZED__).toBe(false);
+  });
+
   it('Functions Emulator利用時は初期化しない', async () => {
     vi.stubEnv('NEXT_PUBLIC_FIREBASE_FUNCTIONS_EMULATOR', 'true');
     const { initializeRoastPlusAppCheck } = await import('./appCheck');

--- a/lib/appCheck.ts
+++ b/lib/appCheck.ts
@@ -1,8 +1,6 @@
 import type { FirebaseApp } from 'firebase/app';
 import { initializeAppCheck, ReCaptchaV3Provider } from 'firebase/app-check';
 
-const DEFAULT_RECAPTCHA_SITE_KEY = '6Ld3s_csAAAAAE_z_o109tYNXPrIcuHiEpQ1LdkT';
-
 interface AppCheckOptions {
   siteKey?: string;
 }
@@ -14,7 +12,7 @@ declare global {
 }
 
 function getRecaptchaSiteKey(siteKey?: string): string {
-  return (siteKey ?? process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY ?? DEFAULT_RECAPTCHA_SITE_KEY).trim();
+  return (siteKey ?? process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY ?? '').trim();
 }
 
 export function initializeRoastPlusAppCheck(app: FirebaseApp, options: AppCheckOptions = {}): void {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "test:coverage": "vitest run --coverage",
     "generate:sound-list": "tsx scripts/generate-sound-list.ts",
     "prepare": "husky",
+    "secrets:scan": "gitleaks git --redact --no-banner --log-opts=\"origin/main..HEAD\"",
+    "secrets:scan:staged": "gitleaks git --staged --redact --no-banner",
     "security": "npm audit --audit-level=high",
     "complexity": "lizard ./app ./components ./hooks ./lib ./types ./scripts -C 15 -L 50 -w",
     "deadcode": "knip",


### PR DESCRIPTION
## 概要
- PR CI に Secrets Scan ジョブを追加し、Gitleaks でPRコミット範囲をスキャンするようにしました。
- Husky pre-commit に staged差分のGitleaksスキャンを追加しました。
- 手動確認用に npm run secrets:scan / npm run secrets:scan:staged を追加しました。
- App Check の reCAPTCHA site key のハードコードを削除し、NEXT_PUBLIC_RECAPTCHA_SITE_KEY から読むようにしました。
- CI / Firebase Hosting build に NEXT_PUBLIC_RECAPTCHA_SITE_KEY を渡すようにしました。
- AGENTS.md にGitleaks運用ルールを追記しました。

## 検証
- npm run secrets:scan
- npm run secrets:scan:staged
- npm run format:check
- npm run typecheck
- npx vitest run lib/appCheck.test.ts
- npm run lint
- npm run build
- npm run test:run
- git diff --check

## 残リスク・確認事項
- 既存のGit履歴全体にはGitleaks検出が7件あります。今回のPRは今後の混入防止と現行コードからのApp Check site key除去を目的にしています。
- 過去履歴の検出は、秘密情報のローテーション要否確認と履歴書き換えの要否判断を別作業で扱うのが安全です。
- GitHub branch protection の required status checks には、PR workflow 実行後に Secrets Scan を追加してください。