### PR TITLE
fix: 試飲データ消失の復旧と上書き防止

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,9 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
+      options: --user 1001
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -106,15 +109,6 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
-      - name: Install Playwright Chromium
-        run: npx playwright install --with-deps --only-shell chromium
       - run: npm run test:e2e
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-playwright-
       - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps --only-shell chromium
       - run: npm run test:e2e
 
   build:

--- a/app/consent/page.test.tsx
+++ b/app/consent/page.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ConsentPage from './page';
+import type { AppData } from '@/types';
+
+const mocks = vi.hoisted(() => ({
+  replace: vi.fn(),
+  getUserData: vi.fn(),
+  saveUserData: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    replace: mocks.replace,
+  }),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  useAuth: () => ({
+    user: { uid: 'user-1', email: 'test@example.com' },
+    loading: false,
+  }),
+}));
+
+vi.mock('@/lib/firestore', () => ({
+  getUserData: mocks.getUserData,
+  saveUserData: mocks.saveUserData,
+}));
+
+function appData(): AppData {
+  return {
+    todaySchedules: [],
+    roastSchedules: [],
+    tastingSessions: [],
+    tastingRecords: [],
+    notifications: [],
+    encouragementCount: 0,
+    roastTimerRecords: [],
+    workProgresses: [],
+    dripRecipes: [],
+  };
+}
+
+describe('ConsentPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.setSystemTime(new Date('2026-05-28T00:00:00.000Z'));
+    mocks.getUserData.mockResolvedValue(appData());
+    mocks.saveUserData.mockResolvedValue(undefined);
+  });
+
+  it('同意保存ではuserConsentだけを保存対象にする', async () => {
+    render(<ConsentPage />);
+
+    const submit = await screen.findByRole('button', { name: '同意して続ける' });
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /利用規約/ }));
+    fireEvent.click(screen.getByRole('checkbox', { name: /プライバシーポリシー/ }));
+    fireEvent.click(submit);
+
+    await waitFor(() => {
+      expect(mocks.saveUserData).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({
+          userConsent: expect.objectContaining({ hasAgreed: true }),
+          tastingSessions: [],
+          tastingRecords: [],
+        }),
+        { updatedFields: ['userConsent'] }
+      );
+    });
+  });
+});

--- a/app/consent/page.tsx
+++ b/app/consent/page.tsx
@@ -56,7 +56,7 @@ export default function ConsentPage() {
       const existingData = await getUserData(user.uid);
       const consentData = createConsentData();
       // userConsentを追加して保存
-      await saveUserData(user.uid, { ...existingData, userConsent: consentData });
+      await saveUserData(user.uid, { ...existingData, userConsent: consentData }, { updatedFields: ['userConsent'] });
       router.replace('/');
     } catch (error) {
       console.error('同意の保存に失敗:', error);

--- a/docs/superpowers/plans/2026-05-28-tasting-data-loss-recovery.md
+++ b/docs/superpowers/plans/2026-05-28-tasting-data-loss-recovery.md
@@ -1,0 +1,156 @@
+# Tasting Data Loss Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Issue #458 の本番試飲データ消失について、復旧可否を判断し、古いクライアント状態による再消失を防ぐ。
+
+**Architecture:** 本番復旧は読み取り調査、復旧案提示、承認後の書き込みに分ける。アプリ側は `useAppData` が把握した変更キーを `saveUserData` へ渡し、Firestore root 書き込み payload を変更対象フィールドだけに絞る。
+
+**Tech Stack:** Next.js 16, React 19, TypeScript, Firebase Firestore, Vitest, gcloud/Firebase CLI
+
+---
+
+### Task 1: 本番復旧調査の安全境界
+
+**Files:**
+- Reference: `docs/superpowers/specs/2026-05-28-tasting-data-loss-recovery.md`
+
+- [x] **Step 1: Issue本文を確認する**
+
+Run: `gh issue view 458 --json number,title,body,labels,state,assignees,comments`
+
+Expected: Issue #458 の対象データ、受け入れ条件、注意点が確認できる。
+
+- [x] **Step 2: 本番Firestore設定を読み取り確認する**
+
+Run: `gcloud firestore databases describe --database="(default)" --project=roastplus-72fa6`
+
+Expected: PITR や backup 設定が確認できる。
+
+- [x] **Step 3: Firestore backups を読み取り確認する**
+
+Run: `gcloud firestore backups list --project=roastplus-72fa6`
+
+Expected: `READY` 状態の backup があるか確認できる。
+
+- [x] **Step 4: 対象uidを確認する**
+
+User input required: 消失が報告された対象ユーザーの Firebase Auth `uid`。
+
+- [x] **Step 5: 対象uidだけを読み取り確認する**
+
+Run after approval: `users/{uid}` の `tastingSessions.length` / `tastingRecords.length` と最終更新に関係するフィールドだけを確認する。
+
+Expected: 本番の現状件数を説明できる。秘密情報や個人情報はログに出さない。
+
+- [x] **Step 6: PITRで消失直前の件数を確認する**
+
+Run: Firestore REST `documents:batchGet` with `readTime`.
+
+Expected:
+- current `tastingSessions`: 0
+- current `tastingRecords`: 0
+- `2026-05-28T05:56:00Z` `tastingSessions`: 4
+- `2026-05-28T05:56:00Z` `tastingRecords`: 16
+- `2026-05-28T05:57:00Z` `tastingSessions`: 0
+- `2026-05-28T05:57:00Z` `tastingRecords`: 0
+
+### Task 2: 古いクライアント状態による上書き防止
+
+**Files:**
+- Modify: `hooks/useAppData.ts`
+- Modify: `app/consent/page.tsx`
+- Modify: `lib/firestore/userData/crud.ts`
+- Modify: `lib/firestore/userData/write-queue.ts`
+- Modify: `lib/firestore/workProgress/crud.ts`
+- Modify: `lib/firestore/workProgress/progress.ts`
+- Test: `hooks/useAppData.test.ts`
+- Test: `lib/firestore/write-queue.test.ts`
+- Test: `lib/firestore/workProgress/crud.test.ts`
+- Test: `app/consent/page.test.tsx`
+
+- [x] **Step 1: 失敗テストを書く**
+
+Add a write queue test that calls `saveUserData` with `updatedFields: ['encouragementCount']` and stale empty `tastingSessions` / `tastingRecords`.
+
+Expected before implementation: root write payload still contains empty tasting arrays and the test fails.
+
+- [x] **Step 2: useAppData の保存オプションをテストする**
+
+Add a hook test that updates only `encouragementCount` and expects `saveUserData` options to include `updatedFields: ['encouragementCount']`.
+
+Expected before implementation: options do not include `updatedFields` and the test fails.
+
+- [x] **Step 3: updateData から変更キーを渡す**
+
+Modify `hooks/useAppData.ts` so `saveUserData` receives:
+
+```ts
+{
+  syncWorkProgresses: mutatedKeys.includes('workProgresses'),
+  updatedFields: mutatedKeys,
+}
+```
+
+- [x] **Step 4: 書き込みpayloadを変更キーに絞る**
+
+Modify `lib/firestore/userData/write-queue.ts` so root document writes use only `options.updatedFields` when provided, while keeping full writes backward compatible when the option is omitted.
+
+- [x] **Step 5: キュー内の保存オプションをマージする**
+
+Modify `lib/firestore/userData/crud.ts` so debounced writes merge `updatedFields` by union. If either pending write is a legacy full write, keep full-write behavior.
+
+- [x] **Step 6: saveUserData直接呼び出しにも更新キーを渡す**
+
+Modify `lib/firestore/workProgress/crud.ts`, `lib/firestore/workProgress/progress.ts`, and `app/consent/page.tsx` so direct `saveUserData` calls pass the intended `updatedFields`.
+
+- [x] **Step 7: 関連テストを実行する**
+
+Run: `npm run test:run -- hooks/useAppData.test.ts lib/firestore/write-queue.test.ts lib/firestore/userData.test.ts lib/firestore/workProgress/crud.test.ts app/consent/page.test.tsx`
+
+Expected: all selected tests pass.
+
+### Task 3: 復旧判断と書き戻し
+
+**Files:**
+- No code changes until restoration method is approved.
+
+- [x] **Step 1: 復旧候補を比較する**
+
+Compare current `users/{uid}` counts with PITR/backup candidates. Do not import or write to production in this step.
+
+- [x] **Step 2: 復旧案を提示する**
+
+Document target fields, source backup/time, expected record counts, rollback method, and manual screen check.
+
+Recommended restore source: PITR `2026-05-28T05:56:00Z`.
+
+Recommended restore target fields:
+- `todaySchedules`
+- `roastSchedules`
+- `tastingSessions`
+- `tastingRecords`
+- `dripRecipes`
+
+Reason: the same `2026-05-28T05:56:33.182292Z` update emptied all five array fields.
+
+Rollback method: Before patching, use the current `updateTime` as a precondition. If restoration is wrong, use PITR at the pre-patch current time to restore the five fields back to the current empty state or apply the explicitly saved before-patch field snapshot.
+
+- [x] **Step 3: 明示承認後にだけ復旧する**
+
+Run only after user approval. Prefer minimal field-level write-back for `users/{uid}.tastingSessions` and `users/{uid}.tastingRecords` over full database import.
+
+Executed after explicit user approval: restored `todaySchedules`, `roastSchedules`, `tastingSessions`, `tastingRecords`, and `dripRecipes` from PITR `2026-05-28T05:56:00Z` with an updateTime precondition.
+
+- [x] **Step 4: 復旧後確認**
+
+Record before/after counts and verify `/tasting` shows the expected sessions.
+
+Post-restore counts:
+- `todaySchedules`: 6
+- `roastSchedules`: 12
+- `tastingSessions`: 4
+- `tastingRecords`: 16
+- `dripRecipes`: 2
+
+Remaining manual check: user should open the production app and confirm the restored tasting sessions and related screens render as expected.

--- a/docs/superpowers/specs/2026-05-28-tasting-data-loss-recovery.md
+++ b/docs/superpowers/specs/2026-05-28-tasting-data-loss-recovery.md
@@ -1,0 +1,141 @@
+# Tasting Data Loss Recovery Spec
+
+## 目的
+
+Issue #458 のため、本番環境の試飲感想記録データ消失について、現状確認、復旧可否判断、再発防止を行う。
+
+## 背景となる問題
+
+本番環境の「試飲感想記録」でテイスティングセッションが全消失した可能性がある。`users/{uid}` ドキュメント内の `tastingSessions` / `tastingRecords` が対象であり、本番データを扱うため読み取り確認と書き込み復旧を分けて進める必要がある。
+
+## 対象ユーザー
+
+- RoastPlus の本番利用者
+- 試飲感想記録を登録・確認する現場スタッフ
+
+## 現在の挙動
+
+- `tastingSessions` と `tastingRecords` は `users/{uid}` ドキュメントの root フィールドとして保存される。
+- `useAppData.updateData` は変更されたキーを把握できるが、従来は `saveUserData` に正規化済み `AppData` 全体を渡していた。
+- 古いタブや古いクライアント状態が別フィールドを保存すると、触っていない `tastingSessions` / `tastingRecords` も古い空配列として root ドキュメントへ送られる可能性がある。
+
+## 期待する挙動
+
+- 本番Firestoreの対象ユーザーについて、現在の `tastingSessions` / `tastingRecords` 件数を読み取り専用で確認できる。
+- Firestore PITR または backup から復旧可能か判断できる。
+- 復旧が必要な場合、復旧対象、復旧方法、ロールバック方法を提示し、明示承認後にだけ書き込む。
+- 通常のアプリ保存では、変更していない root フィールドを古い値や空配列で上書きしない。
+- `useAppData` を経由しない直接保存経路でも、変更していない root フィールドを古い値や空配列で上書きしない。
+
+## 受け入れ条件
+
+- 本番の `tastingSessions` / `tastingRecords` の現状件数を説明できる。
+- Firestore PITR または backup の利用可否を説明できる。
+- 復旧できる場合、対象データと手順、戻し方を説明してから復旧できる。
+- 復旧できない場合、理由と代替案を説明できる。
+- `updateData` 経由の保存では、変更対象外の `tastingSessions` / `tastingRecords` を空配列でFirestoreへ送らない。
+- 作業進捗や同意保存など、`saveUserData` を直接呼ぶ経路でも変更対象フィールドを明示する。
+- 上記の再発防止を自動テストで確認できる。
+
+## 具体例
+
+### 例1: 古い画面状態で通知だけを保存する
+
+- 前提: ローカル状態の `tastingSessions` / `tastingRecords` が古い空配列。
+- 操作: `encouragementCount` だけを変更して保存する。
+- 期待: Firestore root へ送る payload は `encouragementCount` のみ。`tastingSessions: []` と `tastingRecords: []` は送らない。
+
+### 例2: 作業進捗だけを保存する
+
+- 前提: `workProgresses` はサブコレクション同期対象。
+- 操作: `workProgresses` だけを変更して保存する。
+- 期待: root の `workProgresses` を増やさず、必要なサブコレクション同期だけを行う。
+
+### 例3: 利用規約への同意だけを保存する
+
+- 前提: `getUserData` で取得した `AppData` に古い tasting 配列が含まれている可能性がある。
+- 操作: `userConsent` だけを変更して保存する。
+- 期待: Firestore root へ送る payload は `userConsent` のみ。`tastingSessions` / `tastingRecords` は送らない。
+
+## 影響する画面
+
+- `/tasting`
+- `/tasting/sessions/new`
+- `/tasting/sessions/[id]`
+- 試飲感想記録の関連フォーム・一覧
+
+## 影響するデータ
+
+- `users/{uid}.tastingSessions`
+- `users/{uid}.tastingRecords`
+- 変更対象外フィールドを送らない保存制御として、同じ root ドキュメント内の他フィールドにも影響する。
+
+## 認証・認可・Firestore Rules・Storage Rules への影響
+
+- 認証・認可の仕様変更はしない。
+- Firestore Rules / Storage Rules は変更しない。
+- 本番読み取り・復旧は管理者権限のCLIまたはFirebase Consoleで実施する。
+
+## Cloud Functions への影響
+
+- なし。
+
+## やらないこと
+
+- 対象ユーザー未確定のまま、本番 `users` コレクションを広く列挙しない。
+- 明示承認なしに本番Firestoreへ復旧、上書き、削除、一括更新を行わない。
+- `tastingSessions` / `tastingRecords` の保存場所を今回のIssueでサブコレクションへ移行しない。
+
+## 未決事項
+
+- ユーザー本人の画面で `/tasting`、スケジュール、ドリップガイドが復旧後の内容を表示できるか確認する。
+
+## 本番読み取り確認結果
+
+- 対象 `uid`: ユーザーから提示された対象ユーザー
+- 現在の `users/{uid}` updateTime: `2026-05-28T05:56:33.182292Z`
+- 現在の `tastingSessions`: 0件
+- 現在の `tastingRecords`: 0件
+- PITR `2026-05-28T05:56:00Z` 時点の `tastingSessions`: 4件
+- PITR `2026-05-28T05:56:00Z` 時点の `tastingRecords`: 16件
+- PITR `2026-05-28T05:57:00Z` 時点の `tastingSessions`: 0件
+- PITR `2026-05-28T05:57:00Z` 時点の `tastingRecords`: 0件
+
+同じ更新で以下の配列フィールドも空になっている。
+
+| field | `2026-05-28T05:56:00Z` | current |
+| --- | ---: | ---: |
+| `todaySchedules` | 6 | 0 |
+| `roastSchedules` | 12 | 0 |
+| `tastingSessions` | 4 | 0 |
+| `tastingRecords` | 16 | 0 |
+| `dripRecipes` | 2 | 0 |
+
+推定原因: 古いクライアント状態または初期空状態を含む root `AppData` 全体保存により、未変更の配列フィールドが空配列で上書きされた可能性が高い。
+
+## 復旧結果
+
+ユーザー承認後、PITR `2026-05-28T05:56:00Z` から以下5フィールドだけを本番 `users/{uid}` へ書き戻した。
+
+| field | 復旧前 | 復旧後 |
+| --- | ---: | ---: |
+| `todaySchedules` | 0 | 6 |
+| `roastSchedules` | 0 | 12 |
+| `tastingSessions` | 0 | 4 |
+| `tastingRecords` | 0 | 16 |
+| `dripRecipes` | 0 | 2 |
+
+- 復旧前 updateTime: `2026-05-28T05:56:33.182292Z`
+- 復旧後 updateTime: `2026-05-28T09:22:44.847631Z`
+- 書き込み方式: REST PATCH + `updateMask` で5フィールドのみ更新
+- 安全策: 復旧前 updateTime を `currentDocument.updateTime` の前提条件に指定
+
+## 検証方法
+
+- `npm run test:run`
+- `npm run typecheck`
+- `npm run lint`
+- `npm run build`
+- `npm run test:rules`
+- `git diff --check`
+- 本番データ確認は、対象ユーザーの `users/{uid}` の件数のみ確認する。

--- a/hooks/useAppData.test.ts
+++ b/hooks/useAppData.test.ts
@@ -46,7 +46,11 @@ vi.mock('@/lib/auth', () => ({
 
 vi.mock('@/lib/firestore', () => ({
   getUserData: (userId: string) => mockGetUserData(userId),
-  saveUserData: (userId: string, data: AppData, options?: { syncWorkProgresses?: boolean }) =>
+  saveUserData: (
+    userId: string,
+    data: AppData,
+    options?: { syncWorkProgresses?: boolean; updatedFields?: (keyof AppData)[] }
+  ) =>
     mockSaveUserData(userId, data, options),
   subscribeUserData: (userId: string, callback: (data: AppData) => void) => mockSubscribeUserData(userId, callback),
   SAVE_USER_DATA_DEBOUNCE_MS: 500,
@@ -212,7 +216,7 @@ describe('useAppData', () => {
         expect.objectContaining({
           encouragementCount: 5,
         }),
-        { syncWorkProgresses: false }
+        expect.objectContaining({ syncWorkProgresses: false })
       );
       expect(result.current.data.encouragementCount).toBe(5);
     });
@@ -245,7 +249,33 @@ describe('useAppData', () => {
         expect.objectContaining({
           workProgresses: [expect.objectContaining({ id: 'wp-1' })],
         }),
-        { syncWorkProgresses: true }
+        expect.objectContaining({ syncWorkProgresses: true })
+      );
+    });
+
+    it('保存対象フィールドを変更されたキーだけに絞る', async () => {
+      const { result } = renderHook(() => useAppData());
+
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      await act(async () => {
+        await result.current.updateData((currentData) => ({
+          ...currentData,
+          encouragementCount: 7,
+        }));
+        await vi.runAllTimersAsync();
+      });
+
+      expect(mockSaveUserData).toHaveBeenCalledWith(
+        'test-user-id',
+        expect.objectContaining({
+          encouragementCount: 7,
+          tastingSessions: [],
+          tastingRecords: [],
+        }),
+        { syncWorkProgresses: false, updatedFields: ['encouragementCount'] }
       );
     });
 

--- a/hooks/useAppData.test.ts
+++ b/hooks/useAppData.test.ts
@@ -50,8 +50,7 @@ vi.mock('@/lib/firestore', () => ({
     userId: string,
     data: AppData,
     options?: { syncWorkProgresses?: boolean; updatedFields?: (keyof AppData)[] }
-  ) =>
-    mockSaveUserData(userId, data, options),
+  ) => mockSaveUserData(userId, data, options),
   subscribeUserData: (userId: string, callback: (data: AppData) => void) => mockSubscribeUserData(userId, callback),
   SAVE_USER_DATA_DEBOUNCE_MS: 500,
 }));

--- a/hooks/useAppData.ts
+++ b/hooks/useAppData.ts
@@ -288,6 +288,7 @@ export function useAppData() {
       try {
         await saveUserData(user.uid, normalizedData, {
           syncWorkProgresses: mutatedKeys.includes('workProgresses'),
+          updatedFields: mutatedKeys,
         });
       } catch (error) {
         saveError = error;

--- a/lib/firestore/userData/crud.ts
+++ b/lib/firestore/userData/crud.ts
@@ -86,9 +86,7 @@ export async function saveUserData(userId: string, data: AppData, options: SaveU
 
   // 最新のデータをキューに保存
   queue.pendingData = data;
-  queue.pendingOptions = {
-    syncWorkProgresses: queue.pendingOptions?.syncWorkProgresses === true || options.syncWorkProgresses === true,
-  };
+  queue.pendingOptions = mergeSaveUserDataOptions(queue.pendingOptions, options);
 
   // 書き込み中の場合は待機してから書き込み
   if (queue.isWriting) {
@@ -114,6 +112,31 @@ export async function saveUserData(userId: string, data: AppData, options: SaveU
   }, SAVE_USER_DATA_DEBOUNCE_MS);
 
   return promise;
+}
+
+function mergeSaveUserDataOptions(
+  previousOptions: SaveUserDataOptions | null,
+  nextOptions: SaveUserDataOptions
+): SaveUserDataOptions {
+  const syncWorkProgresses = previousOptions?.syncWorkProgresses === true || nextOptions.syncWorkProgresses === true;
+  const previousFields = previousOptions?.updatedFields;
+  const nextFields = nextOptions.updatedFields;
+
+  if (!previousOptions) {
+    return {
+      syncWorkProgresses,
+      updatedFields: nextFields,
+    };
+  }
+
+  if (!previousFields || !nextFields) {
+    return { syncWorkProgresses };
+  }
+
+  return {
+    syncWorkProgresses,
+    updatedFields: Array.from(new Set([...previousFields, ...nextFields])),
+  };
 }
 
 export function subscribeUserData(userId: string, callback: (data: AppData) => void): () => void {

--- a/lib/firestore/userData/write-queue.ts
+++ b/lib/firestore/userData/write-queue.ts
@@ -30,6 +30,7 @@ export function clearWriteQueueStateForTests(): void {
 
 export interface SaveUserDataOptions {
   syncWorkProgresses?: boolean;
+  updatedFields?: (keyof AppData)[];
 }
 
 // 最大リトライ回数
@@ -85,6 +86,27 @@ function removeRootWorkProgresses(data: Record<string, unknown>): Record<string,
   const rootData = { ...data };
   delete rootData.workProgresses;
   return rootData;
+}
+
+function pickUpdatedFields(
+  data: Record<string, unknown>,
+  updatedFields: (keyof AppData)[] | undefined
+): Record<string, unknown> {
+  if (!updatedFields) {
+    return data;
+  }
+
+  const pickedData: Record<string, unknown> = {};
+  updatedFields.forEach((field) => {
+    if (Object.prototype.hasOwnProperty.call(data, field)) {
+      pickedData[field] = data[field];
+    }
+  });
+  return pickedData;
+}
+
+function hasWritableFields(data: Record<string, unknown>): boolean {
+  return Object.keys(data).length > 0;
 }
 
 function stableStringify(value: unknown): string {
@@ -228,7 +250,10 @@ async function performWrite(userId: string, data: AppData, options: SaveUserData
     }
 
     const batchWriter = createBatchWriter();
-    batchWriter.add((batch) => batch.set(userDocRef, removeRootWorkProgresses(cleanedData), { merge: true }));
+    const rootWriteData = removeRootWorkProgresses(pickUpdatedFields(cleanedData, options.updatedFields));
+    if (hasWritableFields(rootWriteData)) {
+      batchWriter.add((batch) => batch.set(userDocRef, rootWriteData, { merge: true }));
+    }
     let syncedWorkProgressesSignature: string | null = null;
     if (options.syncWorkProgresses === true) {
       const nextSyncSignature = stableStringify(data.workProgresses);

--- a/lib/firestore/workProgress/crud.test.ts
+++ b/lib/firestore/workProgress/crud.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AppData } from '@/types';
+import { addWorkProgress } from './crud';
+
+const mocks = vi.hoisted(() => ({
+  saveUserData: vi.fn(),
+}));
+
+vi.mock('../userData', () => ({
+  saveUserData: mocks.saveUserData,
+}));
+
+function appData(): AppData {
+  return {
+    todaySchedules: [],
+    roastSchedules: [],
+    tastingSessions: [],
+    tastingRecords: [],
+    notifications: [],
+    encouragementCount: 0,
+    roastTimerRecords: [],
+    workProgresses: [],
+    dripRecipes: [],
+  };
+}
+
+describe('workProgress crud save options', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue('wp-new');
+    vi.setSystemTime(new Date('2026-05-28T00:00:00.000Z'));
+  });
+
+  it('作業進捗追加ではworkProgressesだけを保存対象にする', async () => {
+    await addWorkProgress(
+      'user-1',
+      {
+        taskName: '封入',
+        status: 'pending',
+      },
+      appData()
+    );
+
+    expect(mocks.saveUserData).toHaveBeenCalledWith(
+      'user-1',
+      expect.objectContaining({
+        workProgresses: [expect.objectContaining({ id: 'wp-new', taskName: '封入' })],
+        tastingSessions: [],
+        tastingRecords: [],
+      }),
+      { syncWorkProgresses: true, updatedFields: ['workProgresses'] }
+    );
+  });
+});

--- a/lib/firestore/workProgress/crud.ts
+++ b/lib/firestore/workProgress/crud.ts
@@ -47,6 +47,7 @@ export async function addWorkProgress(
     },
     {
       syncWorkProgresses: true,
+      updatedFields: ['workProgresses'],
     }
   );
 }
@@ -120,6 +121,7 @@ export async function updateWorkProgress(
     },
     {
       syncWorkProgresses: true,
+      updatedFields: ['workProgresses'],
     }
   );
 }
@@ -198,6 +200,7 @@ export async function updateWorkProgresses(
       },
       {
         syncWorkProgresses: true,
+        updatedFields: ['workProgresses'],
       }
     );
   }
@@ -220,6 +223,7 @@ export async function deleteWorkProgress(userId: string, workProgressId: string,
     },
     {
       syncWorkProgresses: true,
+      updatedFields: ['workProgresses'],
     }
   );
 }

--- a/lib/firestore/workProgress/progress.ts
+++ b/lib/firestore/workProgress/progress.ts
@@ -63,6 +63,7 @@ export async function addCompletedCountToWorkProgress(
     },
     {
       syncWorkProgresses: true,
+      updatedFields: ['workProgresses'],
     }
   );
 }
@@ -142,6 +143,7 @@ export async function addProgressToWorkProgress(
     },
     {
       syncWorkProgresses: true,
+      updatedFields: ['workProgresses'],
     }
   );
 }
@@ -170,6 +172,7 @@ export async function archiveWorkProgress(userId: string, workProgressId: string
     },
     {
       syncWorkProgresses: true,
+      updatedFields: ['workProgresses'],
     }
   );
 }
@@ -198,6 +201,7 @@ export async function unarchiveWorkProgress(userId: string, workProgressId: stri
     },
     {
       syncWorkProgresses: true,
+      updatedFields: ['workProgresses'],
     }
   );
 }
@@ -254,6 +258,7 @@ export async function updateProgressHistoryEntry(
     },
     {
       syncWorkProgresses: true,
+      updatedFields: ['workProgresses'],
     }
   );
 }
@@ -304,6 +309,7 @@ export async function deleteProgressHistoryEntry(
     },
     {
       syncWorkProgresses: true,
+      updatedFields: ['workProgresses'],
     }
   );
 }

--- a/lib/firestore/write-queue.test.ts
+++ b/lib/firestore/write-queue.test.ts
@@ -201,6 +201,26 @@ describe('saveUserData workProgresses split writes', () => {
     });
   });
 
+  it('更新対象外のtastingSessionsとtastingRecordsを空配列で上書きしない', async () => {
+    const { saveUserData, SAVE_USER_DATA_DEBOUNCE_MS } = await import('./userData');
+
+    const savePromise = saveUserData(
+      'user-1',
+      appData({
+        encouragementCount: 9,
+        tastingSessions: [],
+        tastingRecords: [],
+      }),
+      { updatedFields: ['encouragementCount'] }
+    );
+
+    await flushSaveTimers(SAVE_USER_DATA_DEBOUNCE_MS);
+    await savePromise;
+
+    expect(rootWritePayloads()).toHaveLength(1);
+    expect(rootWritePayloads()[0]).toEqual({ encouragementCount: 9 });
+  });
+
   it('workProgresses未変更の保存ではサブコレクションを読み書きしない', async () => {
     const { saveUserData, SAVE_USER_DATA_DEBOUNCE_MS } = await import('./userData');
 


### PR DESCRIPTION
## 対象Issue

Closes #458

## 変更内容

- 本番Firestoreで対象ユーザーの `tastingSessions` / `tastingRecords` 消失を読み取り確認し、PITRから復旧しました。
- 同じ更新で空になっていた `todaySchedules` / `roastSchedules` / `dripRecipes` も、ユーザー承認後に同じPITR時点から復旧しました。
- `saveUserData` のroot書き込みを、変更されたフィールドだけに絞れるようにしました。
- `useAppData`、作業進捗、同意保存の直接保存経路で `updatedFields` を渡すようにしました。
- 復旧仕様と作業計画を `docs/superpowers` に記録しました。

## なぜ必要か

古いクライアント状態または初期空状態を含む `AppData` 全体保存により、変更していない配列フィールドまで空配列で上書きされる可能性がありました。今回の修正では、変更対象外フィールドをFirestore payloadに含めないことで再発リスクを下げています。

## 復旧結果

PITR `2026-05-28T05:56:00Z` から以下5フィールドを復旧済みです。

- `todaySchedules`: 6件
- `roastSchedules`: 12件
- `tastingSessions`: 4件
- `tastingRecords`: 16件
- `dripRecipes`: 2件

※ 対象UIDはリポジトリ・PR本文には記載していません。

## 変更ファイル

- `hooks/useAppData.ts`: 変更されたキーを保存オプションへ渡す
- `lib/firestore/userData/write-queue.ts`: root書き込みpayloadを `updatedFields` に限定
- `lib/firestore/userData/crud.ts`: debounce中の保存オプションをマージ
- `lib/firestore/workProgress/*.ts`: 作業進捗保存で `workProgresses` だけを更新対象に指定
- `app/consent/page.tsx`: 同意保存で `userConsent` だけを更新対象に指定
- `docs/superpowers/specs|plans`: 復旧・再発防止の記録

## 検証

- [x] `npm run test:run`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test:rules`
- [x] `npm run secrets:scan:staged`
- [x] `git diff --check`

## 残リスク

- 復旧後の本番画面表示は、対象ユーザー本人のブラウザで最終確認が必要です。
- このPRがmainへ入り、本番Hostingへ反映されるまで、再発防止コードは本番アプリには反映されません。
