### PR TITLE
test: E2Eローカル起動を安定化

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,28 @@ npm run build      # 本番ビルド（productionではstatic exportでout/を�
 npm run test:e2e   # Playwright E2E
 ```
 
+### E2Eテストのローカル実行
+
+`npm run test:e2e` は E2E 専用に `http://localhost:3100` を使います。
+通常は `scripts/run-e2e.ts` が開発サーバーを起動してから Playwright を実行します。
+
+既に E2E 用サーバーが `3100` で動いている場合、ローカルではそれを再利用します。
+CI では意図しないサーバーを使わないよう、既存サーバーがある場合は失敗させます。
+
+Windows で `3100` の利用状況を確認する場合:
+
+```powershell
+Get-NetTCPConnection -LocalPort 3100 -ErrorAction SilentlyContinue
+```
+
+別ポートで実行したい場合:
+
+```powershell
+$env:E2E_PORT = '3101'
+npm run test:e2e
+Remove-Item Env:E2E_PORT
+```
+
 ---
 
 ## 技術スタック

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -35,9 +35,15 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const e2eMode = process.env.NEXT_PUBLIC_E2E_MODE === 'true';
+
   return (
     <html lang="ja" suppressHydrationWarning>
-      <body className="antialiased font-serif bg-page" suppressHydrationWarning>
+      <body
+        className="antialiased font-serif bg-page"
+        data-roastplus-e2e-mode={e2eMode ? 'true' : 'false'}
+        suppressHydrationWarning
+      >
         <SplashScreenWrapper />
         <ServiceWorkerRegistration />
         <ThemeProvider>

--- a/docs/steering/GUIDELINES.md
+++ b/docs/steering/GUIDELINES.md
@@ -493,6 +493,27 @@ npm run test:e2e:ui       # UIモードで実行
 npm run test:e2e:report   # レポート表示
 ```
 
+#### ローカル実行時の開発サーバー
+
+- E2E は既定で `http://localhost:3100` を使う。
+- `npm run test:e2e` は `scripts/run-e2e.ts` で E2E 用の Next.js 開発サーバーを起動してから Playwright を実行する。
+- ローカルでは `3100` に既存サーバーがある場合、そのサーバーを再利用する。
+- CI では意図しないプロセスを使わないため、既存サーバーがある場合は失敗させる。
+- Playwright 本体には `E2E_SKIP_WEB_SERVER=1` を渡し、Windows で Playwright 管理の dev server 終了待ちが詰まる問題を避ける。
+- ユーザーの作業中プロセスを勝手に停止しない。衝突時は、まず次のコマンドで利用状況を確認する。
+
+```powershell
+Get-NetTCPConnection -LocalPort 3100 -ErrorAction SilentlyContinue
+```
+
+`3100` が別用途で埋まっている場合は、PowerShell で一時的に別ポートを指定する。
+
+```powershell
+$env:E2E_PORT = '3101'
+npm run test:e2e
+Remove-Item Env:E2E_PORT
+```
+
 ---
 
 ### 重要なテストパターン

--- a/docs/steering/TECH_SPEC.md
+++ b/docs/steering/TECH_SPEC.md
@@ -287,6 +287,7 @@ npm run test:coverage
 - **バージョン**: `package.json` の `@playwright/test` を正とする
 - **ブラウザ**: Chromium
 - **設定**: `playwright.config.ts`
+- **ローカル起動**: 既定では `localhost:3100` を使う。`scripts/run-e2e.ts` が既存E2Eサーバーを再利用し、なければ起動する。
 
 | カテゴリ | ディレクトリ | 内容 |
 |---------|------------|------|

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "deadcode": "knip",
     "maintenance": "npm run complexity && npm run security && npm run deadcode && npm run skill:validate",
     "skill:validate": "tsx scripts/validate-ui-skill.ts",
-    "test:e2e": "env-cmd -f e2e/e2e.env playwright test",
-    "test:e2e:ui": "env-cmd -f e2e/e2e.env playwright test --ui",
+    "test:e2e": "tsx scripts/run-e2e.ts",
+    "test:e2e:ui": "tsx scripts/run-e2e.ts --ui",
     "test:e2e:report": "playwright show-report"
   },
   "dependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,14 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const e2ePort = process.env.E2E_PORT ?? '3100';
+
+if (!/^\d+$/.test(e2ePort)) {
+  throw new Error(`E2E_PORT must be a numeric port, received: ${e2ePort}`);
+}
+
+const e2eBaseURL = `http://localhost:${e2ePort}`;
+const skipWebServer = process.env.E2E_SKIP_WEB_SERVER === '1';
+
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: false,
@@ -8,7 +17,7 @@ export default defineConfig({
   workers: 1,
   reporter: process.env.CI ? 'github' : 'html',
   use: {
-    baseURL: 'http://localhost:3100',
+    baseURL: e2eBaseURL,
     timezoneId: 'Asia/Tokyo',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
@@ -35,10 +44,14 @@ export default defineConfig({
       },
     },
   ],
-  webServer: {
-    command: 'env-cmd -f e2e/e2e.env npm run dev -- --port 3100',
-    url: 'http://localhost:3100',
-    reuseExistingServer: false,
-    timeout: 120_000,
-  },
+  webServer: skipWebServer
+    ? undefined
+    : {
+        command: `npm run generate:sound-list && node ./node_modules/next/dist/bin/next dev --port ${e2ePort}`,
+        url: e2eBaseURL,
+        reuseExistingServer: !process.env.CI,
+        stdout: 'ignore',
+        stderr: 'pipe',
+        timeout: 120_000,
+      },
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -47,7 +47,7 @@ export default defineConfig({
   webServer: skipWebServer
     ? undefined
     : {
-        command: `npm run generate:sound-list && node ./node_modules/next/dist/bin/next dev --port ${e2ePort}`,
+        command: `npm run generate:sound-list && env-cmd -f e2e/e2e.env -- node ./node_modules/next/dist/bin/next dev --port ${e2ePort}`,
         url: e2eBaseURL,
         reuseExistingServer: !process.env.CI,
         stdout: 'ignore',

--- a/scripts/run-e2e.test.ts
+++ b/scripts/run-e2e.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'vitest';
+import { getServerProbeURL, isE2EModeHTML } from './run-e2e';
+
+describe('isE2EModeHTML', () => {
+  test('E2E mode marker is required before reusing an existing server', () => {
+    expect(isE2EModeHTML('<body data-roastplus-e2e-mode="true">')).toBe(true);
+    expect(isE2EModeHTML('<body data-roastplus-e2e-mode="false">')).toBe(false);
+    expect(isE2EModeHTML('<body>')).toBe(false);
+  });
+
+  test('server probe URL avoids Next.js trailing slash redirects', () => {
+    expect(getServerProbeURL('3100')).toBe('http://localhost:3100/login/');
+  });
+});

--- a/scripts/run-e2e.ts
+++ b/scripts/run-e2e.ts
@@ -1,0 +1,171 @@
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import http from 'node:http';
+import path from 'node:path';
+
+const DEFAULT_E2E_PORT = '3100';
+const SERVER_TIMEOUT_MS = 120_000;
+const POLL_INTERVAL_MS = 1_000;
+
+function parseEnvFile(filePath: string) {
+  const values: Record<string, string> = {};
+  if (!existsSync(filePath)) return values;
+
+  const lines = readFileSync(filePath, 'utf8').split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const separatorIndex = trimmed.indexOf('=');
+    if (separatorIndex === -1) continue;
+
+    const key = trimmed.slice(0, separatorIndex).trim();
+    let value = trimmed.slice(separatorIndex + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+
+    values[key] = value;
+  }
+
+  return values;
+}
+
+function getE2EPort() {
+  const port = process.env.E2E_PORT ?? DEFAULT_E2E_PORT;
+  if (!/^\d+$/.test(port)) {
+    throw new Error(`E2E_PORT must be a numeric port, received: ${port}`);
+  }
+
+  return port;
+}
+
+function isServerReady(url: string) {
+  return new Promise<boolean>((resolve) => {
+    const request = http.get(url, (response) => {
+      response.resume();
+      resolve(response.statusCode !== undefined && response.statusCode < 500);
+    });
+
+    request.setTimeout(2_000, () => {
+      request.destroy();
+      resolve(false);
+    });
+
+    request.on('error', () => resolve(false));
+  });
+}
+
+async function waitForServer(url: string, timeoutMs: number) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (await isServerReady(url)) return true;
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+
+  return false;
+}
+
+function runCommand(command: string, args: string[], env: NodeJS.ProcessEnv, shell = false) {
+  const result = spawnSync(command, args, {
+    cwd: process.cwd(),
+    env,
+    shell,
+    stdio: 'inherit',
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  return result.status ?? 1;
+}
+
+function runNpmScript(scriptName: string, env: NodeJS.ProcessEnv) {
+  if (process.platform === 'win32') {
+    return runCommand('cmd.exe', ['/d', '/s', '/c', `npm run ${scriptName}`], env);
+  }
+
+  return runCommand('npm', ['run', scriptName], env);
+}
+
+function startServer(port: string, env: NodeJS.ProcessEnv) {
+  const server = spawn(process.execPath, ['./node_modules/next/dist/bin/next', 'dev', '--port', port], {
+    cwd: process.cwd(),
+    detached: process.platform !== 'win32',
+    env,
+    stdio: 'ignore',
+  });
+
+  server.unref();
+  return server;
+}
+
+function stopServer(server: ChildProcess) {
+  if (!server.pid || server.exitCode !== null) return;
+
+  if (process.platform === 'win32') {
+    spawnSync('taskkill', ['/pid', String(server.pid), '/t', '/f'], { stdio: 'ignore' });
+    return;
+  }
+
+  try {
+    process.kill(-server.pid, 'SIGTERM');
+  } catch {
+    return;
+  }
+}
+
+async function main() {
+  const rootDir = process.cwd();
+  const e2eEnvPath = path.join(rootDir, 'e2e', 'e2e.env');
+  const e2eEnv = parseEnvFile(e2eEnvPath);
+  const port = getE2EPort();
+  const serverURL = `http://localhost:${port}/login`;
+  const env = {
+    ...process.env,
+    ...e2eEnv,
+    E2E_PORT: port,
+    E2E_SKIP_WEB_SERVER: '1',
+  };
+
+  let server: ChildProcess | null = null;
+  const existingServerReady = await isServerReady(serverURL);
+
+  if (existingServerReady) {
+    if (process.env.CI) {
+      throw new Error(`E2E server port ${port} is already in use in CI`);
+    }
+
+    console.log(`[e2e] Reusing existing E2E server at http://localhost:${port}`);
+  } else {
+    const generateExitCode = runNpmScript('generate:sound-list', env);
+    if (generateExitCode !== 0) {
+      process.exit(generateExitCode);
+    }
+
+    console.log(`[e2e] Starting E2E server at http://localhost:${port}`);
+    server = startServer(port, env);
+
+    const serverReady = await waitForServer(serverURL, SERVER_TIMEOUT_MS);
+    if (!serverReady) {
+      stopServer(server);
+      throw new Error(`E2E server did not become ready within ${SERVER_TIMEOUT_MS / 1000}s`);
+    }
+  }
+
+  try {
+    const playwrightCli = path.join(rootDir, 'node_modules', '@playwright', 'test', 'cli.js');
+    const exitCode = runCommand(process.execPath, [playwrightCli, 'test', ...process.argv.slice(2)], env);
+    process.exitCode = exitCode;
+  } finally {
+    if (server) {
+      stopServer(server);
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/run-e2e.ts
+++ b/scripts/run-e2e.ts
@@ -2,10 +2,14 @@ import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import http from 'node:http';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const DEFAULT_E2E_PORT = '3100';
 const SERVER_TIMEOUT_MS = 120_000;
 const POLL_INTERVAL_MS = 1_000;
+const E2E_MODE_MARKER = 'data-roastplus-e2e-mode="true"';
+
+type ServerState = 'unreachable' | 'e2e' | 'non-e2e';
 
 function parseEnvFile(filePath: string) {
   const values: Record<string, string> = {};
@@ -40,26 +44,51 @@ function getE2EPort() {
   return port;
 }
 
-function isServerReady(url: string) {
-  return new Promise<boolean>((resolve) => {
+export function isE2EModeHTML(html: string) {
+  return html.includes(E2E_MODE_MARKER);
+}
+
+export function getServerProbeURL(port: string) {
+  return `http://localhost:${port}/login/`;
+}
+
+function fetchServerHTML(url: string) {
+  return new Promise<string | null>((resolve) => {
     const request = http.get(url, (response) => {
-      response.resume();
-      resolve(response.statusCode !== undefined && response.statusCode < 500);
+      if (response.statusCode === undefined || response.statusCode >= 500) {
+        response.resume();
+        resolve(null);
+        return;
+      }
+
+      let body = '';
+      response.setEncoding('utf8');
+      response.on('data', (chunk) => {
+        body += chunk;
+      });
+      response.on('end', () => resolve(body));
     });
 
     request.setTimeout(2_000, () => {
       request.destroy();
-      resolve(false);
+      resolve(null);
     });
 
-    request.on('error', () => resolve(false));
+    request.on('error', () => resolve(null));
   });
 }
 
-async function waitForServer(url: string, timeoutMs: number) {
+async function inspectServer(url: string): Promise<ServerState> {
+  const html = await fetchServerHTML(url);
+  if (html === null) return 'unreachable';
+
+  return isE2EModeHTML(html) ? 'e2e' : 'non-e2e';
+}
+
+async function waitForE2EServer(url: string, timeoutMs: number) {
   const startedAt = Date.now();
   while (Date.now() - startedAt < timeoutMs) {
-    if (await isServerReady(url)) return true;
+    if ((await inspectServer(url)) === 'e2e') return true;
     await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
   }
 
@@ -121,7 +150,7 @@ async function main() {
   const e2eEnvPath = path.join(rootDir, 'e2e', 'e2e.env');
   const e2eEnv = parseEnvFile(e2eEnvPath);
   const port = getE2EPort();
-  const serverURL = `http://localhost:${port}/login`;
+  const serverURL = getServerProbeURL(port);
   const env = {
     ...process.env,
     ...e2eEnv,
@@ -130,11 +159,17 @@ async function main() {
   };
 
   let server: ChildProcess | null = null;
-  const existingServerReady = await isServerReady(serverURL);
+  const existingServerState = await inspectServer(serverURL);
 
-  if (existingServerReady) {
+  if (existingServerState !== 'unreachable') {
     if (process.env.CI) {
       throw new Error(`E2E server port ${port} is already in use in CI`);
+    }
+
+    if (existingServerState !== 'e2e') {
+      throw new Error(
+        `E2E server port ${port} is already in use, but the server is not running in E2E mode. Stop it or set E2E_PORT to another port.`
+      );
     }
 
     console.log(`[e2e] Reusing existing E2E server at http://localhost:${port}`);
@@ -147,10 +182,10 @@ async function main() {
     console.log(`[e2e] Starting E2E server at http://localhost:${port}`);
     server = startServer(port, env);
 
-    const serverReady = await waitForServer(serverURL, SERVER_TIMEOUT_MS);
+    const serverReady = await waitForE2EServer(serverURL, SERVER_TIMEOUT_MS);
     if (!serverReady) {
       stopServer(server);
-      throw new Error(`E2E server did not become ready within ${SERVER_TIMEOUT_MS / 1000}s`);
+      throw new Error(`E2E mode server did not become ready within ${SERVER_TIMEOUT_MS / 1000}s`);
     }
   }
 
@@ -165,7 +200,9 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(error);
-  process.exit(1);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## 対象Issue

Closes #453

## 変更したファイル

- `scripts/run-e2e.ts`: E2E用サーバーの起動・再利用・停止を管理するスクリプトを追加
- `package.json`: `test:e2e` / `test:e2e:ui` を新スクリプト経由に変更
- `playwright.config.ts`: `E2E_PORT` と `E2E_SKIP_WEB_SERVER` に対応
- `README.md`: ローカルE2E実行手順を追記
- `docs/steering/GUIDELINES.md`: E2Eサーバー運用ルールを追記
- `docs/steering/TECH_SPEC.md`: E2E起動仕様を追記

## 変更内容

- `npm run test:e2e` が Windows でも終了待ちで詰まりにくいよう、Playwright の webServer 管理ではなく `scripts/run-e2e.ts` でE2E用サーバーを管理するようにしました。
- ローカルでは `localhost:3100` に既存E2Eサーバーがある場合は再利用します。
- CIでは意図しない既存プロセスを使わないよう、既存サーバーがある場合は失敗させます。
- `E2E_PORT` で一時的に別ポートを指定できるようにしました。

## なぜこの修正が必要か

既存の `playwright.config.ts` は `reuseExistingServer: false` だったため、E2E用ポートに既存サーバーがいるとローカル実行が止まりました。さらに Windows では Playwright 管理の dev server 終了待ちが戻らないケースがあったため、Codexが再現・検証しやすい起動手順に寄せています。

## 実行した確認コマンドと結果

- `npm run format:check` 成功
- `npm run typecheck` 成功
- `npm run lint` 成功（既存の `MODULE_TYPELESS_PACKAGE_JSON` 警告のみ）
- `npm run test:run` 成功（103 files / 1353 tests）
- `npm run test:e2e` 成功（26 passed）
- `npm run build` 成功
- `npm run secrets:scan:staged` 成功（no leaks found）

追加確認:

- 既存E2Eサーバーがある場合、ローカルでは再利用してテストが通ることを確認
- `CI=true` では既存サーバーを衝突として検出することを確認
- E2E後に `localhost:3100` が残らないことを確認

## 残っているリスク

- E2E中に a11y の `serious` な color contrast 警告は表示されますが、現在のE2E失敗条件は `critical` 違反です。このPRではIssue #453の範囲に絞り、UIコントラスト修正は扱っていません。

## 意図的に触らなかった範囲

- E2Eテスト内容の大幅追加・変更
- アプリ機能の修正
- Firebase / Firestore / Storage Rules
- 本番デプロイ設定