### PR TITLE
feat: スマホホームを一覧レイアウトに変更

### DIFF
--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -1,11 +1,12 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import HomePage from './page';
 
 const mocks = vi.hoisted(() => ({
   push: vi.fn(),
   getUserData: vi.fn().mockResolvedValue({}),
+  visibleKeys: new Set<string>(),
 }));
 
 vi.mock('next/navigation', () => ({
@@ -41,12 +42,33 @@ vi.mock('@/hooks/useChristmasMode', () => ({
 
 vi.mock('@/hooks/useHomeFeatureVisibility', () => ({
   useHomeFeatureVisibility: () => ({
-    isVisible: (key: string) => key !== 'dev-stories',
+    isVisible: (key: string) => mocks.visibleKeys.has(key),
   }),
 }));
 
 describe('HomePage', () => {
+  beforeEach(() => {
+    mocks.push.mockClear();
+    mocks.getUserData.mockClear();
+    mocks.visibleKeys.clear();
+    [
+      'assignment',
+      'schedule',
+      'tasting',
+      'roast-timer',
+      'defect-beans',
+      'progress',
+      'production-packs',
+      'drip-guide',
+      'coffee-trivia',
+      'dev-stories',
+      'settings',
+    ].forEach((key) => mocks.visibleKeys.add(key));
+  });
+
   it('非表示設定の機能カードをホームに表示しないが、その他は表示する', () => {
+    mocks.visibleKeys.delete('dev-stories');
+
     render(<HomePage />);
 
     expect(screen.queryByRole('button', { name: '開発秘話' })).not.toBeInTheDocument();
@@ -57,5 +79,19 @@ describe('HomePage', () => {
     render(<HomePage />);
 
     expect(screen.getAllByRole('button', { name: '担当表' })).toHaveLength(1);
+  });
+
+  it('スマホで表示機能が少ない場合もアクションを巨大化させない', async () => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 390 });
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 844 });
+    mocks.visibleKeys.clear();
+    mocks.visibleKeys.add('settings');
+
+    render(<HomePage />);
+
+    const settingsButton = screen.getByRole('button', { name: 'その他' });
+    await waitFor(() => {
+      expect(settingsButton.style.getPropertyValue('--home-card-height')).toBe('64px');
+    });
   });
 });

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -52,4 +52,10 @@ describe('HomePage', () => {
     expect(screen.queryByRole('button', { name: '開発秘話' })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'その他' })).toBeInTheDocument();
   });
+
+  it('表示中の機能は1つのホームアクションとして表示する', () => {
+    render(<HomePage />);
+
+    expect(screen.getAllByRole('button', { name: '担当表' })).toHaveLength(1);
+  });
 });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -209,15 +209,15 @@ export default function HomePage(_props: HomePageProps = {}) {
       const headerHeight = 72; // ヘッダーの高さ目安
       const paddingTop = 8; // pt-2 = 8px
       const paddingBottom = 8; // pb-2 = 8px
-      const rowCount = Math.max(Math.ceil(visibleActions.length / 2), 1);
-      const gridGap = Math.max(rowCount - 1, 0) * 12; // gap-3 = 12px
+      const rowCount = Math.max(visibleActions.length, 1);
+      const gridGap = Math.max(rowCount - 1, 0) * 6; // gap-1.5 = 6px
 
       const availableHeight = viewportHeight - headerHeight - paddingTop - paddingBottom;
       const cardHeightPerRow = (availableHeight - gridGap) / rowCount;
 
-      // 少ない表示件数でもカードが大きくなりすぎないようにする
-      const minCardHeight = 100;
-      const maxCardHeight = 150;
+      // スマホ一覧は少ない表示件数でも巨大化させず、全件表示時は1画面に収める
+      const minCardHeight = 44;
+      const maxCardHeight = 64;
       const calculatedHeight = Math.min(Math.max(cardHeightPerRow, minCardHeight), maxCardHeight);
 
       setCardHeight(calculatedHeight);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -268,7 +268,7 @@ export default function HomePage(_props: HomePageProps = {}) {
       {/* メインコンテンツ */}
       <main className="relative z-10 mx-auto w-full max-w-6xl px-4 pt-2 pb-2 sm:px-6 sm:pt-3 sm:pb-3 flex-1 min-h-0">
         <div
-          className="grid grid-cols-2 gap-3 md:grid-cols-4 md:gap-4"
+          className="flex h-full flex-col gap-1.5 md:grid md:h-auto md:grid-cols-4 md:gap-4"
           style={cardHeight ? { gridAutoRows: `${cardHeight}px` } : { gridAutoRows: '1fr' }}
         >
           {visibleActions.map(({ key, title, description, href, icon: DefaultIcon, badge }, index) => {

--- a/components/home/ActionCard.tsx
+++ b/components/home/ActionCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import type { CSSProperties } from 'react';
 import type { IconType } from 'react-icons';
 import { BsStars } from 'react-icons/bs';
 import { Button } from '@/components/ui';
@@ -17,16 +18,17 @@ interface ActionCardProps {
 
 export function ActionCard({ title, description, href, icon: Icon, badge, index, cardHeight }: ActionCardProps) {
   const router = useRouter();
+  const cardStyle = {
+    ...(cardHeight ? { '--home-card-height': `${cardHeight}px` } : {}),
+    animationDelay: `${index * 60}ms`,
+  } as CSSProperties;
 
   return (
     <Button
       variant="ghost"
       onClick={() => router.push(href)}
-      className="group relative flex h-full flex-col items-center justify-center gap-3 !rounded-2xl p-5 shadow-2xl transition-all hover:-translate-y-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 animate-home-card bg-surface text-ink border border-edge-strong hover:shadow-[0_16px_40px_rgba(0,0,0,0.08)] focus-visible:ring-primary !min-h-0"
-      style={{
-        ...(cardHeight ? { height: `${cardHeight}px` } : {}),
-        animationDelay: `${index * 60}ms`,
-      }}
+      className="group relative flex w-full flex-1 flex-row !items-center !justify-start gap-3 !rounded-xl border border-edge-strong bg-surface px-3 py-1.5 text-left text-ink shadow-card transition-all hover:bg-ground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 animate-home-card !min-h-[44px] md:h-[var(--home-card-height)] md:flex-none md:flex-col md:!justify-center md:gap-3 md:!rounded-2xl md:p-5 md:text-center md:shadow-2xl md:hover:-translate-y-2 md:hover:bg-surface md:hover:shadow-[0_16px_40px_rgba(0,0,0,0.08)] md:!min-h-0"
+      style={cardStyle}
       aria-label={title}
     >
       {/* バッジ表示 */}
@@ -43,17 +45,20 @@ export function ActionCard({ title, description, href, icon: Icon, badge, index,
         </div>
       )}
 
-      <span className="relative flex h-14 w-14 items-center justify-center transition-all duration-300 text-spot">
-        <Icon className="h-11 w-11 relative z-10" />
+      <span className="relative flex h-9 w-9 shrink-0 items-center justify-center self-center text-spot transition-all duration-300 md:h-14 md:w-14">
+        <Icon className="relative z-10 h-6 w-6 md:h-11 md:w-11" />
       </span>
-      <div className="space-y-1 text-center relative z-10">
+      <div className="relative z-10 flex min-w-0 flex-1 items-center md:block md:flex-none md:text-center">
         <p
-          className={`font-bold transition-colors text-ink group-hover:text-spot ${title === 'ハンドピックタイマー' ? 'text-xs md:text-sm' : 'text-base md:text-lg'}`}
+          className={`truncate leading-none font-bold text-ink transition-colors group-hover:text-spot ${title === 'ハンドピックタイマー' ? 'text-sm md:text-sm' : 'text-base md:text-lg'}`}
         >
           {title}
         </p>
-        <p className="text-xs transition-colors text-ink-muted md:text-sm">{description}</p>
+        <p className="hidden text-xs text-ink-muted transition-colors md:block md:text-sm">{description}</p>
       </div>
+      <span aria-hidden="true" className="shrink-0 text-lg leading-none text-ink-muted md:hidden">
+        ›
+      </span>
     </Button>
   );
 }

--- a/components/home/ActionCard.tsx
+++ b/components/home/ActionCard.tsx
@@ -27,7 +27,7 @@ export function ActionCard({ title, description, href, icon: Icon, badge, index,
     <Button
       variant="ghost"
       onClick={() => router.push(href)}
-      className="group relative flex w-full flex-1 flex-row !items-center !justify-start gap-3 !rounded-xl border border-edge-strong bg-surface px-3 py-1.5 text-left text-ink shadow-card transition-all hover:bg-ground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 animate-home-card !min-h-[44px] md:h-[var(--home-card-height)] md:flex-none md:flex-col md:!justify-center md:gap-3 md:!rounded-2xl md:p-5 md:text-center md:shadow-2xl md:hover:-translate-y-2 md:hover:bg-surface md:hover:shadow-[0_16px_40px_rgba(0,0,0,0.08)] md:!min-h-0"
+      className="group relative flex h-[var(--home-card-height)] w-full flex-none flex-row !items-center !justify-start gap-3 !rounded-xl border border-edge-strong bg-surface px-3 py-1.5 text-left text-ink shadow-card transition-all hover:bg-ground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 animate-home-card !min-h-[44px] md:flex-col md:!justify-center md:gap-3 md:!rounded-2xl md:p-5 md:text-center md:shadow-2xl md:hover:-translate-y-2 md:hover:bg-surface md:hover:shadow-[0_16px_40px_rgba(0,0,0,0.08)] md:!min-h-0"
       style={cardStyle}
       aria-label={title}
     >

--- a/docs/superpowers/plans/2026-05-28-home-mobile-list-layout.md
+++ b/docs/superpowers/plans/2026-05-28-home-mobile-list-layout.md
@@ -1,0 +1,48 @@
+# Home Mobile List Layout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the smartphone home screen's cramped 2-column card layout with a compact one-row-per-feature list while keeping the tablet and desktop grid unchanged.
+
+**Architecture:** Reuse the existing `ActionCard` component and make it responsive: list row on mobile, current card on `md` and wider. Keep the existing `visibleActions` flow, home visibility settings, icons, navigation, badges, and card height calculation intact. Do not change Firestore, auth, rules, or feature data.
+
+**Tech Stack:** Next.js App Router, React, TypeScript strict, Tailwind CSS v4, Vitest, Testing Library.
+
+---
+
+## File Structure
+
+- Modify `components/home/ActionCard.tsx`: responsive mobile row layout, hide descriptions on mobile, preserve desktop card layout.
+- Modify `app/page.tsx`: change home container from mobile 2-column grid to mobile vertical list and keep `md:grid`.
+- Modify `app/page.test.tsx`: assert the home actions remain single accessible buttons and mobile-only descriptions are not duplicated.
+
+## Task 1: Regression Test
+
+**Files:**
+- Modify: `app/page.test.tsx`
+
+- [x] Add a test that renders the home page and expects a visible action such as `担当表` to appear once as a button.
+- [x] Keep the existing hidden-feature test for `開発秘話` and `その他`.
+- [x] Run `npm run test:run -- app/page.test.tsx` and confirm the current implementation still passes before layout changes.
+
+## Task 2: Responsive Home Layout
+
+**Files:**
+- Modify: `components/home/ActionCard.tsx`
+- Modify: `app/page.tsx`
+
+- [x] Make `ActionCard` render as a compact row below `md`: `アイコン + 機能名 + 矢印`.
+- [x] Hide the description text below `md`.
+- [x] Keep badge, icon, hover, focus, animation, and desktop layout behavior.
+- [x] Change the home action container to `flex flex-col` on mobile and `md:grid md:grid-cols-4` on wider screens.
+- [x] Keep the calculated card height active only on desktop via CSS custom property.
+
+## Task 3: Verification
+
+**Files:**
+- All changed files.
+
+- [x] Run `npm run test:run -- app/page.test.tsx`.
+- [x] Run `npm run build`.
+- [x] Start the local dev server and inspect the home screen at a smartphone viewport.
+- [x] Confirm `todo.md` and mock artifacts are not accidentally staged.

--- a/docs/superpowers/specs/2026-05-28-home-mobile-layout-mock.html
+++ b/docs/superpowers/specs/2026-05-28-home-mobile-layout-mock.html
@@ -1,0 +1,618 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>RoastPlus Home Mobile Layout Mock</title>
+    <style>
+      :root {
+        --page: #f7f7f5;
+        --surface: #ffffff;
+        --ink: #1f2937;
+        --ink-sub: #4b5563;
+        --ink-muted: #6b7280;
+        --edge: #e5e7eb;
+        --edge-strong: #d1d5db;
+        --spot: #e48003;
+        --spot-hover: #c56604;
+        --header-bg: #261a14;
+        --header-text: #ffffff;
+        --success: #16a34a;
+        --info: #00a0b8;
+        --warning: #d97706;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: #ece8df;
+        color: var(--ink);
+        font-family:
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          sans-serif;
+      }
+
+      button,
+      a {
+        font: inherit;
+      }
+
+      .page {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 24px;
+      }
+
+      .brief {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+        gap: 16px;
+        align-items: end;
+        margin-bottom: 18px;
+      }
+
+      .brief h1 {
+        margin: 0 0 8px;
+        font-size: 24px;
+        line-height: 1.25;
+        letter-spacing: 0;
+      }
+
+      .brief p {
+        margin: 0;
+        color: var(--ink-sub);
+        line-height: 1.7;
+      }
+
+      .tabs {
+        display: flex;
+        gap: 8px;
+        padding: 6px;
+        border: 1px solid rgba(38, 26, 20, 0.12);
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.72);
+      }
+
+      .tab {
+        border: 0;
+        border-radius: 999px;
+        background: transparent;
+        color: var(--ink-sub);
+        padding: 9px 14px;
+        cursor: pointer;
+        white-space: nowrap;
+      }
+
+      .tab[aria-selected="true"] {
+        background: var(--header-bg);
+        color: var(--header-text);
+      }
+
+      .workspace {
+        display: grid;
+        grid-template-columns: minmax(280px, 390px) minmax(0, 1fr);
+        gap: 24px;
+        align-items: start;
+      }
+
+      .phone {
+        width: min(390px, 100%);
+        min-height: 844px;
+        border-radius: 32px;
+        border: 10px solid #18120f;
+        background: var(--page);
+        box-shadow: 0 18px 48px rgba(38, 26, 20, 0.22);
+        overflow: hidden;
+      }
+
+      .screen {
+        min-height: 824px;
+        background: var(--page);
+        display: none;
+      }
+
+      .screen.active {
+        display: block;
+      }
+
+      .home-header {
+        background: var(--header-bg);
+        color: var(--header-text);
+        padding: 18px 18px 14px;
+      }
+
+      .brand-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 10px;
+      }
+
+      .brand {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        min-width: 0;
+      }
+
+      .logo {
+        width: 38px;
+        height: 38px;
+        display: grid;
+        place-items: center;
+        border-radius: 12px;
+        background: rgba(228, 128, 3, 0.2);
+        color: #ffd19b;
+        font-size: 22px;
+      }
+
+      .brand-title {
+        font-weight: 800;
+        font-size: 20px;
+        line-height: 1.1;
+      }
+
+      .brand-sub {
+        margin-top: 2px;
+        color: rgba(255, 255, 255, 0.72);
+        font-size: 12px;
+      }
+
+      .today-chip {
+        border-radius: 999px;
+        padding: 8px 10px;
+        background: rgba(255, 255, 255, 0.1);
+        color: rgba(255, 255, 255, 0.92);
+        font-size: 12px;
+        white-space: nowrap;
+      }
+
+      .content {
+        padding: 14px;
+      }
+
+      .section-title {
+        margin: 14px 2px 8px;
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 10px;
+      }
+
+      .section-title h2 {
+        margin: 0;
+        font-size: 14px;
+        line-height: 1.3;
+      }
+
+      .section-title span {
+        color: var(--ink-muted);
+        font-size: 12px;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 10px;
+      }
+
+      .card {
+        min-height: 104px;
+        border: 1px solid var(--edge);
+        border-radius: 14px;
+        background: var(--surface);
+        padding: 12px;
+        color: inherit;
+        text-decoration: none;
+        box-shadow: 0 6px 18px rgba(31, 41, 55, 0.06);
+      }
+
+      .card.primary {
+        min-height: 118px;
+        border-color: rgba(228, 128, 3, 0.35);
+        background: linear-gradient(180deg, #fff7ed 0%, #ffffff 82%);
+      }
+
+      .card.wide {
+        grid-column: 1 / -1;
+        min-height: auto;
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr) auto;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .icon {
+        width: 36px;
+        height: 36px;
+        display: grid;
+        place-items: center;
+        border-radius: 12px;
+        background: #f3f4f6;
+        color: var(--spot);
+        font-size: 20px;
+      }
+
+      .card h3 {
+        margin: 10px 0 4px;
+        font-size: 15px;
+        line-height: 1.25;
+      }
+
+      .card.wide h3 {
+        margin-top: 0;
+      }
+
+      .card p {
+        margin: 0;
+        color: var(--ink-sub);
+        font-size: 12px;
+        line-height: 1.45;
+      }
+
+      .arrow {
+        color: var(--ink-muted);
+      }
+
+      .dense-list {
+        display: grid;
+        gap: 8px;
+      }
+
+      .row-link {
+        min-height: 52px;
+        border: 1px solid var(--edge);
+        border-radius: 14px;
+        background: var(--surface);
+        padding: 8px 10px;
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr) auto;
+        align-items: center;
+        gap: 10px;
+        color: inherit;
+        text-decoration: none;
+      }
+
+      .row-link .icon {
+        width: 30px;
+        height: 30px;
+        font-size: 16px;
+      }
+
+      .row-link h3 {
+        margin: 0;
+        font-size: 13px;
+        line-height: 1.2;
+      }
+
+      .row-link p {
+        margin: 2px 0 0;
+        color: var(--ink-muted);
+        font-size: 10px;
+      }
+
+      .compact-list {
+        gap: 7px;
+      }
+
+      .compact-list .row-link {
+        min-height: 46px;
+      }
+
+      .compact-list .row-link p {
+        display: none;
+      }
+
+      .category {
+        border: 1px solid var(--edge);
+        border-radius: 16px;
+        background: var(--surface);
+        overflow: hidden;
+        margin-bottom: 8px;
+      }
+
+      .category-head {
+        min-height: 40px;
+        padding: 9px 10px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10px;
+        border-bottom: 1px solid var(--edge);
+      }
+
+      .category-head strong {
+        font-size: 13px;
+      }
+
+      .category-head span {
+        color: var(--ink-muted);
+        font-size: 11px;
+      }
+
+      .category-items {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 0;
+      }
+
+      .mini-link {
+        min-height: 64px;
+        padding: 8px 6px;
+        border-right: 1px solid var(--edge);
+        border-bottom: 1px solid var(--edge);
+        color: inherit;
+        text-decoration: none;
+        text-align: center;
+      }
+
+      .mini-link:nth-child(4n) {
+        border-right: 0;
+      }
+
+      .mini-link h3 {
+        margin: 5px 0 0;
+        font-size: 11px;
+        line-height: 1.2;
+      }
+
+      .mini-icon {
+        color: var(--spot);
+        font-size: 17px;
+      }
+
+      .notes {
+        border: 1px solid rgba(38, 26, 20, 0.12);
+        border-radius: 18px;
+        background: rgba(255, 255, 255, 0.76);
+        padding: 18px;
+      }
+
+      .notes h2 {
+        margin: 0 0 12px;
+        font-size: 18px;
+      }
+
+      .notes h3 {
+        margin: 18px 0 8px;
+        font-size: 15px;
+      }
+
+      .notes p,
+      .notes li {
+        color: var(--ink-sub);
+        line-height: 1.7;
+      }
+
+      .notes ul,
+      .notes ol {
+        padding-left: 20px;
+      }
+
+      .score {
+        display: inline-flex;
+        align-items: center;
+        min-height: 24px;
+        border-radius: 999px;
+        padding: 3px 9px;
+        background: #f3f4f6;
+        color: var(--ink-sub);
+        font-size: 12px;
+      }
+
+      .score.good {
+        background: rgba(22, 163, 74, 0.12);
+        color: #166534;
+      }
+
+      .score.warn {
+        background: rgba(217, 119, 6, 0.12);
+        color: #92400e;
+      }
+
+      @media (max-width: 860px) {
+        .page {
+          padding: 12px;
+        }
+
+        .brief {
+          grid-template-columns: 1fr;
+        }
+
+        .tabs {
+          overflow-x: auto;
+          border-radius: 16px;
+        }
+
+        .workspace {
+          grid-template-columns: 1fr;
+        }
+
+        .phone {
+          margin: 0 auto;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <header class="brief">
+        <div>
+          <h1>スマホホーム画面レイアウト検討</h1>
+          <p>
+            現在の2グリッドは11項目で窮屈。現場でよく使う機能を迷わず押せることを優先し、
+            「全部を同じ大きさで並べる」以外の構造を比較する。
+          </p>
+        </div>
+        <div class="tabs" role="tablist" aria-label="レイアウト案">
+          <button class="tab" type="button" aria-selected="false" data-target="screen-a">A: 優先カード</button>
+          <button class="tab" type="button" aria-selected="true" data-target="screen-b">B: 一覧型</button>
+          <button class="tab" type="button" aria-selected="false" data-target="screen-c">C: カテゴリ</button>
+        </div>
+      </header>
+
+      <div class="workspace">
+        <div class="phone" aria-label="スマホプレビュー">
+          <section id="screen-a" class="screen" aria-label="A案 優先カード">
+            <header class="home-header">
+              <div class="brand-row">
+                <div class="brand">
+                  <div class="logo">☕</div>
+                  <div>
+                    <div class="brand-title">RoastPlus</div>
+                    <div class="brand-sub">今日の作業をはじめる</div>
+                  </div>
+                </div>
+                <div class="today-chip">5/28 木</div>
+              </div>
+            </header>
+            <main class="content">
+              <div class="section-title">
+                <h2>よく使う</h2>
+                <span>大きく表示</span>
+              </div>
+              <div class="grid">
+                <a class="card primary" href="#"><div class="icon">👥</div><h3>担当表</h3><p>今日の担当を確認</p></a>
+                <a class="card primary" href="#"><div class="icon">📅</div><h3>スケジュール</h3><p>一日の予定を見る</p></a>
+                <a class="card primary" href="#"><div class="icon">📦</div><h3>パッケージ記録</h3><p>成功数と失敗数</p></a>
+                <a class="card primary" href="#"><div class="icon">📈</div><h3>作業進捗</h3><p>進み具合を記録</p></a>
+              </div>
+
+              <div class="section-title">
+                <h2>その他の機能</h2>
+                <span>省スペース</span>
+              </div>
+              <div class="dense-list">
+                <a class="row-link" href="#"><div class="icon">⏱</div><div><h3>ローストタイマー</h3><p>焙煎のタイマー</p></div><div class="arrow">›</div></a>
+                <a class="row-link" href="#"><div class="icon">💧</div><div><h3>ドリップガイド</h3><p>淹れ方の手順</p></div><div class="arrow">›</div></a>
+                <a class="row-link" href="#"><div class="icon">☕</div><div><h3>試飲感想記録</h3><p>感想を記録</p></div><div class="arrow">›</div></a>
+                <a class="row-link" href="#"><div class="icon">🫘</div><div><h3>欠点豆図鑑</h3><p>知識を共有</p></div><div class="arrow">›</div></a>
+                <a class="row-link" href="#"><div class="icon">❓</div><div><h3>コーヒークイズ</h3><p>知識を学ぶ</p></div><div class="arrow">›</div></a>
+                <a class="row-link" href="#"><div class="icon">⚙</div><div><h3>その他</h3><p>設定やアプリ情報</p></div><div class="arrow">›</div></a>
+              </div>
+            </main>
+          </section>
+
+          <section id="screen-b" class="screen active" aria-label="B案 一覧型">
+            <header class="home-header">
+              <div class="brand-row">
+                <div class="brand">
+                  <div class="logo">☕</div>
+                  <div>
+                    <div class="brand-title">RoastPlus</div>
+                    <div class="brand-sub">すばやく選ぶ</div>
+                  </div>
+                </div>
+                <div class="today-chip">5/28 木</div>
+              </div>
+            </header>
+            <main class="content">
+              <div class="section-title">
+                <h2>機能一覧</h2>
+                <span>1画面に収める</span>
+              </div>
+              <div class="dense-list compact-list">
+                <a class="row-link" href="#"><div class="icon">👥</div><div><h3>担当表</h3><p>公平に担当を割り当て</p></div><div class="arrow">›</div></a>
+                <a class="row-link" href="#"><div class="icon">📅</div><div><h3>スケジュール</h3><p>一日の予定を確認</p></div><div class="arrow">›</div></a>
+                <a class="row-link" href="#"><div class="icon">📦</div><div><h3>パッケージ記録</h3><p>成功数と失敗数を記録</p></div><div class="arrow">›</div></a>
+                <a class="row-link" href="#"><div class="icon">📈</div><div><h3>作業進捗</h3><p>進捗を可視化</p></div><div class="arrow">›</div></a>
+                <a class="row-link" href="#"><div class="icon">⏱</div><div><h3>ローストタイマー</h3><p>最適なタイマーで焙煎</p></div><div class="arrow">›</div></a>
+                <a class="row-link" href="#"><div class="icon">💧</div><div><h3>ドリップガイド</h3><p>淹れ方の手順</p></div><div class="arrow">›</div></a>
+                <a class="row-link" href="#"><div class="icon">☕</div><div><h3>試飲感想記録</h3><p>試飲の感想を記録</p></div><div class="arrow">›</div></a>
+                <a class="row-link" href="#"><div class="icon">🫘</div><div><h3>欠点豆図鑑</h3><p>欠点豆の知識を共有</p></div><div class="arrow">›</div></a>
+                <a class="row-link" href="#"><div class="icon">❓</div><div><h3>コーヒークイズ</h3><p>楽しく学ぶコーヒー知識</p></div><div class="arrow">›</div></a>
+                <a class="row-link" href="#"><div class="icon">📖</div><div><h3>開発秘話</h3><p>開発の裏話を覗く</p></div><div class="arrow">›</div></a>
+                <a class="row-link" href="#"><div class="icon">⚙</div><div><h3>その他</h3><p>設定やアプリ情報など</p></div><div class="arrow">›</div></a>
+              </div>
+            </main>
+          </section>
+
+          <section id="screen-c" class="screen" aria-label="C案 カテゴリ">
+            <header class="home-header">
+              <div class="brand-row">
+                <div class="brand">
+                  <div class="logo">☕</div>
+                  <div>
+                    <div class="brand-title">RoastPlus</div>
+                    <div class="brand-sub">作業の種類から選ぶ</div>
+                  </div>
+                </div>
+                <div class="today-chip">5/28 木</div>
+              </div>
+            </header>
+            <main class="content">
+              <div class="section-title">
+                <h2>カテゴリから選ぶ</h2>
+                <span>1画面に収める</span>
+              </div>
+              <div class="category">
+                <div class="category-head"><strong>今日の現場作業</strong><span>毎日使う</span></div>
+                <div class="category-items">
+                  <a class="mini-link" href="#"><div class="mini-icon">👥</div><h3>担当表</h3></a>
+                  <a class="mini-link" href="#"><div class="mini-icon">📅</div><h3>スケジュール</h3></a>
+                  <a class="mini-link" href="#"><div class="mini-icon">📦</div><h3>パッケージ記録</h3></a>
+                  <a class="mini-link" href="#"><div class="mini-icon">📈</div><h3>作業進捗</h3></a>
+                </div>
+              </div>
+              <div class="category">
+                <div class="category-head"><strong>記録・学習</strong><span>参照と記録</span></div>
+                <div class="category-items">
+                  <a class="mini-link" href="#"><div class="mini-icon">☕</div><h3>試飲感想記録</h3></a>
+                  <a class="mini-link" href="#"><div class="mini-icon">🫘</div><h3>欠点豆図鑑</h3></a>
+                  <a class="mini-link" href="#"><div class="mini-icon">❓</div><h3>コーヒークイズ</h3></a>
+                  <a class="mini-link" href="#"><div class="mini-icon">📖</div><h3>開発秘話</h3></a>
+                </div>
+              </div>
+              <div class="category">
+                <div class="category-head"><strong>道具・設定</strong><span>補助機能</span></div>
+                <div class="category-items">
+                  <a class="mini-link" href="#"><div class="mini-icon">⏱</div><h3>ローストタイマー</h3></a>
+                  <a class="mini-link" href="#"><div class="mini-icon">💧</div><h3>ドリップガイド</h3></a>
+                  <a class="mini-link" href="#"><div class="mini-icon">⚙</div><h3>その他</h3></a>
+                </div>
+              </div>
+            </main>
+          </section>
+        </div>
+
+        <aside class="notes">
+          <h2>比較メモ</h2>
+          <h3>A案: 優先カード + その他一覧 <span class="score good">おすすめ</span></h3>
+          <p>現場で毎日使う機能を大きく残し、頻度が低いものは1行リストへ落とす。押しやすさと項目増加への耐性のバランスが良い。</p>
+          <h3>B案: 全部1行リスト <span class="score good">採用候補</span></h3>
+          <p>項目数が増えても崩れにくく、ユーザーがカテゴリを考えずに上から探せる。スマホでは説明文を消し、アイコン + 機能名だけにして1画面内に収める。</p>
+          <h3>C案: カテゴリ分け <span class="score">保留</span></h3>
+          <p>カテゴリで意味を残しつつ、4列の小タイルで縦幅を抑える。機能が増えても、カテゴリ追加や並び替えで整理しやすい。</p>
+          <h3>要件定義で決めたいこと</h3>
+          <ol>
+            <li>スマホで最初に大きく出す「よく使う機能」を4件に固定するか。</li>
+            <li>ユーザーのホーム表示設定を、優先表示にも使うか。</li>
+            <li>「開発秘話」「クイズ」など日常業務外の項目を下位に回してよいか。</li>
+            <li>390px × 844px 前後のスマホで、機能一覧を1画面内に収める。</li>
+          </ol>
+        </aside>
+      </div>
+    </div>
+
+    <script>
+      const tabs = document.querySelectorAll(".tab");
+      const screens = document.querySelectorAll(".screen");
+
+      tabs.forEach((tab) => {
+        tab.addEventListener("click", () => {
+          tabs.forEach((item) => item.setAttribute("aria-selected", "false"));
+          screens.forEach((screen) => screen.classList.remove("active"));
+          tab.setAttribute("aria-selected", "true");
+          document.getElementById(tab.dataset.target).classList.add("active");
+        });
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## 概要
- スマホのホーム画面を2列カードから1行1機能の一覧型に変更しました。
- 説明文はスマホでは非表示にし、アイコン・機能名・矢印だけで1画面に収まる密度に調整しました。
- md 以上では従来のカードグリッド表示を維持しています。

## 対象Issue
- なし。今日の開発タスクとして整理したスマホホーム改善です。

## 変更したファイル
- app/page.tsx
- components/home/ActionCard.tsx
- app/page.test.tsx
- docs/superpowers/plans/2026-05-28-home-mobile-list-layout.md
- docs/superpowers/specs/2026-05-28-home-mobile-layout-mock.html

## なぜこの修正が必要か
ホームの機能項目が増え、スマホの2列カード表示では窮屈になっていたためです。現場利用では、スマホで機能をすばやく選べることと、1画面内に収まることを優先しました。

## 確認コマンドと結果
- npm run test:run -- app/page.test.tsx: 成功
- npm run typecheck: 成功
- npm run lint: 成功（既存の package type 警告のみ）
- npm run build: 成功
- localhost:3000 を 390x844 で確認し、その他まで1画面内に収まることを確認
- commit時の eslint --fix / secrets:scan:staged: 成功

## 残っているリスク
- 端末高さがかなり低いスマホでは、1画面内に収まらない可能性があります。
- 文字やアイコンの見え方は実機で最終確認した方が安全です。

## 意図的に触らなかった範囲
- PC / タブレットのホームカードグリッドは維持しました。
- ホーム表示設定、機能の表示順、Firestore、認証、Rules は変更していません。
- todo.md とモック確認用スクリーンショットはPRに含めていません。