### PR TITLE
fix(clock): 作業チャイムの表示と音声初期化を修正

### DIFF
--- a/app/clock/page.tsx
+++ b/app/clock/page.tsx
@@ -2,8 +2,8 @@
 
 import { useState, useCallback, useEffect, useSyncExternalStore } from 'react';
 import { HiCog6Tooth } from 'react-icons/hi2';
-import { MdSchedule } from 'react-icons/md';
-import { BackLink, IconButton } from '@/components/ui';
+import { MdSchedule, MdVolumeUp } from 'react-icons/md';
+import { BackLink, Button, IconButton } from '@/components/ui';
 import { useClockSettings } from '@/hooks/useClockSettings';
 import { ClockSettingsModal } from '@/components/clock/ClockSettingsModal';
 import { NextChimeStrip } from '@/components/clock/NextChimeStrip';
@@ -114,6 +114,8 @@ export default function ClockPage() {
     return () => window.clearTimeout(timer);
   }, [previewChime]);
   const displayedChime = previewChime ?? activeChime;
+  const shouldShowAudioEnableButton =
+    !displayedChime && workChimeSettings.enabled && workChimeSettings.soundEnabled && !isAudioEnabled;
 
   const handleTestWorkChime = useCallback(
     (kind: WorkChimeKind) => {
@@ -238,6 +240,26 @@ export default function ClockPage() {
 
         {!displayedChime && workChimeSettings.enabled && (
           <NextChimeStrip currentPeriod={currentPeriod} nextChime={nextChime} colors={colors} />
+        )}
+
+        {shouldShowAudioEnableButton && (
+          <div className="mt-4 flex justify-center">
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={enableAudio}
+              className="!min-h-11 border"
+              style={{
+                backgroundColor: colors.uiBg,
+                borderColor: colors.accent,
+                color: colors.text,
+              }}
+            >
+              <MdVolumeUp className="mr-1.5 h-5 w-5" aria-hidden="true" />
+              チャイム音を有効化
+            </Button>
+          </div>
         )}
       </div>
 

--- a/hooks/useWorkChime.test.tsx
+++ b/hooks/useWorkChime.test.tsx
@@ -4,9 +4,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useWorkChime } from './useWorkChime';
 
 const playWorkChimeMock = vi.fn();
+const unlockWorkChimeAudioMock = vi.fn(() => true);
 
 vi.mock('@/lib/workChimeAudio', () => ({
   playWorkChime: (...args: unknown[]) => playWorkChimeMock(...args),
+  unlockWorkChimeAudio: () => unlockWorkChimeAudioMock(),
 }));
 
 const createLocalStorageMock = () => {
@@ -33,12 +35,15 @@ describe('useWorkChime', () => {
     vi.useFakeTimers();
     vi.stubGlobal('localStorage', createLocalStorageMock());
     playWorkChimeMock.mockReset();
+    unlockWorkChimeAudioMock.mockReset();
+    unlockWorkChimeAudioMock.mockReturnValue(true);
   });
 
-  it('アンロック前は該当時刻でも音を鳴らさない', () => {
-    renderHook(() => useWorkChime(localDate(10, 45)));
+  it('音の有効化前でも該当時刻は通知を表示する', () => {
+    const { result } = renderHook(() => useWorkChime(localDate(10, 45)));
 
     expect(playWorkChimeMock).not.toHaveBeenCalled();
+    expect(result.current.activeChime?.message).toBe('休憩時間です');
   });
 
   it('アンロック後に該当時刻で音を鳴らして通知を表示する', () => {
@@ -81,6 +86,18 @@ describe('useWorkChime', () => {
     rerender({ now: localDate(10, 45, 40) });
 
     expect(playWorkChimeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('PWA復帰などで区切り時刻の秒をまたいでも通知を表示する', () => {
+    const { result, rerender } = renderHook(({ now }) => useWorkChime(now), {
+      initialProps: { now: localDate(10, 44, 59) },
+    });
+
+    rerender({ now: localDate(10, 45, 3) });
+
+    expect(playWorkChimeMock).not.toHaveBeenCalled();
+    expect(result.current.activeChime?.label).toBe('休憩開始');
+    expect(result.current.activeChime?.message).toBe('休憩時間です');
   });
 
   it('5秒後に通知を消す', () => {

--- a/hooks/useWorkChime.test.tsx
+++ b/hooks/useWorkChime.test.tsx
@@ -4,9 +4,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useWorkChime } from './useWorkChime';
 
 const playWorkChimeMock = vi.fn();
-const unlockWorkChimeAudioMock = vi.fn(() => true);
+const unlockWorkChimeAudioMock = vi.fn(() => Promise.resolve(true));
+const isWorkChimeAudioReadyMock = vi.fn(() => true);
 
 vi.mock('@/lib/workChimeAudio', () => ({
+  isWorkChimeAudioReady: () => isWorkChimeAudioReadyMock(),
   playWorkChime: (...args: unknown[]) => playWorkChimeMock(...args),
   unlockWorkChimeAudio: () => unlockWorkChimeAudioMock(),
 }));
@@ -35,8 +37,11 @@ describe('useWorkChime', () => {
     vi.useFakeTimers();
     vi.stubGlobal('localStorage', createLocalStorageMock());
     playWorkChimeMock.mockReset();
+    playWorkChimeMock.mockResolvedValue(true);
     unlockWorkChimeAudioMock.mockReset();
-    unlockWorkChimeAudioMock.mockReturnValue(true);
+    unlockWorkChimeAudioMock.mockResolvedValue(true);
+    isWorkChimeAudioReadyMock.mockReset();
+    isWorkChimeAudioReadyMock.mockReturnValue(true);
   });
 
   it('音の有効化前でも該当時刻は通知を表示する', () => {
@@ -46,18 +51,22 @@ describe('useWorkChime', () => {
     expect(result.current.activeChime?.message).toBe('休憩時間です');
   });
 
-  it('アンロック後に該当時刻で音を鳴らして通知を表示する', () => {
+  it('アンロック後に該当時刻で音を鳴らして通知を表示する', async () => {
     const { result, rerender } = renderHook(({ now }) => useWorkChime(now), {
       initialProps: { now: localDate(10, 44, 59) },
     });
 
-    act(() => {
+    await act(async () => {
       result.current.enableAudio();
+      await Promise.resolve();
     });
 
     playWorkChimeMock.mockClear();
 
     rerender({ now: localDate(10, 45) });
+    await act(async () => {
+      await Promise.resolve();
+    });
 
     expect(playWorkChimeMock).toHaveBeenCalledWith('break', { volume: 0.8 });
     expect(result.current.activeChime?.message).toBe('休憩時間です');
@@ -71,19 +80,23 @@ describe('useWorkChime', () => {
     expect(result.current.currentPeriod?.minutesUntilEnd).toBe(5);
   });
 
-  it('同じ分では重複再生しない', () => {
+  it('同じ分では重複再生しない', async () => {
     const { result, rerender } = renderHook(({ now }) => useWorkChime(now), {
       initialProps: { now: localDate(10, 44, 59) },
     });
 
-    act(() => {
+    await act(async () => {
       result.current.enableAudio();
+      await Promise.resolve();
     });
 
     playWorkChimeMock.mockClear();
 
     rerender({ now: localDate(10, 45) });
     rerender({ now: localDate(10, 45, 40) });
+    await act(async () => {
+      await Promise.resolve();
+    });
 
     expect(playWorkChimeMock).toHaveBeenCalledTimes(1);
   });
@@ -100,13 +113,14 @@ describe('useWorkChime', () => {
     expect(result.current.activeChime?.message).toBe('休憩時間です');
   });
 
-  it('5秒後に通知を消す', () => {
+  it('5秒後に通知を消す', async () => {
     const { result, rerender } = renderHook(({ now }) => useWorkChime(now), {
       initialProps: { now: localDate(10, 44, 59) },
     });
 
-    act(() => {
+    await act(async () => {
       result.current.enableAudio();
+      await Promise.resolve();
     });
 
     rerender({ now: localDate(10, 45) });
@@ -119,11 +133,12 @@ describe('useWorkChime', () => {
     expect(result.current.activeChime).toBeNull();
   });
 
-  it('テスト用チャイムは通知を表示して音を鳴らす', () => {
+  it('テスト用チャイムは通知を表示して音を鳴らす', async () => {
     const { result } = renderHook(() => useWorkChime(localDate(10, 40)));
 
-    act(() => {
+    await act(async () => {
       result.current.testWorkChime('work-start');
+      await Promise.resolve();
     });
 
     expect(playWorkChimeMock).toHaveBeenCalledWith('work-start', { volume: 0.8 });
@@ -146,5 +161,23 @@ describe('useWorkChime', () => {
     });
 
     expect(result.current.activeChime).toBeNull();
+  });
+
+  it('AudioContextが停止した状態で復帰したら音の有効化を解除する', async () => {
+    const { result } = renderHook(() => useWorkChime(localDate(10, 40)));
+
+    await act(async () => {
+      result.current.enableAudio();
+      await Promise.resolve();
+    });
+    expect(result.current.isAudioEnabled).toBe(true);
+
+    isWorkChimeAudioReadyMock.mockReturnValue(false);
+
+    act(() => {
+      window.dispatchEvent(new Event('focus'));
+    });
+
+    expect(result.current.isAudioEnabled).toBe(false);
   });
 });

--- a/hooks/useWorkChime.ts
+++ b/hooks/useWorkChime.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { playWorkChime, unlockWorkChimeAudio } from '@/lib/workChimeAudio';
+import { isWorkChimeAudioReady, playWorkChime, unlockWorkChimeAudio } from '@/lib/workChimeAudio';
 import {
   getCurrentWorkChimePeriod,
   getDueWorkChimeSince,
@@ -57,7 +57,7 @@ export function useWorkChime(now: Date | null): UseWorkChimeReturn {
   }, []);
 
   const enableAudio = useCallback(() => {
-    setIsAudioEnabled(unlockWorkChimeAudio());
+    void unlockWorkChimeAudio().then(setIsAudioEnabled);
   }, []);
 
   const updateSettings = useCallback((patch: Partial<WorkChimeSettings>) => {
@@ -90,13 +90,14 @@ export function useWorkChime(now: Date | null): UseWorkChimeReturn {
 
       if (timerRef.current) clearTimeout(timerRef.current);
 
-      const audioReady = unlockWorkChimeAudio();
-      setIsAudioEnabled(audioReady);
       setActiveChime(chime);
 
-      if (settings.soundEnabled && audioReady) {
-        playWorkChime(kind, { volume: settings.volume });
-      }
+      void unlockWorkChimeAudio().then((audioReady) => {
+        setIsAudioEnabled(audioReady);
+        if (settings.soundEnabled && audioReady) {
+          void playWorkChime(kind, { volume: settings.volume });
+        }
+      });
 
       timerRef.current = setTimeout(() => {
         setActiveChime(null);
@@ -120,7 +121,9 @@ export function useWorkChime(now: Date | null): UseWorkChimeReturn {
     setActiveChime(due);
 
     if (settings.soundEnabled && isAudioEnabled) {
-      playWorkChime(due.kind, { volume: settings.volume });
+      void playWorkChime(due.kind, { volume: settings.volume }).then((didPlay) => {
+        if (!didPlay) setIsAudioEnabled(false);
+      });
     }
 
     if (timerRef.current) clearTimeout(timerRef.current);
@@ -129,6 +132,27 @@ export function useWorkChime(now: Date | null): UseWorkChimeReturn {
       timerRef.current = null;
     }, 5000);
   }, [isAudioEnabled, now, settings]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof document === 'undefined') return;
+    if (!isAudioEnabled) return;
+
+    const refreshAudioState = () => {
+      if (!isWorkChimeAudioReady()) {
+        setIsAudioEnabled(false);
+      }
+    };
+
+    window.addEventListener('focus', refreshAudioState);
+    window.addEventListener('pageshow', refreshAudioState);
+    document.addEventListener('visibilitychange', refreshAudioState);
+
+    return () => {
+      window.removeEventListener('focus', refreshAudioState);
+      window.removeEventListener('pageshow', refreshAudioState);
+      document.removeEventListener('visibilitychange', refreshAudioState);
+    };
+  }, [isAudioEnabled]);
 
   useEffect(() => {
     return () => {

--- a/hooks/useWorkChime.ts
+++ b/hooks/useWorkChime.ts
@@ -2,10 +2,10 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { playWorkChime } from '@/lib/workChimeAudio';
+import { playWorkChime, unlockWorkChimeAudio } from '@/lib/workChimeAudio';
 import {
   getCurrentWorkChimePeriod,
-  getDueWorkChime,
+  getDueWorkChimeSince,
   getNextWorkChime,
   getWorkChimeMessage,
   getWorkChimeSettings,
@@ -45,6 +45,7 @@ export function useWorkChime(now: Date | null): UseWorkChimeReturn {
   const [isAudioEnabled, setIsAudioEnabled] = useState(false);
   const [activeChime, setActiveChime] = useState<DueWorkChime | null>(null);
   const playedKeysRef = useRef<string[]>([]);
+  const previousNowRef = useRef<Date | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const dismissActiveChime = useCallback(() => {
@@ -56,8 +57,7 @@ export function useWorkChime(now: Date | null): UseWorkChimeReturn {
   }, []);
 
   const enableAudio = useCallback(() => {
-    playWorkChime('work-start', { volume: 0 });
-    setIsAudioEnabled(true);
+    setIsAudioEnabled(unlockWorkChimeAudio());
   }, []);
 
   const updateSettings = useCallback((patch: Partial<WorkChimeSettings>) => {
@@ -90,10 +90,11 @@ export function useWorkChime(now: Date | null): UseWorkChimeReturn {
 
       if (timerRef.current) clearTimeout(timerRef.current);
 
-      setIsAudioEnabled(true);
+      const audioReady = unlockWorkChimeAudio();
+      setIsAudioEnabled(audioReady);
       setActiveChime(chime);
 
-      if (settings.soundEnabled) {
+      if (settings.soundEnabled && audioReady) {
         playWorkChime(kind, { volume: settings.volume });
       }
 
@@ -109,15 +110,16 @@ export function useWorkChime(now: Date | null): UseWorkChimeReturn {
   const nextChime = now ? getNextWorkChime(now, settings) : null;
 
   useEffect(() => {
-    if (!now || !isAudioEnabled) return;
+    if (!now) return;
 
-    const due = getDueWorkChime(now, settings, playedKeysRef.current);
+    const due = getDueWorkChimeSince(previousNowRef.current, now, settings, playedKeysRef.current);
+    previousNowRef.current = now;
     if (!due) return;
 
     playedKeysRef.current = [...playedKeysRef.current, due.playKey].slice(-50);
     setActiveChime(due);
 
-    if (settings.soundEnabled) {
+    if (settings.soundEnabled && isAudioEnabled) {
       playWorkChime(due.kind, { volume: settings.volume });
     }
 

--- a/lib/workChime.test.ts
+++ b/lib/workChime.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_WORK_CHIME_SETTINGS,
   getCurrentWorkChimePeriod,
   getDueWorkChime,
+  getDueWorkChimeSince,
   getNextWorkChime,
   getWorkChimeSettings,
   setWorkChimeSettings,
@@ -156,6 +157,24 @@ describe('workChime', () => {
     const due = getDueWorkChime(now, DEFAULT_WORK_CHIME_SETTINGS, ['2026-05-17:break-1']);
 
     expect(due).toBeNull();
+  });
+
+  it('区切り時刻の秒をまたいだ場合も直近のチャイムを返す', () => {
+    const previous = localDate(10, 44, 59);
+    const now = localDate(10, 45, 3);
+
+    const due = getDueWorkChimeSince(previous, now, DEFAULT_WORK_CHIME_SETTINGS, []);
+
+    expect(due?.period.id).toBe('break-1');
+    expect(due?.kind).toBe('break');
+    expect(due?.message).toBe('休憩時間です');
+  });
+
+  it('長時間停止後は古い区切り時刻のチャイムを後追いしない', () => {
+    const previous = localDate(10, 40, 0);
+    const now = localDate(10, 50, 0);
+
+    expect(getDueWorkChimeSince(previous, now, DEFAULT_WORK_CHIME_SETTINGS, [])).toBeNull();
   });
 
   it('無効化されている場合は現在表示も発火もしない', () => {

--- a/lib/workChime.ts
+++ b/lib/workChime.ts
@@ -167,6 +167,19 @@ function getBoundaryLabel(kind: WorkChimeKind): string {
   return '作業開始';
 }
 
+function createDueWorkChime(now: Date, period: WorkChimePeriod, sortedPeriods: WorkChimePeriod[]): DueWorkChime {
+  const kind = getBoundaryKind(period, sortedPeriods);
+
+  return {
+    period,
+    time: period.start,
+    kind,
+    label: getBoundaryLabel(kind),
+    playKey: `${dateKey(now)}:${period.id}`,
+    message: getWorkChimeMessage(kind),
+  };
+}
+
 export function getWorkChimeMessage(kind: WorkChimeKind): string {
   if (kind === 'cleanup-start') return '掃除開始です';
   return kind === 'break' ? '休憩時間です' : '作業開始です';
@@ -235,17 +248,44 @@ export function getDueWorkChime(now: Date, settings: WorkChimeSettings, playedKe
   const period = sortedPeriods.find((candidate) => candidate.start === currentTime);
   if (!period) return null;
 
-  const playKey = `${dateKey(now)}:${period.id}`;
-  if (playedKeys.includes(playKey)) return null;
+  const due = createDueWorkChime(now, period, sortedPeriods);
+  if (playedKeys.includes(due.playKey)) return null;
 
-  const kind = getBoundaryKind(period, sortedPeriods);
+  return due;
+}
 
-  return {
-    period,
-    time: period.start,
-    kind,
-    label: getBoundaryLabel(kind),
-    playKey,
-    message: getWorkChimeMessage(kind),
-  };
+export function getDueWorkChimeSince(
+  previous: Date | null,
+  now: Date,
+  settings: WorkChimeSettings,
+  playedKeys: string[]
+): DueWorkChime | null {
+  if (!settings.enabled) return null;
+  if (!previous) return getDueWorkChime(now, settings, playedKeys);
+
+  const previousTime = previous.getTime();
+  const currentTime = now.getTime();
+  if (previousTime >= currentTime) return getDueWorkChime(now, settings, playedKeys);
+
+  const maxCatchUpMs = 5 * 60 * 1000;
+  if (currentTime - previousTime > maxCatchUpMs) return getDueWorkChime(now, settings, playedKeys);
+
+  const sortedPeriods = getSortedPeriods(settings);
+  const due = sortedPeriods
+    .map((period) => {
+      const [hours, minutes] = period.start.split(':').map(Number);
+      const boundary = new Date(now);
+      boundary.setHours(hours, minutes, 0, 0);
+
+      return {
+        period,
+        boundaryTime: boundary.getTime(),
+      };
+    })
+    .find(({ boundaryTime, period }) => {
+      const playKey = `${dateKey(now)}:${period.id}`;
+      return previousTime < boundaryTime && boundaryTime <= currentTime && !playedKeys.includes(playKey);
+    });
+
+  return due ? createDueWorkChime(now, due.period, sortedPeriods) : null;
 }

--- a/lib/workChimeAudio.test.ts
+++ b/lib/workChimeAudio.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { playWorkChime } from './workChimeAudio';
+import { playWorkChime, unlockWorkChimeAudio } from './workChimeAudio';
 
 type AudioContextMock = NonNullable<Parameters<typeof playWorkChime>[1]['audioContext']>;
 
-function createAudioContextMock() {
+function createAudioContextMock(options: Partial<Pick<AudioContext, 'state' | 'resume'>> = {}) {
   const events: Array<{ frequency: number; start: number; stop: number; type: OscillatorType }> = [];
   const gainValues: number[] = [];
 
@@ -47,6 +47,7 @@ function createAudioContextMock() {
     destination,
     createOscillator,
     createGain,
+    ...options,
   };
 
   return {
@@ -87,5 +88,41 @@ describe('workChimeAudio', () => {
 
     expect(low.gainValues).toContain(0);
     expect(high.gainValues.some((value) => value > 1)).toBe(false);
+  });
+
+  it('停止中のAudioContextを再開してからチャイムをスケジュールする', () => {
+    const resume = vi.fn(() => Promise.resolve());
+    const mock = createAudioContextMock({ state: 'suspended', resume });
+
+    playWorkChime('break', { volume: 0.8, audioContext: mock.ctx });
+
+    expect(resume).toHaveBeenCalledTimes(1);
+    expect(mock.ctx.createOscillator).toHaveBeenCalled();
+  });
+
+  it('音声有効化時にAudioContextを作成して無音チャイムで初期化する', () => {
+    const resume = vi.fn(() => Promise.resolve());
+    const mock = createAudioContextMock({ state: 'suspended', resume });
+    const AudioContextMockConstructor = vi.fn(function AudioContextMock() {
+      return mock.ctx;
+    });
+    const originalAudioContext = window.AudioContext;
+
+    Object.defineProperty(window, 'AudioContext', {
+      value: AudioContextMockConstructor as unknown as typeof AudioContext,
+      configurable: true,
+    });
+
+    const didUnlock = unlockWorkChimeAudio();
+
+    expect(didUnlock).toBe(true);
+    expect(AudioContextMockConstructor).toHaveBeenCalledTimes(1);
+    expect(resume).toHaveBeenCalledTimes(1);
+    expect(mock.gainValues).toContain(0);
+
+    Object.defineProperty(window, 'AudioContext', {
+      value: originalAudioContext,
+      configurable: true,
+    });
   });
 });

--- a/lib/workChimeAudio.test.ts
+++ b/lib/workChimeAudio.test.ts
@@ -58,20 +58,20 @@ function createAudioContextMock(options: Partial<Pick<AudioContext, 'state' | 'r
 }
 
 describe('workChimeAudio', () => {
-  it('休憩チャイムは下がる2音をスケジュールする', () => {
+  it('休憩チャイムは下がる2音をスケジュールする', async () => {
     const mock = createAudioContextMock();
 
-    playWorkChime('break', { volume: 0.8, audioContext: mock.ctx });
+    await playWorkChime('break', { volume: 0.8, audioContext: mock.ctx });
 
     expect(mock.ctx.createOscillator).toHaveBeenCalledTimes(6);
     expect(mock.events[0].frequency).toBe(784);
     expect(mock.events[3].frequency).toBe(659);
   });
 
-  it('作業開始チャイムは上がる3音をスケジュールする', () => {
+  it('作業開始チャイムは上がる3音をスケジュールする', async () => {
     const mock = createAudioContextMock();
 
-    playWorkChime('work-start', { volume: 0.8, audioContext: mock.ctx });
+    await playWorkChime('work-start', { volume: 0.8, audioContext: mock.ctx });
 
     expect(mock.ctx.createOscillator).toHaveBeenCalledTimes(9);
     expect(mock.events[0].frequency).toBe(659);
@@ -79,28 +79,28 @@ describe('workChimeAudio', () => {
     expect(mock.events[6].frequency).toBe(988);
   });
 
-  it('音量は0から1に丸める', () => {
+  it('音量は0から1に丸める', async () => {
     const low = createAudioContextMock();
     const high = createAudioContextMock();
 
-    playWorkChime('break', { volume: -1, audioContext: low.ctx });
-    playWorkChime('break', { volume: 2, audioContext: high.ctx });
+    await playWorkChime('break', { volume: -1, audioContext: low.ctx });
+    await playWorkChime('break', { volume: 2, audioContext: high.ctx });
 
     expect(low.gainValues).toContain(0);
     expect(high.gainValues.some((value) => value > 1)).toBe(false);
   });
 
-  it('停止中のAudioContextを再開してからチャイムをスケジュールする', () => {
+  it('停止中のAudioContextを再開してからチャイムをスケジュールする', async () => {
     const resume = vi.fn(() => Promise.resolve());
     const mock = createAudioContextMock({ state: 'suspended', resume });
 
-    playWorkChime('break', { volume: 0.8, audioContext: mock.ctx });
+    await playWorkChime('break', { volume: 0.8, audioContext: mock.ctx });
 
     expect(resume).toHaveBeenCalledTimes(1);
     expect(mock.ctx.createOscillator).toHaveBeenCalled();
   });
 
-  it('音声有効化時にAudioContextを作成して無音チャイムで初期化する', () => {
+  it('音声有効化時にAudioContextを作成して無音チャイムで初期化する', async () => {
     const resume = vi.fn(() => Promise.resolve());
     const mock = createAudioContextMock({ state: 'suspended', resume });
     const AudioContextMockConstructor = vi.fn(function AudioContextMock() {
@@ -113,7 +113,7 @@ describe('workChimeAudio', () => {
       configurable: true,
     });
 
-    const didUnlock = unlockWorkChimeAudio();
+    const didUnlock = await unlockWorkChimeAudio();
 
     expect(didUnlock).toBe(true);
     expect(AudioContextMockConstructor).toHaveBeenCalledTimes(1);

--- a/lib/workChimeAudio.ts
+++ b/lib/workChimeAudio.ts
@@ -46,12 +46,18 @@ function getAudioContext(): AudioContextLike | null {
   return workChimeAudioContext;
 }
 
-function resumeAudioContext(ctx: AudioContextLike): void {
-  if (ctx.state !== 'suspended' || !ctx.resume) return;
+async function resumeAudioContext(ctx: AudioContextLike): Promise<boolean> {
+  if (ctx.state === 'closed') return false;
+  if (ctx.state !== 'suspended') return true;
+  if (!ctx.resume) return false;
 
-  void ctx.resume().catch((error) => {
+  try {
+    await ctx.resume();
+    return true;
+  } catch (error) {
     console.warn('Failed to resume work chime audio:', error);
-  });
+    return false;
+  }
 }
 
 function tone(ctx: AudioContextLike, master: GainNode, options: ToneOptions): void {
@@ -102,8 +108,9 @@ function bell(
   });
 }
 
-function scheduleWorkChime(ctx: AudioContextLike, kind: WorkChimeKind, volume: number): void {
-  resumeAudioContext(ctx);
+async function scheduleWorkChime(ctx: AudioContextLike, kind: WorkChimeKind, volume: number): Promise<boolean> {
+  const isReady = await resumeAudioContext(ctx);
+  if (!isReady) return false;
 
   const master = ctx.createGain();
   master.gain.setValueAtTime(volume, ctx.currentTime);
@@ -114,34 +121,38 @@ function scheduleWorkChime(ctx: AudioContextLike, kind: WorkChimeKind, volume: n
   if (kind === 'break') {
     bell(ctx, master, now, 784, 0.18, 0.34);
     bell(ctx, master, now + 0.26, 659, 0.28, 0.3);
-    return;
+    return true;
   }
 
   bell(ctx, master, now, 659, 0.14, 0.3);
   bell(ctx, master, now + 0.21, 784, 0.14, 0.32);
   bell(ctx, master, now + 0.42, 988, 0.22, 0.28);
+  return true;
 }
 
-export function unlockWorkChimeAudio(): boolean {
+export function isWorkChimeAudioReady(): boolean {
+  if (!workChimeAudioContext) return false;
+  return workChimeAudioContext.state !== 'suspended' && workChimeAudioContext.state !== 'closed';
+}
+
+export async function unlockWorkChimeAudio(): Promise<boolean> {
   const ctx = getAudioContext();
   if (!ctx) return false;
 
   try {
-    scheduleWorkChime(ctx, 'work-start', 0);
-    return true;
+    return await scheduleWorkChime(ctx, 'work-start', 0);
   } catch (error) {
     console.warn('Failed to unlock work chime audio:', error);
     return false;
   }
 }
 
-export function playWorkChime(kind: WorkChimeKind, options: PlayWorkChimeOptions): boolean {
+export async function playWorkChime(kind: WorkChimeKind, options: PlayWorkChimeOptions): Promise<boolean> {
   const ctx = options.audioContext ?? getAudioContext();
   if (!ctx) return false;
 
   try {
-    scheduleWorkChime(ctx, kind, clampVolume(options.volume));
-    return true;
+    return await scheduleWorkChime(ctx, kind, clampVolume(options.volume));
   } catch (error) {
     console.warn('Failed to play work chime:', error);
     return false;

--- a/lib/workChimeAudio.ts
+++ b/lib/workChimeAudio.ts
@@ -6,7 +6,8 @@ declare global {
   }
 }
 
-type AudioContextLike = Pick<AudioContext, 'currentTime' | 'destination' | 'createOscillator' | 'createGain'>;
+type AudioContextLike = Pick<AudioContext, 'currentTime' | 'destination' | 'createOscillator' | 'createGain'> &
+  Partial<Pick<AudioContext, 'state' | 'resume'>>;
 
 interface PlayWorkChimeOptions {
   volume: number;
@@ -27,6 +28,8 @@ function clampVolume(value: number): number {
   return Math.max(0, Math.min(1, value));
 }
 
+let workChimeAudioContext: AudioContextLike | null = null;
+
 function createAudioContext(): AudioContextLike | null {
   if (typeof window === 'undefined') return null;
 
@@ -34,6 +37,21 @@ function createAudioContext(): AudioContextLike | null {
   if (!AudioContextConstructor) return null;
 
   return new AudioContextConstructor();
+}
+
+function getAudioContext(): AudioContextLike | null {
+  if (workChimeAudioContext) return workChimeAudioContext;
+
+  workChimeAudioContext = createAudioContext();
+  return workChimeAudioContext;
+}
+
+function resumeAudioContext(ctx: AudioContextLike): void {
+  if (ctx.state !== 'suspended' || !ctx.resume) return;
+
+  void ctx.resume().catch((error) => {
+    console.warn('Failed to resume work chime audio:', error);
+  });
 }
 
 function tone(ctx: AudioContextLike, master: GainNode, options: ToneOptions): void {
@@ -84,11 +102,9 @@ function bell(
   });
 }
 
-export function playWorkChime(kind: WorkChimeKind, options: PlayWorkChimeOptions): void {
-  const ctx = options.audioContext ?? createAudioContext();
-  if (!ctx) return;
+function scheduleWorkChime(ctx: AudioContextLike, kind: WorkChimeKind, volume: number): void {
+  resumeAudioContext(ctx);
 
-  const volume = clampVolume(options.volume);
   const master = ctx.createGain();
   master.gain.setValueAtTime(volume, ctx.currentTime);
   master.connect(ctx.destination);
@@ -104,4 +120,30 @@ export function playWorkChime(kind: WorkChimeKind, options: PlayWorkChimeOptions
   bell(ctx, master, now, 659, 0.14, 0.3);
   bell(ctx, master, now + 0.21, 784, 0.14, 0.32);
   bell(ctx, master, now + 0.42, 988, 0.22, 0.28);
+}
+
+export function unlockWorkChimeAudio(): boolean {
+  const ctx = getAudioContext();
+  if (!ctx) return false;
+
+  try {
+    scheduleWorkChime(ctx, 'work-start', 0);
+    return true;
+  } catch (error) {
+    console.warn('Failed to unlock work chime audio:', error);
+    return false;
+  }
+}
+
+export function playWorkChime(kind: WorkChimeKind, options: PlayWorkChimeOptions): boolean {
+  const ctx = options.audioContext ?? getAudioContext();
+  if (!ctx) return false;
+
+  try {
+    scheduleWorkChime(ctx, kind, clampVolume(options.volume));
+    return true;
+  } catch (error) {
+    console.warn('Failed to play work chime:', error);
+    return false;
+  }
 }


### PR DESCRIPTION
## 対象

時計画面の作業チャイム不具合修正です。Issue番号は未指定です。

## 変更したファイル

- `app/clock/page.tsx`: 時計画面上に「チャイム音を有効化」ボタンを追加
- `hooks/useWorkChime.ts`: チャイム通知判定、音声有効化、PWA復帰時の音声状態確認を修正
- `lib/workChime.ts`: 区切り時刻を数秒またいだ場合も直近チャイムを拾う判定を追加
- `lib/workChimeAudio.ts`: iOS/PWA向けにAudioContextを初回操作で保持・再開する処理を追加
- `hooks/useWorkChime.test.tsx`, `lib/workChime.test.ts`, `lib/workChimeAudio.test.ts`: 再発防止テストを追加

## 変更内容

- 音声が未有効化の状態でも、チャイム時刻になれば中央通知は表示されるようにしました。
- iPad PWAで音が鳴りにくい原因になっていた、チャイム時刻ごとのAudioContext作り直しをやめ、ユーザー操作時に作ったAudioContextを再利用するようにしました。
- PWA復帰やタイマー遅延で、区切り時刻の秒を少しまたいだ場合も通知を出せるようにしました。
- 長時間停止後に古いチャイムをまとめて後追いしないよう、後追い判定は5分以内に制限しています。
- AudioContextが停止状態になった場合は音声有効化を解除し、時計画面上に「チャイム音を有効化」ボタンを表示するようにしました。

## なぜこの修正が必要か

従来は `isAudioEnabled` が false の場合、音だけでなくチャイム判定そのものが止まっていました。そのため、iOS/PWAで音声権限やAudioContextが失効したような状態になると、画面通知も出ないことがありました。

また、iOS/PWAでは音声再生の再有効化にユーザー操作が必要になることがあるため、設定モーダル内だけでなく時計画面上から再有効化できる導線を追加しました。

## 実行した確認コマンドと結果

- `npm run test:run -- lib/workChime.test.ts lib/workChimeAudio.test.ts hooks/useWorkChime.test.tsx` 成功
- `npm run test:run -- lib/workChime.test.ts lib/workChimeAudio.test.ts hooks/useWorkChime.test.tsx components/clock/ClockSettingsModal.test.tsx components/clock/WorkChimeAlert.test.tsx` 成功
- `npm run typecheck` 成功
- `npm run lint` 成功
- `npm run build` 成功
- `npm run secrets:scan:staged` 成功
- `node .\node_modules\@playwright\test\cli.js test --project=chromium --no-deps --grep "時計" e2e/essential.spec.ts` 成功
- Playwrightで `http://localhost:3000/clock?previewChime=cleanup` を開き、中央通知表示と約5秒後の自動非表示を確認
- Playwrightで `http://localhost:3000/clock` を開き、「チャイム音を有効化」ボタンの表示とクリック後の非表示を確認

## 残っているリスク

- 実機iPad PWAでの音声再生は、この環境からは直接確認できていません。PR後に実機で「時計画面のチャイム音を有効化ボタン」または「時計の設定 > 音を有効化 > テスト再生」と、実際の区切り時刻で確認してください。
- 標準の `npm run test:e2e -- e2e/essential.spec.ts --grep 時計` は、既存の Next dev server が `localhost:3000` で動いていたため、E2E用の2つ目の dev server 起動が Next.js に拒否されて失敗しました。代替として既存サーバーを使い、依存セットアップなしで時計E2Eだけ通しています。
- PR CIのE2E Testsは、GitHub Actions上で `Install Playwright Chromium` ステップが長時間 in progress になっています。アプリのE2E本体まで到達していない状態です。

## 意図的に触らなかった範囲

- Firestore / Storage / Cloud Functions / 認証 / 権限 / 本番デプロイ設定は変更していません。
- 音声アナウンス（未実装）の追加は行っていません。