### PR TITLE
[P2] 複雑度の高いファイルを分割

### DIFF
--- a/app/assignment/components/assignment-table/DesktopTableBody.tsx
+++ b/app/assignment/components/assignment-table/DesktopTableBody.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+
+import { Button } from '@/components/ui';
+import type { Assignment, Member, TableSettings, TaskLabel, Team } from '@/types';
+
+import type { HeightConfig } from './types';
+
+type HeaderLabels = {
+  left: string;
+  right: string;
+};
+
+interface DesktopTableBodyProps {
+  teams: Team[];
+  taskLabels: TaskLabel[];
+  assignments: Assignment[];
+  members: Member[];
+  tableSettings: TableSettings | null;
+  selectedCell: { teamId: string; taskLabelId: string } | null;
+  gridTemplateColumns: string;
+  headerLabels: HeaderLabels;
+  setHeightConfig: (config: HeightConfig | null) => void;
+  handleCellTouchStart: (
+    teamId: string,
+    taskLabelId: string,
+    memberId: string | null,
+    event: React.TouchEvent | React.MouseEvent
+  ) => void;
+  handleCellTouchEnd: () => void;
+  handleCellTouchMove: (event: React.TouchEvent | React.MouseEvent) => void;
+  handleCellClick: (teamId: string, taskLabelId: string) => void;
+}
+
+export const DesktopTableBody: React.FC<DesktopTableBodyProps> = ({
+  teams,
+  taskLabels,
+  assignments,
+  members,
+  tableSettings,
+  selectedCell,
+  gridTemplateColumns,
+  headerLabels,
+  setHeightConfig,
+  handleCellTouchStart,
+  handleCellTouchEnd,
+  handleCellTouchMove,
+  handleCellClick,
+}) => {
+  return (
+    <>
+      {taskLabels.map((label) => (
+        <div
+          key={label.id}
+          className="grid items-center transition-colors group hover:bg-ground/50"
+          style={{
+            gridTemplateColumns,
+            minHeight: `${tableSettings?.rowHeights?.[label.id] ?? 60}px`,
+          }}
+        >
+          <div
+            className="p-3 md:p-4 py-2 border-r h-full flex items-center justify-center border-edge cursor-pointer transition-colors hover:bg-ground"
+            onClick={() => {
+              setHeightConfig({
+                taskLabelId: label.id,
+                currentHeight: tableSettings?.rowHeights?.[label.id] ?? 60,
+                label: `${headerLabels.left}の設定`,
+                currentName: label.leftLabel,
+                editMode: 'left',
+                currentRightLabel: label.rightLabel || '',
+              });
+            }}
+          >
+            <div className="w-full p-1 font-medium text-sm md:text-base whitespace-nowrap text-center overflow-visible text-ink">
+              {label.leftLabel}
+            </div>
+          </div>
+
+          {teams.length === 0 ? (
+            <div className="p-2 md:p-4 border-r h-full flex items-center justify-center border-edge bg-ground/30">
+              <span className="text-xs md:text-sm text-ink-muted">班を作成してください</span>
+            </div>
+          ) : (
+            teams.map((team) => {
+              const assignment = assignments.find((item) => item.teamId === team.id && item.taskLabelId === label.id);
+              const member = members.find((item) => item.id === assignment?.memberId);
+              const isSelected = selectedCell?.teamId === team.id && selectedCell?.taskLabelId === label.id;
+
+              return (
+                <div
+                  key={team.id}
+                  className="p-2 md:p-4 py-2 border-r h-full flex items-center justify-center relative border-edge"
+                >
+                  <Button
+                    variant={isSelected ? (member ? 'primary' : 'outline') : 'surface'}
+                    onMouseDown={(event) => handleCellTouchStart(team.id, label.id, member?.id || null, event)}
+                    onMouseUp={handleCellTouchEnd}
+                    onMouseMove={handleCellTouchMove}
+                    onMouseLeave={handleCellTouchEnd}
+                    onTouchStart={(event) => handleCellTouchStart(team.id, label.id, member?.id || null, event)}
+                    onTouchEnd={handleCellTouchEnd}
+                    onTouchMove={handleCellTouchMove}
+                    onClick={() => handleCellClick(team.id, label.id)}
+                    className={`
+                                                !min-h-0 w-full py-2 md:py-3 px-1 !rounded-lg text-sm md:text-base !font-bold text-center transition-all truncate select-none
+                                                ${member && isSelected ? 'shadow-md scale-105' : ''} ${
+                                                  !member && isSelected ? '!bg-surface !border-spot' : ''
+                                                } ${!member && !isSelected ? '!text-ink-muted !bg-ground !border-dashed !border-edge-strong hover:!bg-ground/80 !shadow-none' : ''}
+                                            `}
+                  >
+                    {member ? member.name : '未割当'}
+                  </Button>
+                </div>
+              );
+            })
+          )}
+
+          <div
+            className="p-3 md:p-4 py-2 border-l h-full flex items-center border-edge cursor-pointer transition-colors hover:bg-ground"
+            onClick={() => {
+              setHeightConfig({
+                taskLabelId: label.id,
+                currentHeight: tableSettings?.rowHeights?.[label.id] ?? 60,
+                label: `${headerLabels.right}の設定`,
+                currentName: label.rightLabel || '',
+                editMode: 'right',
+                currentRightLabel: label.leftLabel,
+              });
+            }}
+          >
+            <div className="w-full p-1 font-medium text-sm md:text-base whitespace-nowrap text-center overflow-visible text-ink">
+              {label.rightLabel}
+            </div>
+          </div>
+        </div>
+      ))}
+    </>
+  );
+};

--- a/app/assignment/components/assignment-table/DesktopTableFooter.tsx
+++ b/app/assignment/components/assignment-table/DesktopTableFooter.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { MdAdd } from 'react-icons/md';
+import { PiShuffleBold } from 'react-icons/pi';
+
+import { Button, Input } from '@/components/ui';
+
+import { MAX_TASK_LABELS } from '../../lib/constants';
+
+type HeaderLabels = {
+  left: string;
+  right: string;
+};
+
+interface DesktopTableFooterProps {
+  teamsLength: number;
+  taskLabelsLength: number;
+  gridTemplateColumns: string;
+  headerLabels: HeaderLabels;
+  newLeftLabel: string;
+  setNewLeftLabel: (value: string) => void;
+  newRightLabel: string;
+  setNewRightLabel: (value: string) => void;
+  handleAddTaskLabel: () => Promise<void>;
+  onShuffle: () => Promise<void>;
+  isShuffleDisabled: boolean;
+}
+
+export const DesktopTableFooter: React.FC<DesktopTableFooterProps> = ({
+  teamsLength,
+  taskLabelsLength,
+  gridTemplateColumns,
+  headerLabels,
+  newLeftLabel,
+  setNewLeftLabel,
+  newRightLabel,
+  setNewRightLabel,
+  handleAddTaskLabel,
+  onShuffle,
+  isShuffleDisabled,
+}) => {
+  return (
+    <div className="grid items-center py-2 border-t min-h-[60px] bg-ground border-edge" style={{ gridTemplateColumns }}>
+      {taskLabelsLength < MAX_TASK_LABELS ? (
+        <div className="px-2">
+          <Input
+            value={newLeftLabel}
+            onChange={(e) => setNewLeftLabel(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleAddTaskLabel();
+            }}
+            placeholder={`${headerLabels.left}を入力`}
+            className="!p-2 !text-sm !min-h-0 !text-center"
+          />
+        </div>
+      ) : (
+        <div />
+      )}
+
+      <div
+        className="col-span-full px-2 flex items-center justify-center gap-3"
+        style={{ gridColumn: `2 / span ${Math.max(1, teamsLength)}` }}
+      >
+        {taskLabelsLength < MAX_TASK_LABELS && (
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleAddTaskLabel}
+            disabled={!newLeftLabel.trim()}
+            className="!rounded-full !px-4 shadow-md active:scale-95"
+          >
+            <MdAdd size={18} />
+            <span className="font-medium text-sm">担当を追加</span>
+          </Button>
+        )}
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={onShuffle}
+          disabled={isShuffleDisabled}
+          className="!rounded-full !px-4 shadow-md active:scale-95"
+        >
+          <PiShuffleBold className="w-5 h-5" />
+          <span className="font-medium text-sm">シャッフル</span>
+        </Button>
+      </div>
+
+      {taskLabelsLength < MAX_TASK_LABELS ? (
+        <div className="px-2 flex items-center w-full h-full" style={{ gridColumn: '-2 / -1' }}>
+          <Input
+            value={newRightLabel}
+            onChange={(e) => setNewRightLabel(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleAddTaskLabel();
+            }}
+            placeholder={`${headerLabels.right}を入力`}
+            className="!min-w-0 !p-2 !text-center !text-sm !min-h-0 w-full"
+          />
+        </div>
+      ) : (
+        <div />
+      )}
+    </div>
+  );
+};

--- a/app/assignment/components/assignment-table/DesktopTableHeader.tsx
+++ b/app/assignment/components/assignment-table/DesktopTableHeader.tsx
@@ -1,0 +1,196 @@
+import React from 'react';
+import { MdAdd } from 'react-icons/md';
+
+import { Button, IconButton, InlineInput } from '@/components/ui';
+import type { TableSettings, Team } from '@/types';
+
+import { MAX_TEAMS } from '../../lib/constants';
+import type { WidthConfig } from './types';
+import { formatTeamTitle } from './desktopTableViewLayout';
+
+type HeaderLabels = {
+  left: string;
+  right: string;
+};
+
+interface DesktopTableHeaderProps {
+  teams: Team[];
+  tableSettings: TableSettings | null;
+  gridTemplateColumns: string;
+  headerLabels: HeaderLabels;
+  isAddingTeam: boolean;
+  setIsAddingTeam: (value: boolean) => void;
+  newTeamName: string;
+  setNewTeamName: (value: string) => void;
+  handleAddTeam: () => Promise<void>;
+  editingTeamId: string | null;
+  editTeamName: string;
+  setEditTeamName: (value: string) => void;
+  handleUpdateTeam: (teamId: string) => Promise<void>;
+  setActiveTeamActionId: (id: string | null) => void;
+  setActiveTeamName: (name: string) => void;
+  setWidthConfig: (config: WidthConfig | null) => void;
+}
+
+export const DesktopTableHeader: React.FC<DesktopTableHeaderProps> = ({
+  teams,
+  tableSettings,
+  gridTemplateColumns,
+  headerLabels,
+  isAddingTeam,
+  setIsAddingTeam,
+  newTeamName,
+  setNewTeamName,
+  handleAddTeam,
+  editingTeamId,
+  editTeamName,
+  setEditTeamName,
+  handleUpdateTeam,
+  setActiveTeamActionId,
+  setActiveTeamName,
+  setWidthConfig,
+}) => {
+  return (
+    <div
+      className="grid border-b md:text-base font-semibold text-white sticky top-0 z-20 bg-dark border-gray-700"
+      style={{ gridTemplateColumns, minWidth: 'max-content' }}
+    >
+      <div
+        className="py-2 px-2 sm:px-3 border-r flex items-center justify-center cursor-pointer transition-colors bg-dark border-gray-700 hover:bg-gray-800"
+        onClick={() =>
+          setWidthConfig({
+            type: 'taskLabel',
+            currentWidth: tableSettings?.colWidths?.taskLabel ?? 160,
+            label: `${headerLabels.left}列の幅`,
+            currentTitle: headerLabels.left,
+          })
+        }
+        title="クリックして幅を変更"
+      >
+        {headerLabels.left}
+      </div>
+
+      {teams.length === 0 ? (
+        <div className="py-2 px-2 border-r text-center flex flex-col items-center justify-center h-full min-h-[44px] bg-dark border-gray-700">
+          {isAddingTeam ? (
+            <div className="relative z-20 flex items-center shadow-lg rounded p-1 w-32 md:w-40 bg-surface border border-spot">
+              <InlineInput
+                placeholder="班名(任意)"
+                value={newTeamName}
+                onChange={(e) => setNewTeamName(e.target.value)}
+                autoFocus
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleAddTeam();
+                  if (e.key === 'Escape') setIsAddingTeam(false);
+                }}
+                variant="dark"
+                className="!border-none !px-1 md:!p-2 md:!text-base !text-sm"
+              />
+              <IconButton variant="primary" size="sm" onClick={handleAddTeam}>
+                <MdAdd size={20} className="md:w-6 md:h-6" />
+              </IconButton>
+            </div>
+          ) : (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setIsAddingTeam(true)}
+              className="!text-sm md:!text-base !gap-1 !bg-transparent"
+            >
+              <MdAdd className="md:w-5 md:h-5" /> 最初の班を追加
+            </Button>
+          )}
+        </div>
+      ) : (
+        teams.map((team) => (
+          <div
+            key={team.id}
+            className="py-2 px-2 border-r text-center relative group flex items-center justify-center bg-dark border-gray-700"
+          >
+            {editingTeamId === team.id ? (
+              <InlineInput
+                value={editTeamName}
+                onChange={(e) => setEditTeamName(e.target.value)}
+                autoFocus
+                onKeyDown={(e) => e.key === 'Enter' && handleUpdateTeam(team.id)}
+                onBlur={() => handleUpdateTeam(team.id)}
+                variant="light"
+                className="!text-sm md:!text-base"
+              />
+            ) : (
+              <div
+                className="cursor-pointer rounded px-2 py-1 truncate w-full select-none hover:bg-gray-800 active:bg-gray-700 min-h-[28px] flex items-center justify-center"
+                onClick={() => {
+                  setActiveTeamActionId(team.id);
+                  setActiveTeamName(team.name);
+                }}
+              >
+                {formatTeamTitle(team.name) || <span className="text-gray-500 text-xs">班名を設定</span>}
+              </div>
+            )}
+          </div>
+        ))
+      )}
+
+      <div
+        className="py-2 px-2 sm:px-3 text-center flex items-center justify-between relative cursor-pointer transition-colors bg-dark hover:bg-gray-800"
+        onClick={(e) => {
+          if ((e.target as HTMLElement).closest('button, input')) return;
+          setWidthConfig({
+            type: 'note',
+            currentWidth: tableSettings?.colWidths?.note ?? 160,
+            label: `${headerLabels.right}列の幅`,
+            currentTitle: headerLabels.right,
+          });
+        }}
+        title="クリックして幅を変更"
+      >
+        <div className="relative">
+          {teams.length > 0 &&
+            teams.length < MAX_TEAMS &&
+            (isAddingTeam ? (
+              <>
+                <div
+                  className="fixed inset-0 z-10"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setIsAddingTeam(false);
+                  }}
+                />
+                <div className="absolute top-1/2 -translate-y-1/2 right-0 z-20 flex items-center shadow-lg rounded p-1 w-32 md:w-40 bg-surface border border-spot">
+                  <InlineInput
+                    placeholder="班名(任意)"
+                    value={newTeamName}
+                    onChange={(e) => setNewTeamName(e.target.value)}
+                    autoFocus
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') handleAddTeam();
+                      if (e.key === 'Escape') setIsAddingTeam(false);
+                    }}
+                    variant="dark"
+                    className="!border-none !px-1 md:!p-2 !text-sm md:!text-base"
+                  />
+                  <IconButton variant="primary" size="sm" onClick={handleAddTeam}>
+                    <MdAdd size={20} className="md:w-6 md:h-6" />
+                  </IconButton>
+                </div>
+              </>
+            ) : (
+              <IconButton
+                variant="ghost"
+                size="sm"
+                rounded
+                onClick={() => setIsAddingTeam(true)}
+                className="!bg-gray-700 !text-gray-300 hover:!bg-primary hover:!text-white"
+                title="班を追加"
+              >
+                <MdAdd size={16} className="md:w-5 md:h-5" />
+              </IconButton>
+            ))}
+        </div>
+        <span className="whitespace-nowrap">{headerLabels.right}</span>
+        <span className="w-4"></span>
+      </div>
+    </div>
+  );
+};

--- a/app/assignment/components/assignment-table/DesktopTableView.tsx
+++ b/app/assignment/components/assignment-table/DesktopTableView.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
-import { Team, TaskLabel, Assignment, Member, TableSettings } from '@/types';
-import { MdAdd } from 'react-icons/md';
-import { PiShuffleBold } from 'react-icons/pi';
-import { DEFAULT_TABLE_SETTINGS, WidthConfig, HeightConfig } from './types';
-import { Button, Input, InlineInput, IconButton, Card } from '@/components/ui';
-import { MAX_TEAMS, MAX_TASK_LABELS } from '../../lib/constants';
+
+import { Card } from '@/components/ui';
+import type { Assignment, Member, TableSettings, TaskLabel, Team } from '@/types';
+
+import { DesktopTableBody } from './DesktopTableBody';
+import { DesktopTableFooter } from './DesktopTableFooter';
+import { DesktopTableHeader } from './DesktopTableHeader';
+import { getDesktopGridTemplateColumns } from './desktopTableViewLayout';
+import { DEFAULT_TABLE_SETTINGS, type HeightConfig, type WidthConfig } from './types';
 
 type DesktopTableViewProps = {
   teams: Team[];
@@ -81,335 +84,59 @@ export const DesktopTableView: React.FC<DesktopTableViewProps> = ({
   isShuffleDisabled,
 }) => {
   const headerLabels = tableSettings?.headerLabels ?? DEFAULT_TABLE_SETTINGS.headerLabels;
-  const formatTeamTitle = (teamName?: string) => {
-    return teamName && teamName.trim().length > 0 ? `${teamName.trim()}班` : '';
-  };
-
-  const generateGridTemplateColumns = () => {
-    const defaultWidth = 140;
-    const labelWidth = tableSettings?.colWidths?.taskLabel ?? 160;
-    const noteWidth = tableSettings?.colWidths?.note ?? 160;
-
-    if (teams.length === 0) {
-      return `${labelWidth}px 160px ${noteWidth}px`;
-    }
-
-    const teamColumns = teams
-      .map((team) => {
-        const w = tableSettings?.colWidths?.teams?.[team.id] ?? defaultWidth;
-        return `${w}px`;
-      })
-      .join(' ');
-
-    return `${labelWidth}px ${teamColumns} ${noteWidth}px`;
-  };
-
-  const gridTemplateColumns = generateGridTemplateColumns();
+  const gridTemplateColumns = getDesktopGridTemplateColumns(teams, tableSettings);
 
   return (
     <Card variant="table" className="hidden md:block w-fit mx-auto max-w-full overflow-x-auto relative">
-      {/* ヘッダー */}
-      <div
-        className="grid border-b md:text-base font-semibold text-white sticky top-0 z-20 bg-dark border-gray-700"
-        style={{ gridTemplateColumns, minWidth: 'max-content' }}
-      >
-        <div
-          className="py-2 px-2 sm:px-3 border-r flex items-center justify-center cursor-pointer transition-colors bg-dark border-gray-700 hover:bg-gray-800"
-          onClick={() =>
-            setWidthConfig({
-              type: 'taskLabel',
-              currentWidth: tableSettings?.colWidths?.taskLabel ?? 160,
-              label: `${headerLabels.left}列の幅`,
-              currentTitle: headerLabels.left,
-            })
-          }
-          title="クリックして幅を変更"
-        >
-          {headerLabels.left}
-        </div>
+      <DesktopTableHeader
+        teams={teams}
+        tableSettings={tableSettings}
+        gridTemplateColumns={gridTemplateColumns}
+        headerLabels={headerLabels}
+        isAddingTeam={isAddingTeam}
+        setIsAddingTeam={setIsAddingTeam}
+        newTeamName={newTeamName}
+        setNewTeamName={setNewTeamName}
+        handleAddTeam={handleAddTeam}
+        editingTeamId={editingTeamId}
+        editTeamName={editTeamName}
+        setEditTeamName={setEditTeamName}
+        handleUpdateTeam={handleUpdateTeam}
+        setActiveTeamActionId={setActiveTeamActionId}
+        setActiveTeamName={setActiveTeamName}
+        setWidthConfig={setWidthConfig}
+      />
 
-        {/* チーム列 */}
-        {teams.length === 0 ? (
-          <div className="py-2 px-2 border-r text-center flex flex-col items-center justify-center h-full min-h-[44px] bg-dark border-gray-700">
-            {isAddingTeam ? (
-              <div className="relative z-20 flex items-center shadow-lg rounded p-1 w-32 md:w-40 bg-surface border border-spot">
-                <InlineInput
-                  placeholder="班名(任意)"
-                  value={newTeamName}
-                  onChange={(e) => setNewTeamName(e.target.value)}
-                  autoFocus
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') handleAddTeam();
-                    if (e.key === 'Escape') setIsAddingTeam(false);
-                  }}
-                  variant="dark"
-                  className="!border-none !px-1 md:!p-2 md:!text-base !text-sm"
-                />
-                <IconButton variant="primary" size="sm" onClick={handleAddTeam}>
-                  <MdAdd size={20} className="md:w-6 md:h-6" />
-                </IconButton>
-              </div>
-            ) : (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setIsAddingTeam(true)}
-                className="!text-sm md:!text-base !gap-1 !bg-transparent"
-              >
-                <MdAdd className="md:w-5 md:h-5" /> 最初の班を追加
-              </Button>
-            )}
-          </div>
-        ) : (
-          teams.map((team) => (
-            <div
-              key={team.id}
-              className="py-2 px-2 border-r text-center relative group flex items-center justify-center bg-dark border-gray-700"
-            >
-              {editingTeamId === team.id ? (
-                <InlineInput
-                  value={editTeamName}
-                  onChange={(e) => setEditTeamName(e.target.value)}
-                  autoFocus
-                  onKeyDown={(e) => e.key === 'Enter' && handleUpdateTeam(team.id)}
-                  onBlur={() => handleUpdateTeam(team.id)}
-                  variant="light"
-                  className="!text-sm md:!text-base"
-                />
-              ) : (
-                <div
-                  className="cursor-pointer rounded px-2 py-1 truncate w-full select-none hover:bg-gray-800 active:bg-gray-700 min-h-[28px] flex items-center justify-center"
-                  onClick={() => {
-                    setActiveTeamActionId(team.id);
-                    setActiveTeamName(team.name);
-                  }}
-                >
-                  {formatTeamTitle(team.name) || <span className="text-gray-500 text-xs">班名を設定</span>}
-                </div>
-              )}
-            </div>
-          ))
-        )}
-
-        {/* チーム追加 & 補足ヘッダー */}
-        <div
-          className="py-2 px-2 sm:px-3 text-center flex items-center justify-between relative cursor-pointer transition-colors bg-dark hover:bg-gray-800"
-          onClick={(e) => {
-            if ((e.target as HTMLElement).closest('button, input')) return;
-            setWidthConfig({
-              type: 'note',
-              currentWidth: tableSettings?.colWidths?.note ?? 160,
-              label: `${headerLabels.right}列の幅`,
-              currentTitle: headerLabels.right,
-            });
-          }}
-          title="クリックして幅を変更"
-        >
-          <div className="relative">
-            {teams.length > 0 &&
-              teams.length < MAX_TEAMS &&
-              (isAddingTeam ? (
-                <>
-                  <div
-                    className="fixed inset-0 z-10"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setIsAddingTeam(false);
-                    }}
-                  />
-                  <div className="absolute top-1/2 -translate-y-1/2 right-0 z-20 flex items-center shadow-lg rounded p-1 w-32 md:w-40 bg-surface border border-spot">
-                    <InlineInput
-                      placeholder="班名(任意)"
-                      value={newTeamName}
-                      onChange={(e) => setNewTeamName(e.target.value)}
-                      autoFocus
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') handleAddTeam();
-                        if (e.key === 'Escape') setIsAddingTeam(false);
-                      }}
-                      variant="dark"
-                      className="!border-none !px-1 md:!p-2 !text-sm md:!text-base"
-                    />
-                    <IconButton variant="primary" size="sm" onClick={handleAddTeam}>
-                      <MdAdd size={20} className="md:w-6 md:h-6" />
-                    </IconButton>
-                  </div>
-                </>
-              ) : (
-                <IconButton
-                  variant="ghost"
-                  size="sm"
-                  rounded
-                  onClick={() => setIsAddingTeam(true)}
-                  className="!bg-gray-700 !text-gray-300 hover:!bg-primary hover:!text-white"
-                  title="班を追加"
-                >
-                  <MdAdd size={16} className="md:w-5 md:h-5" />
-                </IconButton>
-              ))}
-          </div>
-          <span className="whitespace-nowrap">{headerLabels.right}</span>
-          <span className="w-4"></span>
-        </div>
-      </div>
-
-      {/* ボディ */}
       <div className="divide-y divide-edge bg-surface" style={{ minWidth: 'max-content' }}>
-        {taskLabels.map((label) => (
-          <div
-            key={label.id}
-            className="grid items-center transition-colors group hover:bg-ground/50"
-            style={{
-              gridTemplateColumns,
-              minHeight: `${tableSettings?.rowHeights?.[label.id] ?? 60}px`,
-            }}
-          >
-            {/* 左ラベル列 */}
-            <div
-              className="p-3 md:p-4 py-2 border-r h-full flex items-center justify-center border-edge cursor-pointer transition-colors hover:bg-ground"
-              onClick={() => {
-                setHeightConfig({
-                  taskLabelId: label.id,
-                  currentHeight: tableSettings?.rowHeights?.[label.id] ?? 60,
-                  label: `${headerLabels.left}の設定`,
-                  currentName: label.leftLabel,
-                  editMode: 'left',
-                  currentRightLabel: label.rightLabel || '',
-                });
-              }}
-            >
-              <div className="w-full p-1 font-medium text-sm md:text-base whitespace-nowrap text-center overflow-visible text-ink">
-                {label.leftLabel}
-              </div>
-            </div>
+        <DesktopTableBody
+          teams={teams}
+          taskLabels={taskLabels}
+          assignments={assignments}
+          members={members}
+          tableSettings={tableSettings}
+          selectedCell={selectedCell}
+          gridTemplateColumns={gridTemplateColumns}
+          headerLabels={headerLabels}
+          setHeightConfig={setHeightConfig}
+          handleCellTouchStart={handleCellTouchStart}
+          handleCellTouchEnd={handleCellTouchEnd}
+          handleCellTouchMove={handleCellTouchMove}
+          handleCellClick={handleCellClick}
+        />
 
-            {/* 各チームの担当者列 */}
-            {teams.length === 0 ? (
-              <div className="p-2 md:p-4 border-r h-full flex items-center justify-center border-edge bg-ground/30">
-                <span className="text-xs md:text-sm text-ink-muted">班を作成してください</span>
-              </div>
-            ) : (
-              teams.map((team) => {
-                const assignment = assignments.find((a) => a.teamId === team.id && a.taskLabelId === label.id);
-                const member = members.find((m) => m.id === assignment?.memberId);
-                const isSelected = selectedCell?.teamId === team.id && selectedCell?.taskLabelId === label.id;
-
-                return (
-                  <div
-                    key={team.id}
-                    className="p-2 md:p-4 py-2 border-r h-full flex items-center justify-center relative border-edge"
-                  >
-                    <Button
-                      variant={isSelected ? (member ? 'primary' : 'outline') : 'surface'}
-                      onMouseDown={(e) => handleCellTouchStart(team.id, label.id, member?.id || null, e)}
-                      onMouseUp={handleCellTouchEnd}
-                      onMouseMove={handleCellTouchMove}
-                      onMouseLeave={handleCellTouchEnd}
-                      onTouchStart={(e) => handleCellTouchStart(team.id, label.id, member?.id || null, e)}
-                      onTouchEnd={handleCellTouchEnd}
-                      onTouchMove={handleCellTouchMove}
-                      onClick={() => handleCellClick(team.id, label.id)}
-                      className={`
-                                                !min-h-0 w-full py-2 md:py-3 px-1 !rounded-lg text-sm md:text-base !font-bold text-center transition-all truncate select-none
-                                                ${member && isSelected ? 'shadow-md scale-105' : ''} ${
-                                                  !member && isSelected ? '!bg-surface !border-spot' : ''
-                                                } ${!member && !isSelected ? '!text-ink-muted !bg-ground !border-dashed !border-edge-strong hover:!bg-ground/80 !shadow-none' : ''}
-                                            `}
-                    >
-                      {member ? member.name : '未割当'}
-                    </Button>
-                  </div>
-                );
-              })
-            )}
-
-            {/* 右ラベル列 */}
-            <div
-              className="p-3 md:p-4 py-2 border-l h-full flex items-center border-edge cursor-pointer transition-colors hover:bg-ground"
-              onClick={() => {
-                setHeightConfig({
-                  taskLabelId: label.id,
-                  currentHeight: tableSettings?.rowHeights?.[label.id] ?? 60,
-                  label: `${headerLabels.right}の設定`,
-                  currentName: label.rightLabel || '',
-                  editMode: 'right',
-                  currentRightLabel: label.leftLabel,
-                });
-              }}
-            >
-              <div className="w-full p-1 font-medium text-sm md:text-base whitespace-nowrap text-center overflow-visible text-ink">
-                {label.rightLabel}
-              </div>
-            </div>
-          </div>
-        ))}
-
-        {/* 新規ラベル追加行 / シャッフル */}
-        <div
-          className="grid items-center py-2 border-t min-h-[60px] bg-ground border-edge"
-          style={{ gridTemplateColumns }}
-        >
-          {taskLabels.length < MAX_TASK_LABELS ? (
-            <div className="px-2">
-              <Input
-                value={newLeftLabel}
-                onChange={(e) => setNewLeftLabel(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') handleAddTaskLabel();
-                }}
-                placeholder={`${headerLabels.left}を入力`}
-                className="!p-2 !text-sm !min-h-0 !text-center"
-              />
-            </div>
-          ) : (
-            <div />
-          )}
-
-          {/* シャッフル & 追加ボタン（中央配置） */}
-          <div
-            className="col-span-full px-2 flex items-center justify-center gap-3"
-            style={{ gridColumn: `2 / span ${Math.max(1, teams.length)}` }}
-          >
-            {taskLabels.length < MAX_TASK_LABELS && (
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={handleAddTaskLabel}
-                disabled={!newLeftLabel.trim()}
-                className="!rounded-full !px-4 shadow-md active:scale-95"
-              >
-                <MdAdd size={18} />
-                <span className="font-medium text-sm">担当を追加</span>
-              </Button>
-            )}
-            <Button
-              variant="primary"
-              size="sm"
-              onClick={onShuffle}
-              disabled={isShuffleDisabled}
-              className="!rounded-full !px-4 shadow-md active:scale-95"
-            >
-              <PiShuffleBold className="w-5 h-5" />
-              <span className="font-medium text-sm">シャッフル</span>
-            </Button>
-          </div>
-
-          {taskLabels.length < MAX_TASK_LABELS ? (
-            <div className="px-2 flex items-center w-full h-full" style={{ gridColumn: '-2 / -1' }}>
-              <Input
-                value={newRightLabel}
-                onChange={(e) => setNewRightLabel(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') handleAddTaskLabel();
-                }}
-                placeholder={`${headerLabels.right}を入力`}
-                className="!min-w-0 !p-2 !text-center !text-sm !min-h-0 w-full"
-              />
-            </div>
-          ) : (
-            <div />
-          )}
-        </div>
+        <DesktopTableFooter
+          teamsLength={teams.length}
+          taskLabelsLength={taskLabels.length}
+          gridTemplateColumns={gridTemplateColumns}
+          headerLabels={headerLabels}
+          newLeftLabel={newLeftLabel}
+          setNewLeftLabel={setNewLeftLabel}
+          newRightLabel={newRightLabel}
+          setNewRightLabel={setNewRightLabel}
+          handleAddTaskLabel={handleAddTaskLabel}
+          onShuffle={onShuffle}
+          isShuffleDisabled={isShuffleDisabled}
+        />
       </div>
     </Card>
   );

--- a/app/assignment/components/assignment-table/desktopTableViewLayout.test.ts
+++ b/app/assignment/components/assignment-table/desktopTableViewLayout.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import type { TableSettings, Team } from '@/types';
+
+import { getDesktopGridTemplateColumns } from './desktopTableViewLayout';
+
+const tableSettings: TableSettings = {
+  colWidths: {
+    taskLabel: 180,
+    note: 220,
+    teams: {
+      'team-1': 120,
+    },
+  },
+  rowHeights: {},
+  headerLabels: {
+    left: '作業',
+    right: '補足',
+  },
+};
+
+describe('getDesktopGridTemplateColumns', () => {
+  it('班がないときはラベル列と補足列の設定幅を使う', () => {
+    expect(getDesktopGridTemplateColumns([], tableSettings)).toBe('180px 160px 220px');
+  });
+
+  it('班があるときは班ごとの設定幅を使い、未設定の班は既定幅にする', () => {
+    const teams: Team[] = [
+      { id: 'team-1', name: 'A', order: 0 },
+      { id: 'team-2', name: 'B', order: 1 },
+    ];
+
+    expect(getDesktopGridTemplateColumns(teams, tableSettings)).toBe('180px 120px 140px 220px');
+  });
+});

--- a/app/assignment/components/assignment-table/desktopTableViewLayout.ts
+++ b/app/assignment/components/assignment-table/desktopTableViewLayout.ts
@@ -1,0 +1,28 @@
+import type { TableSettings, Team } from '@/types';
+
+const DEFAULT_TEAM_COLUMN_WIDTH = 140;
+const EMPTY_TEAM_COLUMN_WIDTH = 160;
+const DEFAULT_TASK_LABEL_COLUMN_WIDTH = 160;
+const DEFAULT_NOTE_COLUMN_WIDTH = 160;
+
+export function formatTeamTitle(teamName?: string) {
+  return teamName && teamName.trim().length > 0 ? `${teamName.trim()}班` : '';
+}
+
+export function getDesktopGridTemplateColumns(teams: Team[], tableSettings: TableSettings | null) {
+  const labelWidth = tableSettings?.colWidths?.taskLabel ?? DEFAULT_TASK_LABEL_COLUMN_WIDTH;
+  const noteWidth = tableSettings?.colWidths?.note ?? DEFAULT_NOTE_COLUMN_WIDTH;
+
+  if (teams.length === 0) {
+    return `${labelWidth}px ${EMPTY_TEAM_COLUMN_WIDTH}px ${noteWidth}px`;
+  }
+
+  const teamColumns = teams
+    .map((team) => {
+      const width = tableSettings?.colWidths?.teams?.[team.id] ?? DEFAULT_TEAM_COLUMN_WIDTH;
+      return `${width}px`;
+    })
+    .join(' ');
+
+  return `${labelWidth}px ${teamColumns} ${noteWidth}px`;
+}


### PR DESCRIPTION
## 概要
Part of #413

`app/assignment/components/assignment-table/DesktopTableView.tsx` だけを分割し、UI仕様や保存・状態更新の流れを変えずに、デスクトップ担当表の表示責務を小さなコンポーネントへ分けました。

## 今回選んだファイル
- `app/assignment/components/assignment-table/DesktopTableView.tsx`

## 選定理由
- `npm run complexity` の対象候補内で最も高い結果でした。
  - `DesktopTableView.tsx`: CCN 139 / NLOC 319
  - `TableModals.tsx`: CCN 127 / NLOC 505
  - `RecipeForm.tsx`: CCN 87 / NLOC 228
  - `hooks/useAppData.ts`: 主な警告は CCN 19 / 26 / 25
  - `app/assignment/lib/shuffle.ts`: `backtrack` CCN 31 / NLOC 102
- 表示用コンポーネントの抽出が中心で、Firestore同期、保存キュー、シャッフルロジックに触れずに分割できます。
- 変更範囲を `assignment-table` 配下に限定でき、レビューしやすい差分に収まります。

## 分割前の問題
- `DesktopTableView` が、列幅計算、ヘッダー、ボディ、フッター行、入力欄、シャッフルボタン表示を1つのコンポーネント内で持っていました。
- JSXの分岐が多く、表示変更時にどの責務へ影響するか読み取りにくい状態でした。

## 分割後の構成
- `DesktopTableView.tsx`: 全体レイアウトと props の受け渡し
- `DesktopTableHeader.tsx`: ヘッダー、班名表示、班追加UI、列幅設定トリガー
- `DesktopTableBody.tsx`: 作業ラベル行、担当者セル、行高さ設定トリガー
- `DesktopTableFooter.tsx`: 作業ラベル追加行とシャッフルボタン
- `desktopTableViewLayout.ts`: 列幅計算と班名表示整形
- `desktopTableViewLayout.test.ts`: 列幅計算の最小テスト

## 振る舞いを変えていないこと
- 既存の className、文言、クリック、Enter/Escape、blur、touch/mouse ハンドラーは維持しました。
- 保存処理、状態更新順序、バリデーション、Firestore / rules / Cloud Functions / Service Worker には触れていません。
- 新しい状態管理ライブラリや依存関係は追加していません。

## complexity の変化
- Before: `DesktopTableView` CCN 139 / NLOC 319
- After: `DesktopTableView` CCN 7 / NLOC 56
- 抽出後の主な分割先:
  - `DesktopTableBody` CCN 47 / NLOC 88
  - `DesktopTableHeader` CCN 43 / NLOC 143
  - `DesktopTableFooter` CCN 11 / NLOC 63

`npm run complexity` はリポジトリ内の既存高複雑度ファイルも検出するため exit 1 のままですが、今回選んだファイルの複雑度は下がっています。

## 実行した確認コマンドと結果
- `npm run complexity`: 既存警告により exit 1。対象ファイルは CCN 139 → 7 に低下。
- `npm run test:run -- app/assignment/components/assignment-table/desktopTableViewLayout.test.ts`: 2 tests passed。
- `npm run test:run -- app/assignment/components/assignment-table/desktopTableViewLayout.test.ts app/assignment/components/assignment-table/useTableEditing.test.ts app/assignment/page.test.tsx`: 12 tests passed。
- `npm run typecheck`: passed。
- `npm run test:run`: 100 files / 1315 tests passed。
- `npm run build`: passed。
- `npm run lint`: passed。
- `npx prettier --check ...`: passed。
- pre-commit: `eslint --fix` and `npm run secrets:scan:staged` passed。

## 手動確認
- `npm run dev -- --port 3001` / `3002` で `/assignment` へアクセスし、HTTP 200 とページ描画開始を確認しました。
- ログイン後の担当表操作確認は未実施です。理由は、このローカル環境で Firebase App Check が 403 / throttle になり、画面が `読み込み中...` から進まなかったためです。
- 3000番は既存の `node.exe` プロセス PID 28012 が使用中だったため、確認では別ポートを使用しました。

## 残リスク
- 手動でのログイン後UI操作確認は未実施です。
- JSXを責務ごとに移動したため、差分は大きく見えますが、処理内容は既存の受け渡しに留めています。

## 今回触らなかった対象候補
- `app/assignment/components/assignment-table/TableModals.tsx`
- `components/drip-guide/RecipeForm.tsx`
- `hooks/useAppData.ts`
- `app/assignment/lib/shuffle.ts`
