### PR TITLE
chore: 依存関係のセキュリティ監査をCIに追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,18 @@ jobs:
             ghcr.io/gitleaks/gitleaks:v8.30.0 \
             git --redact --no-banner --log-opts="origin/${{ github.base_ref }}..HEAD"
 
+  security:
+    name: Security
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run security
+
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest

--- a/docs/steering/GUIDELINES.md
+++ b/docs/steering/GUIDELINES.md
@@ -56,6 +56,7 @@
 ```bash
 npm run typecheck
 npm run lint
+npm run security
 npm run test:run
 npm run test:rules
 npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -10356,14 +10356,17 @@
       }
     },
     "node_modules/firebase-tools/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/firebase-tools/node_modules/ws": {
@@ -10650,10 +10653,9 @@
       }
     },
     "node_modules/gaxios/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -10661,7 +10663,7 @@
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/gcp-metadata": {
@@ -14942,9 +14944,9 @@
       }
     },
     "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -14961,9 +14963,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -18487,9 +18489,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -76,5 +76,20 @@
     "tsx": "^4.7.0",
     "typescript": "^5",
     "vitest": "^4.0.18"
+  },
+  "overrides": {
+    "firebase-tools": {
+      "tmp": "0.2.7",
+      "uuid": "11.1.1"
+    },
+    "gaxios": {
+      "uuid": "11.1.1"
+    },
+    "next": {
+      "postcss": "8.5.15"
+    },
+    "universal-analytics": {
+      "uuid": "14.0.0"
+    }
   }
 }


### PR DESCRIPTION
## 対象Issue

Closes #452

## 変更内容

- `npm audit` の high 以上をPR CIで確認する `Security` ジョブを追加
- `next` / `firebase-tools` の下位依存に出ていた警告を `overrides` で安全版へ固定
- 標準検証手順に `npm run security` を追加

## 変更ファイル

- `.github/workflows/ci.yml`: PR CIにSecurityジョブを追加
- `package.json`: `overrides` を追加
- `package-lock.json`: override反映後の依存バージョンを固定
- `docs/steering/GUIDELINES.md`: 標準検証コマンドにsecurityを追加

## 検証

- `npm run security`: 成功、0 vulnerabilities
- `npm audit --json`: 成功、total 0 / moderate 0 / high 0 / critical 0
- `npm run format:check`: 成功
- `npm ci --dry-run --ignore-scripts --no-audit --no-fund --loglevel error`: 成功
- `npm run typecheck`: 成功
- `npm run test:run`: 成功、103 files / 1353 tests passed
- `npm run build`: 成功

## 残リスク

- `overrides` は一時的な固定です。将来 `next` / `firebase-tools` 側の依存が修正されたら削除できます。
- `npm audit` はnpm registryに依存するため、外部障害時にSecurityジョブが落ちる可能性があります。

## 意図的に触らなかった範囲

- `npm audit fix --force` は使っていません。
- 本番デプロイ設定、Firestore Rules、Storage Rules、認証処理、業務データ処理は変更していません。