### PR TITLE
fix: オレンジアクセント色を調整

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -133,11 +133,11 @@ RoastPlus では、色を直接指定せず、意味を持つセマンティッ�
 | `bg-overlay` | `--overlay` | `#FFFFFF` | モーダル・ダイアログ。不透明必須 |
 | `bg-ground` | `--ground` | `#F5F5F5` | テーブルヘッダー・セクション背景 |
 | `bg-field` | `--field` | `#FFFFFF` | 入力フィールド背景 |
-| `bg-spot` | `--spot` | `#d97706` | アクセント背景 |
+| `bg-spot` | `--spot` | `#E48003` | アクセント背景 |
 | `bg-spot-subtle` | `--spot-subtle` | `#f0f0f0` | アクセント薄背景 |
 | `bg-spot-surface` | `--spot-surface` | `#f7f7f7` | アクセント極薄背景 |
-| `bg-btn-primary` | `--btn-primary` | `#d97706` | プライマリボタン背景 |
-| `bg-btn-primary-hover` | `--btn-primary-hover` | `#b45309` | プライマリボタンホバー |
+| `bg-btn-primary` | `--btn-primary` | `#E48003` | プライマリボタン背景 |
+| `bg-btn-primary-hover` | `--btn-primary-hover` | `#C56604` | プライマリボタンホバー |
 | `bg-header-bg` | `--header-bg` | `#261a14` | ヘッダー背景 |
 
 ### 5.4 テキスト色
@@ -147,8 +147,8 @@ RoastPlus では、色を直接指定せず、意味を持つセマンティッ�
 | `text-ink` | `--ink` | `#1f2937` | メインテキスト |
 | `text-ink-sub` | `--ink-sub` | `#4b5563` | 補助テキスト・説明文 |
 | `text-ink-muted` | `--ink-muted` | `#9ca3af` | プレースホルダー・薄いテキスト |
-| `text-spot` | `--spot` | `#d97706` | アクセントテキスト |
-| `text-spot-hover` | `--spot-hover` | `#b45309` | アクセントホバー |
+| `text-spot` | `--spot` | `#E48003` | アクセントテキスト |
+| `text-spot-hover` | `--spot-hover` | `#C56604` | アクセントホバー |
 | `text-header-text` | `--header-text` | `#FFFFFF` | ヘッダーテキスト |
 | `text-header-accent` | `--header-accent` | `#EF8A00` | ヘッダーアクセント |
 | `text-danger` | `--danger` | `#dc2626` | エラー・削除 |

--- a/app/globals.css
+++ b/app/globals.css
@@ -48,14 +48,14 @@
     --edge-strong: #d1d5db;
     --edge-subtle: #f3f4f6;
     /* アクセント */
-    --spot: #d97706;
-    --spot-hover: #b45309;
+    --spot: #e48003;
+    --spot-hover: #c56604;
     --spot-subtle: #f0f0f0;
     --spot-surface: #f7f7f7;
     --on-spot: #ffffff;
     /* ボタン */
-    --btn-primary: #d97706;
-    --btn-primary-hover: #b45309;
+    --btn-primary: #e48003;
+    --btn-primary-hover: #c56604;
     --btn-primary-text: #ffffff;
     /* ステータスカラー */
     --danger: #dc2626;

--- a/lib/themeTokens.test.ts
+++ b/lib/themeTokens.test.ts
@@ -13,7 +13,7 @@ function getRootThemeToken(css: string, tokenName: string): string | undefined {
 }
 
 describe('theme tokens', () => {
-  it('通常テーマのアクセント色は明るいオレンジと白い文字色を使う', () => {
+  it('通常テーマのアクセント色は明るすぎないオレンジと白い文字色を使う', () => {
     const css = readThemeCss();
     const spot = getRootThemeToken(css, '--spot');
     const spotHover = getRootThemeToken(css, '--spot-hover');
@@ -22,11 +22,11 @@ describe('theme tokens', () => {
     const btnPrimaryHover = getRootThemeToken(css, '--btn-primary-hover');
     const btnPrimaryText = getRootThemeToken(css, '--btn-primary-text');
 
-    expect(spot).toBe('#d97706');
-    expect(spotHover).toBe('#b45309');
+    expect(spot).toBe('#e48003');
+    expect(spotHover).toBe('#c56604');
     expect(onSpot).toBe('#ffffff');
-    expect(btnPrimary).toBe('#d97706');
-    expect(btnPrimaryHover).toBe('#b45309');
+    expect(btnPrimary).toBe('#e48003');
+    expect(btnPrimaryHover).toBe('#c56604');
     expect(btnPrimaryText).toBe('#ffffff');
   });
 });


### PR DESCRIPTION
## 概要
- 通常テーマの共通アクセント色を暗すぎない中間のオレンジに調整しました。
- DESIGN.md の通常テーマ色表を実装値に同期しました。
- themeTokens の回帰テストを更新し、同じ暗色戻りを検出できるようにしました。

## 変更したファイル
- DESIGN.md
- app/globals.css
- lib/themeTokens.test.ts

## なぜこの修正が必要か
アプリ内のオレンジ色が過去修正後の値に戻っていたものの、ブランド色まで明るくすると強すぎたため、操作色として見やすい中間値に調整しました。

## 確認コマンドと結果
- npm run test:run -- lib/themeTokens.test.ts: 成功
- npm run build: 成功
- pre-commit の eslint --fix / secrets:scan:staged: 成功

## 残リスク
- 色味は視覚判断を含むため、実機またはブラウザで最終確認してください。

## 意図的に触らなかった範囲
- todo.md は作業用メモのためPRに含めていません。
- スマホホーム画面の2グリッド改善は次タスクとして分離します。