### PR TITLE
ci: Playwrightブラウザをキャッシュ

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,13 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
       - run: npm run test:e2e


### PR DESCRIPTION
## 概要
- E2E Tests ジョブで Playwright のブラウザ保存先 ~/.cache/ms-playwright をキャッシュします。
- E2E自体はPR CIに残し、Chromiumの再ダウンロードを減らします。
- package-lock.json をキーにして、Playwright依存が変わった時は新しいキャッシュを作ります。

## 変更したファイル
- .github/workflows/ci.yml

## なぜこの修正が必要か
CIのE2E Testsが 
px playwright install --with-deps chromium のChromiumダウンロード後に長く待つことがあり、PRごとの待ち時間が大きくなっていました。E2E本体は残しつつ、ブラウザ本体をGitHub Actions cacheに載せて軽量化します。

## 確認コマンドと結果
- npx prettier --check .github/workflows/ci.yml: 成功
- git diff --check -- .github/workflows/ci.yml: 成功
- commit時の secrets:scan:staged: 成功

## 残リスク
- 初回実行や package-lock.json 変更後はキャッシュがないため、Chromiumダウンロードは発生します。
- --with-deps は残しているため、Linux依存パッケージ確認は引き続き行われます。

## 意図的に触らなかった範囲
- E2E Testsジョブ自体はPR CIから外していません。
- todo.md は作業用メモのためPRに含めていません。