### PR TITLE
[P2] アクセシビリティ serious 指摘を改善

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -42,20 +42,20 @@
     /* テキスト */
     --ink: #1f2937;
     --ink-sub: #4b5563;
-    --ink-muted: #9ca3af;
+    --ink-muted: #6b7280;
     /* ボーダー */
     --edge: #e5e7eb;
     --edge-strong: #d1d5db;
     --edge-subtle: #f3f4f6;
     /* アクセント */
-    --spot: #d97706;
-    --spot-hover: #b45309;
+    --spot: #b45309;
+    --spot-hover: #92400e;
     --spot-subtle: #f0f0f0;
     --spot-surface: #f7f7f7;
     --on-spot: #ffffff;
     /* ボタン */
-    --btn-primary: #d97706;
-    --btn-primary-hover: #b45309;
+    --btn-primary: #b45309;
+    --btn-primary-hover: #92400e;
     /* ステータスカラー */
     --danger: #dc2626;
     --danger-subtle: #fee2e2;

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -132,7 +132,12 @@ export default function SettingsPage() {
                 <p className="text-sm text-ink-sub">開発者向けの機能を有効化します</p>
               </div>
               <div className="ml-4">
-                <Switch size="lg" checked={isEnabled} onChange={(e) => handleToggleChange(e.target.checked)} />
+                <Switch
+                  size="lg"
+                  checked={isEnabled}
+                  onChange={(e) => handleToggleChange(e.target.checked)}
+                  aria-label="開発者モードを切り替える"
+                />
               </div>
             </div>
           </Card>

--- a/components/Loading.tsx
+++ b/components/Loading.tsx
@@ -45,7 +45,7 @@ export function Loading({ message = '読み込み中...', fullScreen = true }: L
         <div className="flex justify-center mb-4">
           {isLoading || !animationData ? (
             <div className="w-[200px] h-[200px] flex items-center justify-center">
-              <div className="text-gray-400">読み込み中...</div>
+              <div className="text-ink-muted">読み込み中...</div>
             </div>
           ) : (
             <Lottie animationData={animationData} loop={true} style={{ width: 200, height: 200 }} />

--- a/components/ui/Switch.tsx
+++ b/components/ui/Switch.tsx
@@ -91,6 +91,8 @@ export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
           id={switchId}
           type="checkbox"
           className="sr-only"
+          aria-label={label ? undefined : ariaLabel}
+          aria-labelledby={label ? `${switchId}-label` : undefined}
           checked={checked}
           onChange={props.onChange || (() => {})}
           disabled={disabled}

--- a/e2e/accessibility/a11y.spec.ts
+++ b/e2e/accessibility/a11y.spec.ts
@@ -1,0 +1,177 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test, type Page } from '@playwright/test';
+
+const E2E_AUTH_STORAGE_KEY = 'roastplus_e2e_auth';
+const E2E_USER_ID = 'e2e-user';
+
+interface A11yPage {
+  name: string;
+  path: string;
+  authenticated?: boolean;
+}
+
+const pages: A11yPage[] = [
+  { name: 'ホーム', path: '/', authenticated: true },
+  { name: 'クイズトップ', path: '/coffee-trivia', authenticated: true },
+  { name: 'タイマー', path: '/roast-timer', authenticated: true },
+  { name: 'スケジュール', path: '/schedule', authenticated: true },
+  { name: 'テイスティング', path: '/tasting', authenticated: true },
+  { name: 'ログイン', path: '/login' },
+  { name: '担当表', path: '/assignment', authenticated: true },
+  { name: 'ドリップガイド', path: '/drip-guide', authenticated: true },
+  { name: '欠点豆', path: '/defect-beans', authenticated: true },
+  { name: '設定', path: '/settings', authenticated: true },
+  { name: 'お問い合わせ', path: '/contact', authenticated: true },
+  { name: '変更履歴', path: '/changelog', authenticated: true },
+];
+
+async function preparePage(page: Page, target: A11yPage) {
+  await page.addInitScript(
+    ({ isAuthenticated, authKey, userId }) => {
+      if (isAuthenticated) {
+        window.localStorage.setItem(authKey, userId);
+        return;
+      }
+
+      window.localStorage.removeItem(authKey);
+    },
+    {
+      isAuthenticated: target.authenticated === true,
+      authKey: E2E_AUTH_STORAGE_KEY,
+      userId: E2E_USER_ID,
+    }
+  );
+}
+
+function formatViolation(violation: Awaited<ReturnType<AxeBuilder['analyze']>>['violations'][number]) {
+  const targets = violation.nodes
+    .slice(0, 5)
+    .map((node) => `${node.target.join(' ')}${node.failureSummary ? `: ${node.failureSummary}` : ''}`);
+
+  return [
+    `[${violation.impact ?? 'unknown'}] ${violation.id}: ${violation.description} (${violation.nodes.length}箇所)`,
+    ...targets.map((target) => `  - ${target}`),
+  ].join('\n');
+}
+
+test.describe('アクセシビリティ: axe-core自動スキャン', () => {
+  for (const target of pages) {
+    test(`${target.name}ページにcriticalな違反がない`, async ({ page }) => {
+      await preparePage(page, target);
+      await page.goto(target.path);
+      await page.waitForLoadState('domcontentloaded');
+
+      const results = await new AxeBuilder({ page })
+        .withTags(['wcag2a', 'wcag2aa', 'wcag22aa'])
+        .options({
+          rules: {
+            'target-size': { enabled: true },
+          },
+        })
+        .analyze();
+
+      const seriousViolations = results.violations.filter((violation) => violation.impact === 'serious');
+      if (seriousViolations.length > 0) {
+        const nodeCount = seriousViolations.reduce((total, violation) => total + violation.nodes.length, 0);
+        console.log(
+          [
+            `[a11y serious] ${target.name} ${target.path}: ${seriousViolations.length}種類 / ${nodeCount}箇所`,
+            ...seriousViolations.map(formatViolation),
+          ].join('\n')
+        );
+      }
+
+      const criticalViolations = results.violations.filter((violation) => violation.impact === 'critical');
+      expect(criticalViolations).toHaveLength(0);
+    });
+  }
+});
+
+test.describe('アクセシビリティ: キーボードナビゲーション', () => {
+  test('ホームページでTabキーによるナビゲーションが動作する', async ({ page }) => {
+    await preparePage(page, pages[0]);
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+
+    await page.keyboard.press('Tab');
+    const firstFocusedTag = await page.evaluate(() => document.activeElement?.tagName.toLowerCase() ?? null);
+    expect(firstFocusedTag).not.toBeNull();
+
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    const thirdFocusedTag = await page.evaluate(() => document.activeElement?.tagName.toLowerCase() ?? null);
+    expect(thirdFocusedTag).not.toBeNull();
+  });
+
+  test('Escapeキーでモーダルを閉じられる', async ({ page }) => {
+    await preparePage(page, { name: 'スケジュール', path: '/schedule', authenticated: true });
+    await page.goto('/schedule');
+    await page.waitForLoadState('domcontentloaded');
+
+    const dateButton = page.getByRole('button', { name: '日付を選択' }).first();
+    await expect(dateButton).toBeVisible({ timeout: 10_000 });
+    await dateButton.click();
+
+    await page.keyboard.press('Escape');
+    await expect(page.getByRole('dialog')).toBeHidden({ timeout: 10_000 });
+  });
+
+  test('Enterキーでリンクをアクティベートできる', async ({ page }) => {
+    await preparePage(page, pages[0]);
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+
+    const links = page.locator('a[href]:visible');
+    const linkCount = await links.count();
+
+    if (linkCount > 0) {
+      await links.first().focus();
+      await page.keyboard.press('Enter');
+      await page.waitForLoadState('domcontentloaded');
+      expect(page.url()).toBeTruthy();
+    }
+  });
+});
+
+test.describe('アクセシビリティ: ARIA属性', () => {
+  test('ボタンにアクセシブルな名前がある', async ({ page }) => {
+    await preparePage(page, pages[0]);
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+
+    const buttons = page.locator('button:visible');
+    const count = await buttons.count();
+
+    for (let i = 0; i < Math.min(count, 20); i += 1) {
+      const button = buttons.nth(i);
+      const ariaLabel = await button.getAttribute('aria-label');
+      const text = await button.textContent();
+      const title = await button.getAttribute('title');
+
+      const hasAccessibleName =
+        (ariaLabel !== null && ariaLabel.trim().length > 0) ||
+        (text !== null && text.trim().length > 0) ||
+        (title !== null && title.trim().length > 0);
+      expect(hasAccessibleName).toBe(true);
+    }
+  });
+
+  test('画像にalt属性がある', async ({ page }) => {
+    await preparePage(page, pages[0]);
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+
+    const images = page.locator('img:visible');
+    const count = await images.count();
+
+    for (let i = 0; i < count; i += 1) {
+      const img = images.nth(i);
+      const alt = await img.getAttribute('alt');
+      const role = await img.getAttribute('role');
+
+      if (role !== 'presentation' && role !== 'none') {
+        expect(alt).not.toBeNull();
+      }
+    }
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -27,6 +27,13 @@ export default defineConfig({
       },
       dependencies: ['setup'],
     },
+    {
+      name: 'a11y',
+      testMatch: /accessibility\/a11y\.spec\.ts/,
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
   ],
   webServer: {
     command: 'env-cmd -f e2e/e2e.env npm run dev -- --port 3100',


### PR DESCRIPTION
Closes #409

## 修正前の serious 指摘の概要
- `npx playwright test e2e/accessibility/a11y.spec.ts` は、`e2e/accessibility/a11y.spec.ts` が削除済みだったため最初は `No tests found`。
- 削除前のa11y検査を復元し、`target-size` も有効化して baseline を取得。
- baseline: serious 177箇所 / critical 2箇所。
- serious は全て `color-contrast`。
  - ホーム: 3
  - スケジュール: 6
  - テイスティング: 1
  - ログイン: 1
  - ドリップガイド: 7
  - 欠点豆: 1
  - 設定: 1
  - お問い合わせ: 4
  - 変更履歴: 153
- critical は設定ページのSwitchラベル不足2件。

## 修正したページ
- ホーム
- クイズトップ / テイスティング / 欠点豆の読み込み表示
- ログイン
- スケジュール
- ドリップガイド
- 設定
- お問い合わせ
- 変更履歴

## 修正した種類
- 色コントラスト
  - 標準テーマの `--ink-muted` を濃くし、薄い補助テキストのコントラストを改善。
  - 標準テーマの `--spot` / `--btn-primary` を濃くし、白文字ボタンとアクセント文字のコントラストを改善。
  - `Loading` の `text-gray-400` を既存トークン `text-ink-muted` に変更。
- ラベル不足
  - 設定ページの開発者モードSwitchに `aria-label` を追加。
  - 共通 `Switch` のhidden inputにも同じラベル情報を渡すよう修正。
- タップ領域
  - a11y検査で `target-size` を有効化して確認。
  - `/contact` を含め、今回の最終検査では `target-size` serious は出ていません。
- その他
  - 削除されていた `e2e/accessibility/a11y.spec.ts` を復元。
  - Playwrightに `a11y` project を追加し、指定コマンドで検査できるようにしました。

## `/contact` のタップ領域除外
- 既存の `/contact` タップ領域除外は現在のmainには存在しませんでした。
- 今回は除外を追加せず、axeの `target-size` ルールを有効化して `/contact` を検査しました。
- 最終検査で `/contact` の `target-size` serious は0件です。

## アクセシビリティ検査を弱めていないこと
- axe検査の削除、skip/fixme、除外追加はしていません。
- 削除済みだったa11y検査を復元し、`wcag22aa` と `target-size` も含めて検査対象を増やしています。
- critical違反は引き続き失敗条件です。

## 確認コマンド
- `npx playwright test e2e/accessibility/a11y.spec.ts` - 成功。最終 serious 0 / critical 0。
- `npm run typecheck` - 成功。
- `npm run test:run` - 成功。98 files / 1309 tests passed。
- `npm run build` - 成功。
- `npm run lint` - 成功。既存の `MODULE_TYPELESS_PACKAGE_JSON` 警告のみ。
- `npm run test:e2e` - 成功。25 passed。

## 手動確認した内容
- Playwrightで390x844幅のスクリーンショットを取得し、`/schedule`, `/contact`, `/changelog`, `/settings` の表示を確認。
- 文字の重なり、主要ボタンの崩れ、フォームの表示崩れは見当たりません。

## 残っている serious / moderate / minor の扱い
- 今回のa11y検査対象ページでは final serious は0件です。
- moderate / minor は今回のIssue範囲外として一括修正していません。

## 残リスク
- 標準テーマのアクセント色と補助テキスト色を共通トークンで変更したため、標準テーマ全体の見た目が少し濃くなります。
- 他テーマのコントラストは今回の自動検査対象外です。

## このIssue外として触らなかったもの
- デザイン全体の作り直し。
- moderate / minor の一括修正。
- Firebase / Firestore / Cloud Functions / Service Worker / public配下。
- #408や他Issueの実装。