### PR TITLE
[P2] Service Worker runtime cacheに上限制御を追加

### DIFF
--- a/lib/pwa/sw.test.ts
+++ b/lib/pwa/sw.test.ts
@@ -19,10 +19,7 @@ interface ServiceWorkerContext {
     match?: () => Promise<Response | undefined>;
   };
   __listeners: {
-    fetch?: (event: {
-      request: Request;
-      respondWith: (response: Promise<Response>) => void;
-    }) => void;
+    fetch?: (event: { request: Request; respondWith: (response: Promise<Response>) => void }) => void;
   };
 }
 

--- a/lib/pwa/sw.test.ts
+++ b/lib/pwa/sw.test.ts
@@ -7,16 +7,28 @@ import { describe, expect, it, vi } from 'vitest';
 interface ServiceWorkerContext {
   __getHtmlPath: (url: string) => string;
   __putInRuntimeCache: (requests: Request[], response: Response) => Promise<void>;
+  __trimRuntimeCache?: (cache: {
+    keys: () => Promise<Request[]>;
+    delete: (request: Request) => Promise<boolean>;
+  }) => Promise<void>;
   __getNavigationFallback: () => Promise<Response>;
+  __MAX_RUNTIME_CACHE_ENTRIES?: number;
   __PRECACHE_URLS: string[];
   caches: {
     open?: () => Promise<{ put: (request: Request, response: Response) => Promise<void> }>;
     match?: () => Promise<Response | undefined>;
   };
+  __listeners: {
+    fetch?: (event: {
+      request: Request;
+      respondWith: (response: Promise<Response>) => void;
+    }) => void;
+  };
 }
 
 function loadServiceWorkerContext(): ServiceWorkerContext {
   const source = readFileSync(join(process.cwd(), 'public', 'sw.js'), 'utf8');
+  const listeners: ServiceWorkerContext['__listeners'] = {};
   const context = {
     URL,
     Request,
@@ -27,17 +39,27 @@ function loadServiceWorkerContext(): ServiceWorkerContext {
     },
     self: {
       location: { origin: 'https://example.test' },
-      addEventListener: () => undefined,
+      addEventListener: (
+        type: string,
+        listener: ServiceWorkerContext['__listeners'][keyof ServiceWorkerContext['__listeners']]
+      ) => {
+        if (type === 'fetch') {
+          listeners.fetch = listener;
+        }
+      },
       skipWaiting: () => undefined,
       clients: { claim: () => undefined },
     },
+    __listeners: listeners,
   };
 
   vm.runInNewContext(
     `${source}
 globalThis.__getHtmlPath = getHtmlPath;
 globalThis.__putInRuntimeCache = putInRuntimeCache;
+globalThis.__trimRuntimeCache = typeof trimRuntimeCache === 'undefined' ? undefined : trimRuntimeCache;
 globalThis.__getNavigationFallback = getNavigationFallback;
+globalThis.__MAX_RUNTIME_CACHE_ENTRIES = typeof MAX_RUNTIME_CACHE_ENTRIES === 'undefined' ? undefined : MAX_RUNTIME_CACHE_ENTRIES;
 globalThis.__PRECACHE_URLS = PRECACHE_URLS;`,
     context
   );
@@ -101,13 +123,41 @@ describe('PWA Service Worker navigation paths', () => {
 });
 
 describe('PWA Service Worker runtime cache', () => {
+  it('runtime cacheの上限値を定義する', () => {
+    const { __MAX_RUNTIME_CACHE_ENTRIES } = loadServiceWorkerContext();
+
+    expect(__MAX_RUNTIME_CACHE_ENTRIES).toBe(80);
+  });
+
+  it('上限超過時は古いruntime cache entryから削除する', async () => {
+    const { __MAX_RUNTIME_CACHE_ENTRIES, __trimRuntimeCache } = loadServiceWorkerContext();
+    const requests = Array.from(
+      { length: Number(__MAX_RUNTIME_CACHE_ENTRIES) + 2 },
+      (_, index) => new Request(`https://example.test/page-${index}`)
+    );
+    const deleted: string[] = [];
+    const cache = {
+      keys: () => Promise.resolve(requests),
+      delete: (request: Request) => {
+        deleted.push(request.url);
+        return Promise.resolve(true);
+      },
+    };
+
+    await expect(__trimRuntimeCache?.(cache)).resolves.toBeUndefined();
+
+    expect(deleted).toEqual([requests[0].url, requests[1].url]);
+  });
+
   it('同じResponseを複数URLへ保存してもbodyを使い回さない', async () => {
     const put = vi.fn().mockImplementation(async (_request: Request, response: Response) => {
       await response.text();
     });
+    const keys = vi.fn().mockResolvedValue([]);
+    const deleteEntry = vi.fn().mockResolvedValue(true);
     const context = loadServiceWorkerContext();
 
-    context.caches = { open: () => Promise.resolve({ put }) };
+    context.caches = { open: () => Promise.resolve({ put, keys, delete: deleteEntry }) };
 
     const originalResponse = new Response('assignment html');
     const cachePromise = context.__putInRuntimeCache(
@@ -118,6 +168,7 @@ describe('PWA Service Worker runtime cache', () => {
     await originalResponse.text();
     await cachePromise;
     expect(put).toHaveBeenCalledTimes(2);
+    expect(keys).toHaveBeenCalledOnce();
   });
 
   it('キャッシュが空でもナビゲーションフォールバックはResponseを返す', async () => {
@@ -125,5 +176,20 @@ describe('PWA Service Worker runtime cache', () => {
     context.caches = { match: () => Promise.resolve(undefined) };
 
     await expect(context.__getNavigationFallback()).resolves.toBeInstanceOf(Response);
+  });
+
+  it('外部URLはfetch handlerでruntime cache対象にしない', () => {
+    const context = loadServiceWorkerContext();
+    const respondWith = vi.fn();
+    const externalRequest = new Request('https://firestore.googleapis.com/v1/projects/example', {
+      method: 'GET',
+    });
+
+    context.__listeners.fetch?.({
+      request: externalRequest,
+      respondWith,
+    });
+
+    expect(respondWith).not.toHaveBeenCalled();
   });
 });

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,7 @@
 // Service Worker for PWA
 const CACHE_NAME = 'roast-plus-v6';
-const RUNTIME_CACHE = 'roast-plus-runtime-v6';
+const RUNTIME_CACHE = 'roast-plus-runtime-v7';
+const MAX_RUNTIME_CACHE_ENTRIES = 80;
 
 // キャッシュするリソース
 const PRECACHE_URLS = [
@@ -45,9 +46,39 @@ function putInRuntimeCache(requests, response) {
 
   return caches
     .open(RUNTIME_CACHE)
-    .then((cache) => Promise.all(cacheEntries.map(({ request, response }) => cache.put(request, response))))
+    .then((cache) =>
+      Promise.all(cacheEntries.map(({ request, response }) => cache.put(request, response))).then(() =>
+        trimRuntimeCache(cache)
+      )
+    )
     .catch((error) => {
       console.error('Service Worker cache put failed:', error);
+    });
+}
+
+function trimRuntimeCache(cache) {
+  return cache
+    .keys()
+    .then((requests) => {
+      const deleteCount = requests.length - MAX_RUNTIME_CACHE_ENTRIES;
+
+      if (deleteCount <= 0) {
+        return undefined;
+      }
+
+      const requestsToDelete = requests.slice(0, deleteCount);
+
+      return Promise.all(
+        requestsToDelete.map((request) =>
+          cache.delete(request).catch((error) => {
+            console.error('Service Worker runtime cache delete failed:', error);
+            return false;
+          })
+        )
+      ).then(() => undefined);
+    })
+    .catch((error) => {
+      console.error('Service Worker runtime cache trim failed:', error);
     });
 }
 


### PR DESCRIPTION
Closes #410

## 変更したファイル
- `public/sw.js`
- `lib/pwa/sw.test.ts`

## runtime cacheの現在の問題
- `putInRuntimeCache()` が同一originのGETレスポンスを保存する一方で、保存件数の上限や古いentryの削除処理がなく、長期利用で `roast-plus-runtime-*` が増え続ける可能性がありました。

## 変更内容
- `MAX_RUNTIME_CACHE_ENTRIES = 80` を追加しました。
- runtime cache保存後に `trimRuntimeCache()` を実行し、`cache.keys()` の順序に従って上限超過分を古いentryから削除します。
- 複数requestへ同じresponseを保存する既存仕様は維持し、保存完了後にまとめてtrimします。
- trimまたはdelete失敗時は `console.error` に留め、Service Worker全体を落とさないようにしています。

## CACHE_NAME / RUNTIME_CACHE のバージョン
- `CACHE_NAME` は `roast-plus-v6` のままです。precache内容を変更していないためです。
- `RUNTIME_CACHE` は `roast-plus-runtime-v7` に上げました。runtime cacheの保持方針が変わるため、activate時に旧runtime cacheを削除し、新しい上限制御へ移行しやすくするためです。

## 維持している方針
- GET以外は処理しません。
- 外部URL、Firebaseなど他originのURLはfetch handlerで処理せず、runtime cache対象にしません。
- document requestのHTMLパス変換、navigation fallback、precache対象は維持しています。
- Workboxなど新規依存は追加していません。

## 追加・更新したテスト
- runtime cache上限値が `80` として定義されていること。
- 上限超過時に古いentryから削除すること。
- 複数request保存後にtrimが呼ばれること。
- 外部URLがfetch handlerでruntime cache対象にならないこと。
- 既存のprecache実在確認、navigation fallback確認は維持しています。

## 確認コマンド
- `npm run typecheck` - 成功
- `npm run test:run -- lib/pwa/sw.test.ts` - 成功、9 tests passed
- `npm run test:run` - 成功、98 files / 1312 tests passed
- `npm run build` - 成功
- `npm run lint` - 成功。既存の `MODULE_TYPELESS_PACKAGE_JSON` 警告のみ表示
- `npm run test:e2e` - 成功、25 tests passed
- commit hook: `npm run secrets:scan:staged` - 成功、no leaks found

## 手動確認
- ビルド済み `out/` をローカル配信し、PlaywrightでDevTools相当のCache Storage確認を実施しました。
- Service Workerは `controller: true` になりました。
- Cache Storageに `roast-plus-v6` と `roast-plus-runtime-v7` が作成されました。
- `/settings` と `/assignment` を開いた後のruntime cacheは29件でした。
- runtime cacheに外部originのentryはありませんでした。

## 残リスク
- 古いService Workerはブラウザの更新タイミングに依存するため、既存ユーザーへの反映には通常のService Worker更新待ちが発生します。
- 上限80が実利用に対して強すぎる場合、一部ページや静的アセットのオフライン再利用が早めに失われる可能性があります。

## Issue外として触らなかったもの
- Workbox導入や新規依存追加。
- Service Worker全面改修。
- precache対象の変更。
- オフライン対応範囲の拡大。
- Firebase Rules / Firestore / Cloud Functions。
- PWA以外のUI変更。