### PR TITLE
[P2] 未使用exportを段階整理 Phase 2

### DIFF
--- a/app/dev/design-lab/components/registry.ts
+++ b/app/dev/design-lab/components/registry.ts
@@ -1,4 +1,4 @@
-export interface LabSection {
+interface LabSection {
   id: string;
   title: string;
   description: string;

--- a/components/splash/patterns.tsx
+++ b/components/splash/patterns.tsx
@@ -2,7 +2,7 @@
 
 // ─── スプラッシュアニメーションパターン ───
 
-export interface PatternProps {
+interface PatternProps {
   phase: number;
   compact?: boolean; // プレビューカード用の小さいサイズ
 }

--- a/docs/working/20260526_412_deadcode-cleanup/phase2-summary.md
+++ b/docs/working/20260526_412_deadcode-cleanup/phase2-summary.md
@@ -1,0 +1,76 @@
+# Issue #412 Phase 2 deadcode整理メモ
+
+## 修正前概要
+
+`npm run deadcode` を再実行した。
+
+- 未使用ファイル: 33件
+- 未使用依存: 2件
+  - `tailwind-merge`
+  - `zod`
+- 未使用devDependency: 4件
+  - `@remotion/google-fonts`
+  - `@remotion/transitions`
+  - `lint-staged`
+  - `remotion`
+- 未使用export: 62件
+  - ただし `productionPackRecords` 系は作業開始時点の未コミット変更由来のため、今回の対象外。
+- 未使用exported type: 85件
+
+## 今回触る候補
+
+`rg` で名前検索し、同一ファイル内だけで使われている型exportに限定してexportを解除した。
+
+- `QuestionsStats` in `hooks/useQuizData.ts`
+- `QuizMode` in `hooks/useQuizSession.ts`
+- `UseTimerControlsReturn` in `hooks/roast-timer/useTimerControls.ts`
+- `ClockFontOption` in `lib/clockSettings.ts`
+- `ContactFormValidationResult` in `lib/contactForm.ts`
+- `CompressImageOptions` in `lib/imageCompression.ts`
+- `PatternProps` in `components/splash/patterns.tsx`
+- `LabSection` in `app/dev/design-lab/components/registry.ts`
+- `WorkProgressSplitState` in `lib/firestore/workProgress/subcollection.ts`
+- `UseTimerUpdaterArgs` in `hooks/roast-timer/useTimerUpdater.ts`
+
+## 今回残す候補
+
+- 未使用依存 / devDependency
+  - lockfile差分が大きくなりやすいため別PR候補。
+- `components/ui/**` のProps型
+  - 共通UIの公開APIやbarrel exportの意図がある可能性が高いため残す。
+- `components/coffee-quiz/index.ts` のbarrel export
+  - 将来機能・再利用前提の可能性があるため残す。
+- `data/legal/**`
+  - 法務表示データで、公開APIや表示用途の可能性があるため残す。
+- `e2eMode` 関連
+  - テスト・E2E設定経由の参照可能性があるため残す。
+- `app/assignment/lib/firebase/**`
+  - Firebase補助関数で、分割・動的参照の可能性があるため残す。
+- `productionPackRecords` 系
+  - 作業開始時点から存在する別Issueの未コミット変更由来のため触らない。
+
+## 修正後概要
+
+`npm run deadcode` を再実行した。
+
+- 未使用ファイル: 33件のまま
+- 未使用依存: 2件のまま
+- 未使用devDependency: 4件のまま
+- 未使用export: 62件のまま
+  - `productionPackRecords` 系を除くPR #438後の既存指摘は50件相当のまま。
+- 未使用exported type: 85件 -> 75件
+
+## 検証メモ
+
+- `npm run deadcode`
+  - 検出ありのため終了コード1。未使用exported typeが10件減少。
+- `npm run typecheck`
+  - 成功。
+- `npx vitest run hooks/useQuizData.test.ts hooks/useQuizSession.test.ts lib/contactForm.test.ts lib/clockSettings.test.ts lib/imageCompression.test.ts lib/firestore/workProgress/helpers.test.ts`
+  - 成功。6 files / 139 tests passed。
+- `npm run test:run`
+  - 成功。101 files / 1330 tests passed。
+- `npm run build`
+  - 成功。
+- `npm run lint`
+  - 成功。既存の `MODULE_TYPELESS_PACKAGE_JSON` warningのみ。

--- a/hooks/roast-timer/useTimerControls.ts
+++ b/hooks/roast-timer/useTimerControls.ts
@@ -21,7 +21,7 @@ export interface UseTimerControlsArgs {
   currentDeviceId: string;
 }
 
-export interface UseTimerControlsReturn {
+interface UseTimerControlsReturn {
   startTimer: (
     duration: number,
     beanName?: string,

--- a/hooks/roast-timer/useTimerUpdater.ts
+++ b/hooks/roast-timer/useTimerUpdater.ts
@@ -16,7 +16,7 @@ type UpdateAppDataFn = (
 
 const UPDATE_INTERVAL = 250; // 250msごとに更新（CSS transitionと同期）
 
-export interface UseTimerUpdaterArgs {
+interface UseTimerUpdaterArgs {
   user: { uid: string } | null;
   updateData: UpdateAppDataFn;
   isLoading: boolean;

--- a/hooks/useQuizData.ts
+++ b/hooks/useQuizData.ts
@@ -50,7 +50,7 @@ export interface AnswerResult {
 }
 
 // 問題の統計情報の型
-export interface QuestionsStats {
+interface QuestionsStats {
   total: number;
   byCategory: Record<QuizCategory, number>;
   byDifficulty: Record<QuizDifficulty, number>;

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -10,7 +10,7 @@ import {
 } from '@/lib/coffee-quiz/questions';
 import { useQuizData } from './useQuizData';
 
-export type QuizMode = 'daily' | 'review' | 'category' | 'random' | 'single' | 'shuffle' | 'sequential';
+type QuizMode = 'daily' | 'review' | 'category' | 'random' | 'single' | 'shuffle' | 'sequential';
 
 interface UseQuizSessionOptions {
   mode?: QuizMode;

--- a/lib/clockSettings.ts
+++ b/lib/clockSettings.ts
@@ -81,7 +81,7 @@ export const CLOCK_THEMES: Record<ClockTheme, { label: string; colors: ThemeColo
 
 export type ClockFontKey = 'inter' | 'robotoMono' | 'oswald' | 'orbitron' | 'notoSansJP';
 
-export interface ClockFontOption {
+interface ClockFontOption {
   label: string;
   cssVar: string;
   fallback: string;

--- a/lib/contactForm.ts
+++ b/lib/contactForm.ts
@@ -10,7 +10,7 @@ export const CONTACT_FORM_LIMITS = {
 export const CONTACT_FORM_COOLDOWN_MS = 2 * 60 * 1000;
 export const CONTACT_FORM_COOLDOWN_STORAGE_KEY = 'roastplus-contact-last-success-at';
 
-export interface ContactFormValidationResult {
+interface ContactFormValidationResult {
   isValid: boolean;
   errors: Partial<Record<keyof ContactFormData, string>>;
 }

--- a/lib/firestore/workProgress/subcollection.ts
+++ b/lib/firestore/workProgress/subcollection.ts
@@ -2,7 +2,7 @@ import { collection, doc, getDoc, getDocs, type DocumentData, type QuerySnapshot
 import { getDb, normalizeAppData } from '../common';
 import type { WorkProgress } from '@/types';
 
-export interface WorkProgressSplitState {
+interface WorkProgressSplitState {
   workProgresses: WorkProgress[];
   isMigrated: boolean;
 }

--- a/lib/imageCompression.ts
+++ b/lib/imageCompression.ts
@@ -1,7 +1,7 @@
 /**
  * 画像圧縮オプション
  */
-export interface CompressImageOptions {
+interface CompressImageOptions {
   /** リサイズの最大辺長（px）。デフォルト: 800 */
   maxSize?: number;
   /** JPEG圧縮品質（0-1）。デフォルト: 0.8 */


### PR DESCRIPTION
Part of #412

## 変更したファイル
- `hooks/useQuizData.ts`
- `hooks/useQuizSession.ts`
- `hooks/roast-timer/useTimerControls.ts`
- `hooks/roast-timer/useTimerUpdater.ts`
- `lib/clockSettings.ts`
- `lib/contactForm.ts`
- `lib/imageCompression.ts`
- `lib/firestore/workProgress/subcollection.ts`
- `components/splash/patterns.tsx`
- `app/dev/design-lab/components/registry.ts`
- `docs/working/20260526_412_deadcode-cleanup/phase2-summary.md`

## npm run deadcode の修正前概要
- 未使用ファイル: 33件
- 未使用依存: 2件
  - `tailwind-merge`
  - `zod`
- 未使用devDependency: 4件
  - `@remotion/google-fonts`
  - `@remotion/transitions`
  - `lint-staged`
  - `remotion`
- 未使用export: 62件
  - 作業開始時点の未コミット変更由来の `productionPackRecords` 系を含むため、PR #438後の既存指摘としては50件相当です。
- 未使用exported type: 85件

## 今回export解除したもの
同一ファイル内だけで使われている型に限定して、exportだけ外しました。

- `QuestionsStats` in `hooks/useQuizData.ts`
- `QuizMode` in `hooks/useQuizSession.ts`
- `UseTimerControlsReturn` in `hooks/roast-timer/useTimerControls.ts`
- `UseTimerUpdaterArgs` in `hooks/roast-timer/useTimerUpdater.ts`
- `ClockFontOption` in `lib/clockSettings.ts`
- `ContactFormValidationResult` in `lib/contactForm.ts`
- `CompressImageOptions` in `lib/imageCompression.ts`
- `WorkProgressSplitState` in `lib/firestore/workProgress/subcollection.ts`
- `PatternProps` in `components/splash/patterns.tsx`
- `LabSection` in `app/dev/design-lab/components/registry.ts`

## 削除理由
- knipが未使用exported typeとして検出していたため。
- `rg` で外部importがないことを確認できたため。
- 型自体は同一ファイル内の引数・戻り値・内部データ構造として使われているため、削除ではなく非export化に留めました。

## 削除前に確認した参照方法
- `npm run deadcode`
- `rg` による名前検索
  - `QuestionsStats`
  - `QuizMode`
  - `UseTimerControlsReturn`
  - `UseTimerUpdaterArgs`
  - `ClockFontOption`
  - `ContactFormValidationResult`
  - `CompressImageOptions`
  - `WorkProgressSplitState`
  - `PatternProps`
  - `LabSection`

## 削除しなかったものと理由
- 未使用依存 / devDependency
  - lockfile差分が大きくなりやすいため別PR候補に残しました。
- `components/ui/**` のProps型
  - 共通UIの公開APIやbarrel exportの意図がある可能性が高いため残しました。
- `components/coffee-quiz/index.ts` のbarrel export
  - 将来機能・再利用前提の可能性があるため残しました。
- `data/legal/**`
  - 法務表示データで、公開APIや表示用途の可能性があるため残しました。
- `e2eMode` 関連
  - テスト・E2E設定経由の参照可能性があるため残しました。
- `app/assignment/lib/firebase/**`
  - Firebase補助関数で、分割・動的参照の可能性があるため残しました。
- `productionPackRecords` 系
  - 作業開始時点から存在する別Issueの未コミット変更由来のため触っていません。

## npm run deadcode の修正後概要
- 未使用ファイル: 33件のまま
- 未使用依存: 2件のまま
- 未使用devDependency: 4件のまま
- 未使用export: 62件のまま
- 未使用exported type: 85件 -> 75件

## 実行した確認コマンドと結果
- `npm run deadcode`
  - 検出ありのため終了コード1。未使用exported typeが10件減少。
- `npm run typecheck`
  - 成功。
- `npx vitest run hooks/useQuizData.test.ts hooks/useQuizSession.test.ts lib/contactForm.test.ts lib/clockSettings.test.ts lib/imageCompression.test.ts lib/firestore/workProgress/helpers.test.ts`
  - 成功。6 files / 139 tests passed。
- `npm run test:run`
  - 成功。101 files / 1330 tests passed。
- `npm run build`
  - 成功。
- `npm run lint`
  - 成功。既存の `MODULE_TYPELESS_PACKAGE_JSON` warningのみ。
- `git diff --check`
  - 成功。CRLF変換warningのみ。

## 残リスク
- knipの誤検知、dynamic import、barrel export、公開APIの可能性は残っています。
- 共通UIのProps型やbarrel exportは外部利用の可能性があるため、今回は触っていません。
- 依存削除はlockfile差分が大きくなる可能性があるため、別PRに回しています。
- 作業開始時点で別Issueの未コミット変更があり、ローカルdeadcodeにはその影響が一部含まれています。このPRのコミットには含めていません。

## このIssue外として触らなかったもの
- package.json / package-lock.json
- UI変更
- 仕様変更
- 未使用ファイルの大量削除
- Firebase / Firestore Rules / Cloud Functions / Service Worker の機能変更
- #413以降の修正
