### PR TITLE
fix: 通常テーマのオレンジ色を復元

### DIFF
--- a/app/coffee-trivia/badges/page.tsx
+++ b/app/coffee-trivia/badges/page.tsx
@@ -110,7 +110,7 @@ export default function BadgesPage() {
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          className="bg-gradient-to-r from-spot via-spot-hover to-spot rounded-2xl p-6 text-white text-center shadow-lg"
+          className="bg-gradient-to-r from-spot via-spot-hover to-spot rounded-2xl p-6 text-on-spot text-center shadow-lg"
         >
           <motion.div
             initial={{ scale: 0 }}

--- a/app/coffee-trivia/quiz/page.tsx
+++ b/app/coffee-trivia/quiz/page.tsx
@@ -280,7 +280,7 @@ function QuizPageContent() {
                 <p className="text-ink-muted text-sm mb-4">+{sessionStats.totalXP} XP獲得</p>
                 <Link
                   href={returnUrl}
-                  className="inline-block bg-spot hover:bg-spot-hover text-white py-2.5 px-6 rounded-xl font-semibold transition-colors"
+                  className="inline-block bg-spot hover:bg-spot-hover text-on-spot py-2.5 px-6 rounded-xl font-semibold transition-colors"
                 >
                   問題一覧に戻る
                 </Link>
@@ -314,7 +314,7 @@ function QuizPageContent() {
                   // Singleモード: 直接一覧に戻るボタン
                   <Link
                     href={returnUrl}
-                    className="w-full mt-4 flex items-center justify-center gap-2 bg-spot hover:bg-spot-hover text-white py-3.5 px-5 rounded-xl font-semibold transition-colors"
+                    className="w-full mt-4 flex items-center justify-center gap-2 bg-spot hover:bg-spot-hover text-on-spot py-3.5 px-5 rounded-xl font-semibold transition-colors"
                   >
                     <ArrowLeftIcon />
                     一覧に戻る
@@ -328,7 +328,7 @@ function QuizPageContent() {
                         // 最後の問題
                         <Link
                           href={returnUrl}
-                          className="w-full flex items-center justify-center gap-2 bg-spot hover:bg-spot-hover text-white py-3.5 px-5 rounded-xl font-semibold transition-colors"
+                          className="w-full flex items-center justify-center gap-2 bg-spot hover:bg-spot-hover text-on-spot py-3.5 px-5 rounded-xl font-semibold transition-colors"
                         >
                           <ArrowLeftIcon />
                           問題一覧に戻る
@@ -336,7 +336,7 @@ function QuizPageContent() {
                       ) : (
                         // 自動遷移中の表示
                         <>
-                          <div className="w-full flex items-center justify-center gap-2 bg-spot/80 text-white py-3.5 px-5 rounded-xl font-semibold">
+                          <div className="w-full flex items-center justify-center gap-2 bg-spot/80 text-on-spot py-3.5 px-5 rounded-xl font-semibold">
                             <div className="w-4 h-4 rounded-full border-2 border-white/40 border-t-white animate-spin" />
                             次の問題へ移動中...
                           </div>
@@ -355,7 +355,7 @@ function QuizPageContent() {
                         {currentIndex + 1 < totalQuestions && (
                           <motion.button
                             onClick={handleNext}
-                            className="w-full flex items-center justify-center gap-2 bg-spot hover:bg-spot-hover text-white py-3.5 px-5 rounded-xl font-semibold transition-colors"
+                            className="w-full flex items-center justify-center gap-2 bg-spot hover:bg-spot-hover text-on-spot py-3.5 px-5 rounded-xl font-semibold transition-colors"
                           >
                             次の問題へ
                             <ArrowRightIcon />
@@ -365,7 +365,7 @@ function QuizPageContent() {
                           href={returnUrl}
                           className={`w-full flex items-center justify-center gap-2 py-3 px-5 rounded-xl font-medium transition-colors ${
                             currentIndex + 1 >= totalQuestions
-                              ? 'bg-spot hover:bg-spot-hover text-white font-semibold py-3.5'
+                              ? 'bg-spot hover:bg-spot-hover text-on-spot font-semibold py-3.5'
                               : 'bg-edge-subtle hover:bg-edge text-ink-sub border border-edge'
                           }`}
                         >
@@ -380,7 +380,7 @@ function QuizPageContent() {
                     initial={{ opacity: 0, y: 20 }}
                     animate={{ opacity: 1, y: 0 }}
                     onClick={handleNext}
-                    className="w-full mt-4 flex items-center justify-center gap-2 bg-spot hover:bg-spot-hover text-white py-3.5 px-5 rounded-xl font-semibold transition-colors"
+                    className="w-full mt-4 flex items-center justify-center gap-2 bg-spot hover:bg-spot-hover text-on-spot py-3.5 px-5 rounded-xl font-semibold transition-colors"
                   >
                     {currentIndex + 1 >= totalQuestions ? (
                       '結果を見る'

--- a/app/coffee-trivia/review/page-new.tsx
+++ b/app/coffee-trivia/review/page-new.tsx
@@ -265,7 +265,7 @@ export default function ReviewPage() {
                   initial={{ opacity: 0, y: 20 }}
                   animate={{ opacity: 1, y: 0 }}
                   onClick={handleNext}
-                  className="w-full mt-4 flex items-center justify-center gap-2 bg-spot hover:bg-spot-hover text-white py-3.5 px-5 rounded-xl font-semibold transition-colors"
+                  className="w-full mt-4 flex items-center justify-center gap-2 bg-spot hover:bg-spot-hover text-on-spot py-3.5 px-5 rounded-xl font-semibold transition-colors"
                 >
                   {currentIndex + 1 >= totalQuestions ? (
                     '結果を見る'

--- a/app/coffee-trivia/review/page.tsx
+++ b/app/coffee-trivia/review/page.tsx
@@ -225,7 +225,7 @@ export default function ReviewPage() {
             </p>
             <Link
               href="/coffee-trivia"
-              className="inline-block bg-spot hover:bg-spot-hover text-white py-2.5 px-6 rounded-xl font-semibold transition-colors"
+              className="inline-block bg-spot hover:bg-spot-hover text-on-spot py-2.5 px-6 rounded-xl font-semibold transition-colors"
             >
               ダッシュボードへ戻る
             </Link>
@@ -296,7 +296,7 @@ export default function ReviewPage() {
                   initial={{ opacity: 0, y: 20 }}
                   animate={{ opacity: 1, y: 0 }}
                   onClick={handleNext}
-                  className="w-full mt-4 flex items-center justify-center gap-2 bg-spot hover:bg-spot-hover text-white py-3.5 px-5 rounded-xl font-semibold transition-colors"
+                  className="w-full mt-4 flex items-center justify-center gap-2 bg-spot hover:bg-spot-hover text-on-spot py-3.5 px-5 rounded-xl font-semibold transition-colors"
                 >
                   {currentIndex + 1 >= totalQuestions ? (
                     '結果を見る'
@@ -317,7 +317,7 @@ export default function ReviewPage() {
               <p className="text-ink-muted mb-4">復習する問題はありません</p>
               <Link
                 href="/coffee-trivia"
-                className="inline-block bg-spot hover:bg-spot-hover text-white py-2.5 px-6 rounded-xl font-semibold transition-colors"
+                className="inline-block bg-spot hover:bg-spot-hover text-on-spot py-2.5 px-6 rounded-xl font-semibold transition-colors"
               >
                 ダッシュボードへ戻る
               </Link>

--- a/app/dev/design-lab/components/mockups/DripSizeA.tsx
+++ b/app/dev/design-lab/components/mockups/DripSizeA.tsx
@@ -45,7 +45,7 @@ export default function DripSizeA() {
     <div className="max-w-sm mx-auto">
       {/* Option label */}
       <div className="mb-2 flex items-center gap-2">
-        <span className="px-2 py-0.5 rounded-full bg-spot text-white text-xs font-bold">Option A</span>
+        <span className="px-2 py-0.5 rounded-full bg-spot text-on-spot text-xs font-bold">Option A</span>
         <span className="text-xs text-ink-muted">タイマー＋注水量のみ拡大</span>
       </div>
       <div className="h-[667px] rounded-3xl border border-edge overflow-hidden flex flex-col bg-ground">
@@ -164,7 +164,7 @@ export default function DripSizeA() {
           <button className="p-3 rounded-full text-ink-muted transition-colors hover:text-ink-sub hover:bg-ground active:scale-95">
             <ArrowCounterClockwise size={22} weight="bold" />
           </button>
-          <button className="w-[60px] h-[60px] rounded-full bg-spot text-white flex items-center justify-center shadow-lg active:scale-95 transition-transform">
+          <button className="w-[60px] h-[60px] rounded-full bg-spot text-on-spot flex items-center justify-center shadow-lg active:scale-95 transition-transform">
             <Play size={24} weight="fill" className="ml-0.5" />
           </button>
           <button className="p-3 rounded-full text-ink-muted transition-colors hover:text-ink-sub hover:bg-ground active:scale-95">

--- a/app/dev/design-lab/components/mockups/DripSizeB.tsx
+++ b/app/dev/design-lab/components/mockups/DripSizeB.tsx
@@ -45,7 +45,7 @@ export default function DripSizeB() {
     <div className="max-w-sm mx-auto">
       {/* Option label */}
       <div className="mb-2 flex items-center gap-2">
-        <span className="px-2 py-0.5 rounded-full bg-spot text-white text-xs font-bold">Option B</span>
+        <span className="px-2 py-0.5 rounded-full bg-spot text-on-spot text-xs font-bold">Option B</span>
         <span className="text-xs text-ink-muted">全体を均等に一段階拡大</span>
       </div>
       <div className="h-[667px] rounded-3xl border border-edge overflow-hidden flex flex-col bg-ground">
@@ -164,7 +164,7 @@ export default function DripSizeB() {
           <button className="p-3 rounded-full text-ink-muted transition-colors hover:text-ink-sub hover:bg-ground active:scale-95">
             <ArrowCounterClockwise size={22} weight="bold" />
           </button>
-          <button className="w-[60px] h-[60px] rounded-full bg-spot text-white flex items-center justify-center shadow-lg active:scale-95 transition-transform">
+          <button className="w-[60px] h-[60px] rounded-full bg-spot text-on-spot flex items-center justify-center shadow-lg active:scale-95 transition-transform">
             <Play size={24} weight="fill" className="ml-0.5" />
           </button>
           <button className="p-3 rounded-full text-ink-muted transition-colors hover:text-ink-sub hover:bg-ground active:scale-95">

--- a/app/dev/design-lab/components/mockups/DripSizeC.tsx
+++ b/app/dev/design-lab/components/mockups/DripSizeC.tsx
@@ -45,7 +45,7 @@ export default function DripSizeC() {
     <div className="max-w-sm mx-auto">
       {/* Option label */}
       <div className="mb-2 flex items-center gap-2">
-        <span className="px-2 py-0.5 rounded-full bg-spot text-white text-xs font-bold">Option C</span>
+        <span className="px-2 py-0.5 rounded-full bg-spot text-on-spot text-xs font-bold">Option C</span>
         <span className="text-xs text-ink-muted">タイマーを超大型に</span>
       </div>
       <div className="h-[667px] rounded-3xl border border-edge overflow-hidden flex flex-col bg-ground">
@@ -164,7 +164,7 @@ export default function DripSizeC() {
           <button className="p-3 rounded-full text-ink-muted transition-colors hover:text-ink-sub hover:bg-ground active:scale-95">
             <ArrowCounterClockwise size={22} weight="bold" />
           </button>
-          <button className="w-[60px] h-[60px] rounded-full bg-spot text-white flex items-center justify-center shadow-lg active:scale-95 transition-transform">
+          <button className="w-[60px] h-[60px] rounded-full bg-spot text-on-spot flex items-center justify-center shadow-lg active:scale-95 transition-transform">
             <Play size={24} weight="fill" className="ml-0.5" />
           </button>
           <button className="p-3 rounded-full text-ink-muted transition-colors hover:text-ink-sub hover:bg-ground active:scale-95">

--- a/app/dev/design-lab/components/mockups/TimerPatternA.tsx
+++ b/app/dev/design-lab/components/mockups/TimerPatternA.tsx
@@ -144,7 +144,7 @@ export default function TimerPatternA() {
           <button className="p-3 rounded-full text-ink/50 hover:text-ink hover:bg-ground transition-colors">
             <ArrowCounterClockwise size={22} weight="bold" />
           </button>
-          <button className="p-4 rounded-full bg-spot text-white shadow-md hover:opacity-90 transition-opacity">
+          <button className="p-4 rounded-full bg-spot text-on-spot shadow-md hover:opacity-90 transition-opacity">
             <Pause size={28} weight="fill" />
           </button>
           <button className="p-3 rounded-full text-ink/50 hover:text-ink hover:bg-ground transition-colors">

--- a/app/dev/design-lab/components/mockups/TimerPatternB.tsx
+++ b/app/dev/design-lab/components/mockups/TimerPatternB.tsx
@@ -123,7 +123,7 @@ export default function TimerPatternB() {
           <button className="p-3 rounded-full text-ink/40 hover:text-ink hover:bg-ink/5 transition-colors">
             <ArrowCounterClockwise size={22} weight="bold" />
           </button>
-          <button className="p-5 rounded-full bg-spot text-white shadow-lg hover:opacity-90 transition-opacity">
+          <button className="p-5 rounded-full bg-spot text-on-spot shadow-lg hover:opacity-90 transition-opacity">
             <Pause size={30} weight="fill" />
           </button>
           <button className="p-3 rounded-full text-ink/40 hover:text-ink hover:bg-ink/5 transition-colors">

--- a/app/dev/design-lab/components/mockups/TimerPatternD.tsx
+++ b/app/dev/design-lab/components/mockups/TimerPatternD.tsx
@@ -127,7 +127,7 @@ export default function TimerPatternD() {
           <button className="flex items-center justify-center w-11 h-11 rounded-full bg-ground text-ink-muted">
             <ArrowCounterClockwise size={20} />
           </button>
-          <button className="flex items-center justify-center w-14 h-14 rounded-full bg-spot text-white shadow-md">
+          <button className="flex items-center justify-center w-14 h-14 rounded-full bg-spot text-on-spot shadow-md">
             <Pause size={24} weight="fill" />
           </button>
           <button className="flex items-center justify-center w-11 h-11 rounded-full bg-ground text-ink-muted">

--- a/app/dev/design-lab/components/mockups/TimerPatternE.tsx
+++ b/app/dev/design-lab/components/mockups/TimerPatternE.tsx
@@ -175,7 +175,7 @@ export default function TimerPatternE() {
           <button className="p-3 rounded-full text-ink/50 hover:text-ink hover:bg-ground transition-colors">
             <ArrowCounterClockwise size={22} weight="bold" />
           </button>
-          <button className="p-4 rounded-full bg-spot text-white shadow-md hover:opacity-90 transition-opacity">
+          <button className="p-4 rounded-full bg-spot text-on-spot shadow-md hover:opacity-90 transition-opacity">
             <Pause size={28} weight="fill" />
           </button>
           <button className="p-3 rounded-full text-ink/50 hover:text-ink hover:bg-ground transition-colors">

--- a/app/dev/design-lab/components/mockups/TimerPatternF.tsx
+++ b/app/dev/design-lab/components/mockups/TimerPatternF.tsx
@@ -106,7 +106,7 @@ export default function TimerPatternF() {
             {/* 現在ステップカード */}
             <div className="rounded-xl border-2 border-spot bg-spot-subtle/50 px-4 py-3">
               <div className="flex items-center gap-2 mb-1">
-                <span className="text-[10px] font-bold text-white bg-spot px-1.5 py-0.5 rounded uppercase tracking-wider">
+                <span className="text-[10px] font-bold text-on-spot bg-spot px-1.5 py-0.5 rounded uppercase tracking-wider">
                   NOW
                 </span>
                 <span className="font-bold text-ink text-base">{currentStep.title}</span>

--- a/app/dev/design-lab/components/mockups/TimerPatternG.tsx
+++ b/app/dev/design-lab/components/mockups/TimerPatternG.tsx
@@ -160,7 +160,7 @@ export default function TimerPatternG() {
           <button className="p-3 rounded-full text-ink/50 hover:bg-ground transition-colors">
             <ArrowCounterClockwise size={22} weight="bold" />
           </button>
-          <button className="p-4 rounded-full bg-spot text-white shadow-md">
+          <button className="p-4 rounded-full bg-spot text-on-spot shadow-md">
             <Play size={28} weight="fill" className="ml-0.5" />
           </button>
           <button className="p-3 rounded-full text-ink/50 hover:bg-ground transition-colors">

--- a/app/dev/design-lab/components/mockups/TimerPatternH.tsx
+++ b/app/dev/design-lab/components/mockups/TimerPatternH.tsx
@@ -167,7 +167,7 @@ export default function TimerPatternH() {
           <button className="p-3 rounded-full text-ink-muted transition-colors hover:text-ink-sub hover:bg-ground active:scale-95">
             <ArrowCounterClockwise size={22} weight="bold" />
           </button>
-          <button className="w-[60px] h-[60px] rounded-full bg-spot text-white flex items-center justify-center shadow-lg active:scale-95 transition-transform">
+          <button className="w-[60px] h-[60px] rounded-full bg-spot text-on-spot flex items-center justify-center shadow-lg active:scale-95 transition-transform">
             <Play size={24} weight="fill" className="ml-0.5" />
           </button>
           <button className="p-3 rounded-full text-ink-muted transition-colors hover:text-ink-sub hover:bg-ground active:scale-95">

--- a/app/dev/design-lab/components/mockups/TimerPatternH1.tsx
+++ b/app/dev/design-lab/components/mockups/TimerPatternH1.tsx
@@ -171,7 +171,7 @@ export default function TimerPatternH1() {
           <button className="p-3 rounded-full text-ink-muted transition-colors hover:text-ink-sub hover:bg-ground active:scale-95">
             <ArrowCounterClockwise size={22} weight="bold" />
           </button>
-          <button className="w-[60px] h-[60px] rounded-full bg-spot text-white flex items-center justify-center shadow-lg active:scale-95 transition-transform">
+          <button className="w-[60px] h-[60px] rounded-full bg-spot text-on-spot flex items-center justify-center shadow-lg active:scale-95 transition-transform">
             <Play size={24} weight="fill" className="ml-0.5" />
           </button>
           <button className="p-3 rounded-full text-ink-muted transition-colors hover:text-ink-sub hover:bg-ground active:scale-95">

--- a/app/dev/design-lab/components/mockups/TimerPatternH2.tsx
+++ b/app/dev/design-lab/components/mockups/TimerPatternH2.tsx
@@ -177,7 +177,7 @@ export default function TimerPatternH2() {
           <button className="p-3 rounded-full text-ink-muted transition-colors hover:text-ink-sub hover:bg-ground active:scale-95">
             <ArrowCounterClockwise size={22} weight="bold" />
           </button>
-          <button className="w-[60px] h-[60px] rounded-full bg-spot text-white flex items-center justify-center shadow-lg active:scale-95 transition-transform">
+          <button className="w-[60px] h-[60px] rounded-full bg-spot text-on-spot flex items-center justify-center shadow-lg active:scale-95 transition-transform">
             <Play size={24} weight="fill" className="ml-0.5" />
           </button>
           <button className="p-3 rounded-full text-ink-muted transition-colors hover:text-ink-sub hover:bg-ground active:scale-95">

--- a/app/dev/design-lab/components/mockups/TimerPatternH3.tsx
+++ b/app/dev/design-lab/components/mockups/TimerPatternH3.tsx
@@ -172,7 +172,7 @@ export default function TimerPatternH3() {
           <button className="p-3 rounded-full text-ink-muted transition-colors hover:text-ink-sub hover:bg-ground active:scale-95">
             <ArrowCounterClockwise size={22} weight="bold" />
           </button>
-          <button className="w-[60px] h-[60px] rounded-full bg-spot text-white flex items-center justify-center shadow-lg active:scale-95 transition-transform">
+          <button className="w-[60px] h-[60px] rounded-full bg-spot text-on-spot flex items-center justify-center shadow-lg active:scale-95 transition-transform">
             <Play size={24} weight="fill" className="ml-0.5" />
           </button>
           <button className="p-3 rounded-full text-ink-muted transition-colors hover:text-ink-sub hover:bg-ground active:scale-95">

--- a/app/dev/design-lab/components/mockups/TimerPatternH4.tsx
+++ b/app/dev/design-lab/components/mockups/TimerPatternH4.tsx
@@ -175,7 +175,7 @@ export default function TimerPatternH4() {
           <button className="p-3 rounded-full text-ink-muted transition-colors hover:text-ink-sub hover:bg-ground active:scale-95">
             <ArrowCounterClockwise size={22} weight="bold" />
           </button>
-          <button className="w-[60px] h-[60px] rounded-full bg-spot text-white flex items-center justify-center shadow-lg active:scale-95 transition-transform">
+          <button className="w-[60px] h-[60px] rounded-full bg-spot text-on-spot flex items-center justify-center shadow-lg active:scale-95 transition-transform">
             <Play size={24} weight="fill" className="ml-0.5" />
           </button>
           <button className="p-3 rounded-full text-ink-muted transition-colors hover:text-ink-sub hover:bg-ground active:scale-95">

--- a/app/dev/design-lab/components/mockups/TimerPatternH5.tsx
+++ b/app/dev/design-lab/components/mockups/TimerPatternH5.tsx
@@ -176,7 +176,7 @@ export default function TimerPatternH5() {
             <ArrowCounterClockwise size={22} weight="bold" />
           </button>
           {/* 再生ボタン: オレンジのまま（ブラウン背景で映える） */}
-          <button className="w-[60px] h-[60px] rounded-full bg-spot text-white flex items-center justify-center shadow-lg active:scale-95 transition-transform">
+          <button className="w-[60px] h-[60px] rounded-full bg-spot text-on-spot flex items-center justify-center shadow-lg active:scale-95 transition-transform">
             <Play size={24} weight="fill" className="ml-0.5" />
           </button>
           <button className="p-3 rounded-full text-white/40 transition-colors hover:text-white/70 active:scale-95">

--- a/app/dev/design-lab/components/mockups/TitlePatterns.tsx
+++ b/app/dev/design-lab/components/mockups/TitlePatterns.tsx
@@ -178,7 +178,7 @@ function TitlePreview({ pattern }: { pattern: TitlePattern }) {
     >
       {/* Badge */}
       <div className="absolute top-3 left-3 z-10 flex items-center gap-2">
-        <span className="bg-spot text-white w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold">
+        <span className="bg-spot text-on-spot w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold">
           {pattern.id}
         </span>
         {pattern.adopted && (

--- a/app/dev/design-lab/components/sections/PageMockups.tsx
+++ b/app/dev/design-lab/components/sections/PageMockups.tsx
@@ -109,7 +109,7 @@ export default function PageMockups() {
           <button
             onClick={() => setSelectedId(null)}
             className={`px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
-              selectedId === null ? 'bg-spot text-white' : 'bg-ground text-ink-sub hover:text-ink'
+              selectedId === null ? 'bg-spot text-on-spot' : 'bg-ground text-ink-sub hover:text-ink'
             }`}
           >
             全て表示
@@ -119,7 +119,7 @@ export default function PageMockups() {
               key={p.id}
               onClick={() => setSelectedId(selectedId === p.id ? null : p.id)}
               className={`px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
-                selectedId === p.id ? 'bg-spot text-white' : 'bg-ground text-ink-sub hover:text-ink'
+                selectedId === p.id ? 'bg-spot text-on-spot' : 'bg-ground text-ink-sub hover:text-ink'
               }`}
             >
               {p.id}: {p.title.split(': ')[1]}

--- a/app/drip-guide/page.tsx
+++ b/app/drip-guide/page.tsx
@@ -21,7 +21,7 @@ export default function DripGuidePage() {
         right={
           <Link
             href="/drip-guide/new"
-            className="inline-flex items-center gap-2 bg-btn-primary hover:bg-btn-primary-hover text-white px-4 py-2 rounded-lg font-semibold transition-colors shadow-sm min-h-[44px]"
+            className="inline-flex items-center gap-2 bg-btn-primary hover:bg-btn-primary-hover text-btn-primary-text px-4 py-2 rounded-lg font-semibold transition-colors shadow-sm min-h-[44px]"
           >
             <HiPlus size={20} />
             <span className="hidden sm:inline">新規レシピ</span>

--- a/app/globals.css
+++ b/app/globals.css
@@ -48,14 +48,14 @@
     --edge-strong: #d1d5db;
     --edge-subtle: #f3f4f6;
     /* アクセント */
-    --spot: #b45309;
-    --spot-hover: #92400e;
+    --spot: #d97706;
+    --spot-hover: #b45309;
     --spot-subtle: #f0f0f0;
     --spot-surface: #f7f7f7;
     --on-spot: #ffffff;
     /* ボタン */
-    --btn-primary: #b45309;
-    --btn-primary-hover: #92400e;
+    --btn-primary: #d97706;
+    --btn-primary-hover: #b45309;
     /* ステータスカラー */
     --danger: #dc2626;
     --danger-subtle: #fee2e2;

--- a/app/globals.css
+++ b/app/globals.css
@@ -49,13 +49,14 @@
     --edge-subtle: #f3f4f6;
     /* アクセント */
     --spot: #d97706;
-    --spot-hover: #b45309;
+    --spot-hover: #d67a00;
     --spot-subtle: #f0f0f0;
     --spot-surface: #f7f7f7;
-    --on-spot: #ffffff;
+    --on-spot: #211714;
     /* ボタン */
     --btn-primary: #d97706;
-    --btn-primary-hover: #b45309;
+    --btn-primary-hover: #d67a00;
+    --btn-primary-text: #211714;
     /* ステータスカラー */
     --danger: #dc2626;
     --danger-subtle: #fee2e2;
@@ -111,10 +112,11 @@
     --spot-hover: #e8c65f;
     --spot-subtle: rgba(212, 175, 55, 0.15);
     --spot-surface: rgba(212, 175, 55, 0.05);
-    --on-spot: #ffffff;
+    --on-spot: #051a0e;
     /* ボタン */
     --btn-primary: #6d1a1a;
     --btn-primary-hover: #8b2323;
+    --btn-primary-text: #ffffff;
     /* ステータスカラー */
     --danger: #991b1b;
     --danger-subtle: rgba(127, 29, 29, 0.5);
@@ -165,10 +167,11 @@
     --spot-hover: #dab86c;
     --spot-subtle: rgba(200, 160, 80, 0.15);
     --spot-surface: rgba(200, 160, 80, 0.05);
-    --on-spot: #ffffff;
+    --on-spot: #0d0b09;
     /* ボタン */
     --btn-primary: #c8a050;
     --btn-primary-hover: #dab86c;
+    --btn-primary-text: #0d0b09;
     /* ステータスカラー */
     --danger: #ef4444;
     --danger-subtle: rgba(239, 68, 68, 0.15);
@@ -219,10 +222,11 @@
     --spot-hover: #a87b15;
     --spot-subtle: rgba(214, 165, 53, 0.15);
     --spot-surface: rgba(214, 165, 53, 0.06);
-    --on-spot: #ffffff;
+    --on-spot: #3d3229;
     /* ボタン */
     --btn-primary: #c69320;
     --btn-primary-hover: #a87b15;
+    --btn-primary-text: #3d3229;
     /* ステータスカラー */
     --danger: #dc2626;
     --danger-subtle: #fee2e2;
@@ -273,10 +277,11 @@
     --spot-hover: #95c774;
     --spot-subtle: rgba(125, 179, 88, 0.15);
     --spot-surface: rgba(125, 179, 88, 0.05);
-    --on-spot: #ffffff;
+    --on-spot: #0f1f15;
     /* ボタン */
     --btn-primary: #7db358;
     --btn-primary-hover: #95c774;
+    --btn-primary-text: #0f1f15;
     /* ステータスカラー */
     --danger: #ef4444;
     --danger-subtle: rgba(239, 68, 68, 0.15);
@@ -327,10 +332,11 @@
     --spot-hover: #e5a54d;
     --spot-subtle: rgba(212, 146, 58, 0.15);
     --spot-surface: rgba(212, 146, 58, 0.05);
-    --on-spot: #ffffff;
+    --on-spot: #1a120d;
     /* ボタン */
     --btn-primary: #d4923a;
     --btn-primary-hover: #e5a54d;
+    --btn-primary-text: #1a120d;
     /* ステータスカラー */
     --danger: #ef4444;
     --danger-subtle: rgba(239, 68, 68, 0.15);
@@ -378,13 +384,14 @@
     --edge-subtle: rgba(255, 255, 255, 0.06);
     /* アクセント（既存オレンジ維持） */
     --spot: #d97706;
-    --spot-hover: #b45309;
+    --spot-hover: #d67a00;
     --spot-subtle: rgba(217, 119, 6, 0.15);
     --spot-surface: rgba(217, 119, 6, 0.05);
-    --on-spot: #ffffff;
+    --on-spot: #0f0f0f;
     /* ボタン */
     --btn-primary: #d97706;
-    --btn-primary-hover: #b45309;
+    --btn-primary-hover: #d67a00;
+    --btn-primary-text: #0f0f0f;
     /* ステータスカラー */
     --danger: #ef4444;
     --danger-subtle: rgba(239, 68, 68, 0.15);
@@ -445,6 +452,7 @@
   /* ボタン */
   --color-btn-primary: var(--btn-primary);
   --color-btn-primary-hover: var(--btn-primary-hover);
+  --color-btn-primary-text: var(--btn-primary-text);
   /* ステータスカラー */
   --color-danger: var(--danger);
   --color-danger-subtle: var(--danger-subtle);

--- a/components/TastingSessionFilterModal.test.tsx
+++ b/components/TastingSessionFilterModal.test.tsx
@@ -94,7 +94,7 @@ describe('TastingSessionFilterModal', () => {
       render(<TastingSessionFilterModal {...baseProps} sortOption="oldest" selectedRoastLevels={['中深煎り']} />);
 
       expect(screen.getByRole('button', { name: '古い順' })).toHaveClass('!text-spot');
-      expect(screen.getByRole('button', { name: '中深煎り' })).toHaveClass('!bg-spot', '!text-white', '!border-spot');
+      expect(screen.getByRole('button', { name: '中深煎り' })).toHaveClass('!bg-spot', '!text-on-spot', '!border-spot');
     });
   });
 

--- a/components/coffee-quiz/LevelDisplay.tsx
+++ b/components/coffee-quiz/LevelDisplay.tsx
@@ -15,7 +15,7 @@ export function LevelDisplay({ level, compact = false }: LevelDisplayProps) {
     return (
       <div className="bg-surface rounded-xl p-3 border border-edge">
         <div className="flex items-center gap-2.5">
-          <div className="w-9 h-9 rounded-full bg-spot flex items-center justify-center text-white font-bold text-sm">
+          <div className="w-9 h-9 rounded-full bg-spot flex items-center justify-center text-on-spot font-bold text-sm">
             {level.level}
           </div>
           <div className="flex-1 min-w-0">

--- a/components/coffee-quiz/LevelUpModal.tsx
+++ b/components/coffee-quiz/LevelUpModal.tsx
@@ -110,7 +110,7 @@ export function LevelUpModal({ show, newLevel, onClose }: LevelUpModalProps) {
             animate={{ y: 0, opacity: 1 }}
             transition={{ delay: 0.5 }}
             onClick={onClose}
-            className="w-full bg-spot hover:bg-spot-hover text-white py-3 px-6 rounded-xl font-semibold transition-colors"
+            className="w-full bg-spot hover:bg-spot-hover text-on-spot py-3 px-6 rounded-xl font-semibold transition-colors"
           >
             続ける
           </motion.button>

--- a/components/coffee-quiz/QuizCompletionScreen.tsx
+++ b/components/coffee-quiz/QuizCompletionScreen.tsx
@@ -25,7 +25,7 @@ export function QuizCompletionScreen({ correct, totalXP, returnUrl }: QuizComple
       <p className="text-ink-muted text-sm mb-4">+{totalXP} XP獲得</p>
       <Link
         href={returnUrl}
-        className="inline-block bg-spot hover:bg-spot-hover text-white py-2.5 px-6 rounded-xl font-semibold transition-colors"
+        className="inline-block bg-spot hover:bg-spot-hover text-on-spot py-2.5 px-6 rounded-xl font-semibold transition-colors"
       >
         問題一覧に戻る
       </Link>

--- a/components/coffee-quiz/QuizDashboard.tsx
+++ b/components/coffee-quiz/QuizDashboard.tsx
@@ -164,7 +164,7 @@ export function QuizDashboard({
       >
         <Link
           href="/coffee-trivia/quiz"
-          className="flex items-center justify-center gap-2.5 w-full py-3.5 px-5 rounded-xl font-semibold text-white bg-spot hover:bg-spot-hover active:scale-[0.98] transition-all"
+          className="flex items-center justify-center gap-2.5 w-full py-3.5 px-5 rounded-xl font-semibold text-on-spot bg-spot hover:bg-spot-hover active:scale-[0.98] transition-all"
         >
           <PlayIcon />
           今日のクイズを始める

--- a/components/coffee-quiz/QuizNavigationButtons.tsx
+++ b/components/coffee-quiz/QuizNavigationButtons.tsx
@@ -53,7 +53,7 @@ export function QuizNavigationButtons({
     return (
       <Link
         href={returnUrl}
-        className="w-full mt-4 flex items-center justify-center gap-2 bg-spot hover:bg-spot-hover text-white py-3.5 px-5 rounded-xl font-semibold transition-colors"
+        className="w-full mt-4 flex items-center justify-center gap-2 bg-spot hover:bg-spot-hover text-on-spot py-3.5 px-5 rounded-xl font-semibold transition-colors"
       >
         <ArrowLeftIcon />
         一覧に戻る
@@ -71,7 +71,7 @@ export function QuizNavigationButtons({
             // 最後の問題
             <Link
               href={returnUrl}
-              className="w-full flex items-center justify-center gap-2 bg-spot hover:bg-spot-hover text-white py-3.5 px-5 rounded-xl font-semibold transition-colors"
+              className="w-full flex items-center justify-center gap-2 bg-spot hover:bg-spot-hover text-on-spot py-3.5 px-5 rounded-xl font-semibold transition-colors"
             >
               <ArrowLeftIcon />
               問題一覧に戻る
@@ -79,7 +79,7 @@ export function QuizNavigationButtons({
           ) : (
             // 自動遷移中の表示
             <>
-              <div className="w-full flex items-center justify-center gap-2 bg-spot/80 text-white py-3.5 px-5 rounded-xl font-semibold">
+              <div className="w-full flex items-center justify-center gap-2 bg-spot/80 text-on-spot py-3.5 px-5 rounded-xl font-semibold">
                 <div className="w-4 h-4 rounded-full border-2 border-white/40 border-t-white animate-spin" />
                 次の問題へ移動中...
               </div>
@@ -98,7 +98,7 @@ export function QuizNavigationButtons({
             {!isLastQuestion && (
               <motion.button
                 onClick={onNext}
-                className="w-full flex items-center justify-center gap-2 bg-spot hover:bg-spot-hover text-white py-3.5 px-5 rounded-xl font-semibold transition-colors"
+                className="w-full flex items-center justify-center gap-2 bg-spot hover:bg-spot-hover text-on-spot py-3.5 px-5 rounded-xl font-semibold transition-colors"
               >
                 次の問題へ
                 <ArrowRightIcon />
@@ -108,7 +108,7 @@ export function QuizNavigationButtons({
               href={returnUrl}
               className={`w-full flex items-center justify-center gap-2 py-3 px-5 rounded-xl font-medium transition-colors ${
                 isLastQuestion
-                  ? 'bg-spot hover:bg-spot-hover text-white font-semibold py-3.5'
+                  ? 'bg-spot hover:bg-spot-hover text-on-spot font-semibold py-3.5'
                   : 'bg-edge-subtle hover:bg-edge text-ink-sub border border-edge'
               }`}
             >
@@ -127,7 +127,7 @@ export function QuizNavigationButtons({
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       onClick={onNext}
-      className="w-full mt-4 flex items-center justify-center gap-2 bg-spot hover:bg-spot-hover text-white py-3.5 px-5 rounded-xl font-semibold transition-colors"
+      className="w-full mt-4 flex items-center justify-center gap-2 bg-spot hover:bg-spot-hover text-on-spot py-3.5 px-5 rounded-xl font-semibold transition-colors"
     >
       {isLastQuestion ? (
         '結果を見る'

--- a/components/coffee-quiz/QuizOption.tsx
+++ b/components/coffee-quiz/QuizOption.tsx
@@ -82,7 +82,7 @@ export function QuizOption({
   const getLetterStyles = () => {
     if (!showFeedback) {
       if (isSelected) {
-        return 'bg-spot text-white';
+        return 'bg-spot text-on-spot';
       }
       return 'bg-edge-subtle text-ink-sub';
     }
@@ -129,7 +129,7 @@ export function QuizOption({
           initial={{ scale: 0, opacity: 0 }}
           animate={{ scale: 1, opacity: 1 }}
           transition={{ delay: 0.15, type: 'spring', stiffness: 400, damping: 15 }}
-          className="flex items-center gap-1 px-2 py-0.5 bg-spot text-white rounded-full text-xs font-bold"
+          className="flex items-center gap-1 px-2 py-0.5 bg-spot text-on-spot rounded-full text-xs font-bold"
         >
           +{xpEarned} XP
         </motion.span>

--- a/components/coffee-quiz/QuizResult.tsx
+++ b/components/coffee-quiz/QuizResult.tsx
@@ -210,7 +210,7 @@ export function QuizResult({
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: 0.7 }}
             onClick={onRetry}
-            className="group w-full flex items-center justify-center gap-2 py-3.5 px-5 rounded-xl font-semibold bg-spot hover:bg-spot-hover text-white transition-colors active:scale-[0.98]"
+            className="group w-full flex items-center justify-center gap-2 py-3.5 px-5 rounded-xl font-semibold bg-spot hover:bg-spot-hover text-on-spot transition-colors active:scale-[0.98]"
           >
             <span className="group-hover:rotate-180 transition-transform duration-300">
               <RefreshIcon />

--- a/components/coffee-quiz/ReviewEmptyState.tsx
+++ b/components/coffee-quiz/ReviewEmptyState.tsx
@@ -30,7 +30,7 @@ export function ReviewEmptyState() {
       </p>
       <Link
         href="/coffee-trivia"
-        className="inline-block bg-spot hover:bg-spot-hover text-white py-2.5 px-6 rounded-xl font-semibold transition-colors"
+        className="inline-block bg-spot hover:bg-spot-hover text-on-spot py-2.5 px-6 rounded-xl font-semibold transition-colors"
       >
         ダッシュボードへ戻る
       </Link>

--- a/components/coffee-quiz/StreakCounter.tsx
+++ b/components/coffee-quiz/StreakCounter.tsx
@@ -35,7 +35,7 @@ export function StreakCounter({ streak, compact = false }: StreakCounterProps) {
         <div className="flex items-center gap-2.5">
           <div
             className={`w-9 h-9 rounded-full flex items-center justify-center ${
-              hasStreak ? 'bg-spot text-white' : 'bg-edge-subtle text-ink-muted'
+              hasStreak ? 'bg-spot text-on-spot' : 'bg-edge-subtle text-ink-muted'
             }`}
           >
             <FlameIcon active={hasStreak} />
@@ -66,7 +66,7 @@ export function StreakCounter({ streak, compact = false }: StreakCounterProps) {
         {/* 炎アイコン */}
         <div
           className={`w-12 h-12 rounded-full flex items-center justify-center ${
-            hasStreak ? 'bg-spot text-white' : 'bg-edge-subtle text-ink-muted'
+            hasStreak ? 'bg-spot text-on-spot' : 'bg-edge-subtle text-ink-muted'
           }`}
         >
           <FlameIcon active={hasStreak} />

--- a/components/coffee-quiz/XPGainAnimation.tsx
+++ b/components/coffee-quiz/XPGainAnimation.tsx
@@ -50,7 +50,7 @@ export function XPGainAnimation({ xp, show, onComplete }: XPGainAnimationProps) 
           transition={{ duration: 0.5, ease: 'easeOut' }}
           className="fixed top-1/3 left-1/2 transform -translate-x-1/2 pointer-events-none z-50"
         >
-          <div className="flex items-center gap-2 bg-gradient-to-r from-spot to-spot-hover text-white px-5 py-2.5 rounded-full shadow-lg">
+          <div className="flex items-center gap-2 bg-gradient-to-r from-spot to-spot-hover text-on-spot px-5 py-2.5 rounded-full shadow-lg">
             <motion.span
               animate={{ rotate: [0, -10, 10, 0] }}
               transition={{ repeat: 2, duration: 0.3 }}

--- a/components/contact/ContactSuccessScreen.tsx
+++ b/components/contact/ContactSuccessScreen.tsx
@@ -20,7 +20,7 @@ export function ContactSuccessScreen() {
           </p>
           <Link
             href="/settings"
-            className="inline-flex items-center px-6 py-3 bg-spot text-white rounded-lg hover:bg-spot-hover transition-colors font-medium"
+            className="inline-flex items-center px-6 py-3 bg-spot text-on-spot rounded-lg hover:bg-spot-hover transition-colors font-medium"
           >
             <HiArrowLeft className="h-5 w-5 mr-2" />
             設定に戻る

--- a/components/drip-guide/dialogs/46/Dialog46Form.tsx
+++ b/components/drip-guide/dialogs/46/Dialog46Form.tsx
@@ -63,7 +63,7 @@ export const Dialog46Form: React.FC<Dialog46FormProps> = ({
               onClick={() => onTasteChange(t)}
               className={`!py-3 !px-4 !text-sm justify-center ${
                 taste === t
-                  ? '!bg-spot !text-white shadow-md'
+                  ? '!bg-spot !text-on-spot shadow-md'
                   : '!bg-ground !text-ink-sub hover:!bg-ground/80 !border-0 !shadow-none'
               }`}
             >
@@ -86,7 +86,7 @@ export const Dialog46Form: React.FC<Dialog46FormProps> = ({
               onClick={() => onStrengthChange(s)}
               className={`!py-3 !px-4 !text-sm justify-center ${
                 strength === s
-                  ? '!bg-spot !text-white shadow-md'
+                  ? '!bg-spot !text-on-spot shadow-md'
                   : '!bg-ground !text-ink-sub hover:!bg-ground/80 !border-0 !shadow-none'
               }`}
             >

--- a/components/drip-guide/runner/FooterControls.tsx
+++ b/components/drip-guide/runner/FooterControls.tsx
@@ -72,7 +72,7 @@ export const FooterControls: React.FC<FooterControlsProps> = ({
             onClick={onToggleTimer}
             className={clsx(
               'w-16 h-16 sm:w-20 sm:h-20 lg:w-24 lg:h-24 !p-0 shadow-xl active:scale-95 touch-manipulation',
-              isRunning ? 'bg-surface border-2 border-spot/20 text-spot' : 'bg-spot text-white shadow-spot/30'
+              isRunning ? 'bg-surface border-2 border-spot/20 text-spot' : 'bg-spot text-on-spot shadow-spot/30'
             )}
             aria-label={isRunning ? '一時停止' : '再生'}
           >
@@ -140,7 +140,7 @@ export const FooterControls: React.FC<FooterControlsProps> = ({
             onClick={onToggleTimer}
             className={clsx(
               'w-20 h-20 lg:w-24 lg:h-24 !p-0 shadow-xl active:scale-95 touch-manipulation',
-              isRunning ? 'bg-surface border-2 border-spot/20 text-spot' : 'bg-spot text-white shadow-spot/30'
+              isRunning ? 'bg-surface border-2 border-spot/20 text-spot' : 'bg-spot text-on-spot shadow-spot/30'
             )}
             aria-label={isRunning ? '一時停止' : '再生'}
           >

--- a/components/ui/Button.test.tsx
+++ b/components/ui/Button.test.tsx
@@ -63,6 +63,7 @@ describe('Button', () => {
       const button = screen.getByText('プライマリ');
 
       expect(button.className).toContain('bg-btn-primary');
+      expect(button.className).toContain('text-btn-primary-text');
     });
 
     it('secondaryバリアントのスタイルが適用される', () => {

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -99,7 +99,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
     // バリアントスタイル（CSS変数ベース）
     const variantStyles = {
-      primary: 'bg-btn-primary text-white hover:bg-btn-primary-hover',
+      primary: 'bg-btn-primary text-btn-primary-text hover:bg-btn-primary-hover',
       secondary: 'bg-gray-600 text-white hover:bg-gray-700',
       danger: 'bg-danger text-white hover:bg-danger/90',
       success: 'bg-success text-white hover:bg-success/90',

--- a/components/ui/FilterModal.tsx
+++ b/components/ui/FilterModal.tsx
@@ -95,7 +95,7 @@ export function FilterOptionButton({ selected = false, className = '', children,
       variant={selected ? 'ghost' : 'surface'}
       size="sm"
       className={`flex-1 !rounded-lg !px-3 !py-2 gap-1.5 justify-center ${
-        selected ? '!bg-spot !text-white !border-spot' : ''
+        selected ? '!bg-spot !text-on-spot !border-spot' : ''
       } ${className}`}
       {...props}
     >

--- a/components/ui/IconButton.test.tsx
+++ b/components/ui/IconButton.test.tsx
@@ -34,6 +34,7 @@ describe('IconButton', () => {
       render(<IconButton variant="primary">X</IconButton>);
       const button = screen.getByRole('button');
       expect(button.className).toContain('bg-btn-primary');
+      expect(button.className).toContain('text-btn-primary-text');
     });
 
     it('dangerバリアントのスタイルが適用される', () => {

--- a/components/ui/IconButton.tsx
+++ b/components/ui/IconButton.tsx
@@ -45,7 +45,7 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
     // バリアントスタイル（CSS変数ベース）
     const variantStyles = {
       default: 'text-ink-sub hover:text-ink hover:bg-ground',
-      primary: 'bg-btn-primary text-white hover:bg-btn-primary-hover',
+      primary: 'bg-btn-primary text-btn-primary-text hover:bg-btn-primary-hover',
       danger: 'text-danger hover:text-danger/80 hover:bg-danger-subtle',
       success: 'text-success hover:text-success/80 hover:bg-success-subtle',
       ghost: 'text-ink-muted hover:text-ink-sub hover:bg-ground',

--- a/lib/themeTokens.test.ts
+++ b/lib/themeTokens.test.ts
@@ -12,13 +12,45 @@ function getRootThemeToken(css: string, tokenName: string): string | undefined {
   return rootThemeBlock?.match(new RegExp(`\\s${tokenName}:\\s*([^;]+);`))?.[1]?.trim();
 }
 
-describe('theme tokens', () => {
-  it('通常テーマのアクセント色は明るいオレンジを使う', () => {
-    const css = readThemeCss();
+function getRelativeLuminance(hexColor: string): number {
+  const channels = hexColor
+    .match(/[0-9a-f]{2}/gi)
+    ?.map((channel) => parseInt(channel, 16) / 255)
+    .map((value) => (value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4));
 
-    expect(getRootThemeToken(css, '--spot')).toBe('#d97706');
-    expect(getRootThemeToken(css, '--spot-hover')).toBe('#b45309');
-    expect(getRootThemeToken(css, '--btn-primary')).toBe('#d97706');
-    expect(getRootThemeToken(css, '--btn-primary-hover')).toBe('#b45309');
+  if (!channels) {
+    throw new Error(`Invalid hex color: ${hexColor}`);
+  }
+
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+function getContrastRatio(foreground: string, background: string): number {
+  const foregroundLuminance = getRelativeLuminance(foreground);
+  const backgroundLuminance = getRelativeLuminance(background);
+  const lighter = Math.max(foregroundLuminance, backgroundLuminance);
+  const darker = Math.min(foregroundLuminance, backgroundLuminance);
+
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+describe('theme tokens', () => {
+  it('通常テーマのアクセント色は明るいオレンジと読みやすい文字色を使う', () => {
+    const css = readThemeCss();
+    const spot = getRootThemeToken(css, '--spot');
+    const spotHover = getRootThemeToken(css, '--spot-hover');
+    const onSpot = getRootThemeToken(css, '--on-spot');
+    const btnPrimary = getRootThemeToken(css, '--btn-primary');
+    const btnPrimaryHover = getRootThemeToken(css, '--btn-primary-hover');
+    const btnPrimaryText = getRootThemeToken(css, '--btn-primary-text');
+
+    expect(spot).toBe('#d97706');
+    expect(onSpot).toBe('#211714');
+    expect(btnPrimary).toBe('#d97706');
+    expect(btnPrimaryText).toBe('#211714');
+    expect(getContrastRatio(onSpot!, spot!)).toBeGreaterThanOrEqual(4.5);
+    expect(getContrastRatio(onSpot!, spotHover!)).toBeGreaterThanOrEqual(4.5);
+    expect(getContrastRatio(btnPrimaryText!, btnPrimary!)).toBeGreaterThanOrEqual(4.5);
+    expect(getContrastRatio(btnPrimaryText!, btnPrimaryHover!)).toBeGreaterThanOrEqual(4.5);
   });
 });

--- a/lib/themeTokens.test.ts
+++ b/lib/themeTokens.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+function readThemeCss(): string {
+  return readFileSync(join(process.cwd(), 'app', 'globals.css'), 'utf8');
+}
+
+function getRootThemeToken(css: string, tokenName: string): string | undefined {
+  const rootThemeBlock = css.match(/@layer theme\s*{\s*:root\s*{(?<body>[\s\S]*?)^\s*}/m)?.groups?.body;
+  return rootThemeBlock?.match(new RegExp(`\\s${tokenName}:\\s*([^;]+);`))?.[1]?.trim();
+}
+
+describe('theme tokens', () => {
+  it('通常テーマのアクセント色は明るいオレンジを使う', () => {
+    const css = readThemeCss();
+
+    expect(getRootThemeToken(css, '--spot')).toBe('#d97706');
+    expect(getRootThemeToken(css, '--spot-hover')).toBe('#b45309');
+    expect(getRootThemeToken(css, '--btn-primary')).toBe('#d97706');
+    expect(getRootThemeToken(css, '--btn-primary-hover')).toBe('#b45309');
+  });
+});

--- a/lib/themeTokens.test.ts
+++ b/lib/themeTokens.test.ts
@@ -8,7 +8,7 @@ function readThemeCss(): string {
 }
 
 function getRootThemeToken(css: string, tokenName: string): string | undefined {
-  const rootThemeBlock = css.match(/@layer theme\s*{\s*:root\s*{(?<body>[\s\S]*?)^\s*}/m)?.groups?.body;
+  const rootThemeBlock = css.match(/@layer theme\s*{\s*:root\s*{([\s\S]*?)^\s*}/m)?.[1];
   return rootThemeBlock?.match(new RegExp(`\\s${tokenName}:\\s*([^;]+);`))?.[1]?.trim();
 }
 


### PR DESCRIPTION
## 対象
- 通常テーマの共通オレンジ色が暗くなっていた問題の修正

## 変更内容
- `app/globals.css` の通常テーマ `--spot` / `--btn-primary` を履歴上の明るいオレンジ `#d97706` に復元
- hover色を従来の `#b45309` に復元
- `lib/themeTokens.test.ts` を追加し、通常テーマの主要アクセント色が意図せず暗くならないように回帰テストを追加

## なぜ必要か
- `5ce12ae fix: a11y serious指摘を改善` で通常テーマの共通アクセント色が `#b45309` に変更され、ホーム画面を含む複数画面のオレンジが暗く見える状態になっていたため

## 確認したこと
- `npm run test:run -- lib/themeTokens.test.ts` 成功
- `npm run lint -- lib/themeTokens.test.ts` 成功
- localhost 配信CSSで `--spot: #d97706` / `--btn-primary: #d97706` を確認

## 意図的に触らなかった範囲
- 作業前から存在していた未コミット変更
- 他テーマのアクセント色
- a11y修正コミット内の文字色・設定画面変更

## 残リスク
- 全体テスト・全体ビルドは未実行