### PR TITLE
fix: ホームのスマホカードを角丸に統一

### DIFF
--- a/components/home/ActionCard.tsx
+++ b/components/home/ActionCard.tsx
@@ -26,7 +26,7 @@ export function ActionCard({ title, label, description, href, icon: Icon, badge,
     <Button
       variant="ghost"
       onClick={() => router.push(href)}
-      className="group relative flex max-h-[112px] w-full flex-1 flex-row !items-center !justify-start gap-3 !rounded-md border border-edge-strong bg-surface px-3 py-2 text-left text-ink shadow-card transition-all hover:bg-ground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 animate-home-card !min-h-[56px] md:max-h-none md:!min-h-0 md:flex-none md:flex-col md:!justify-center md:gap-3 md:!rounded-2xl md:p-5 md:text-center md:shadow-2xl md:hover:-translate-y-2 md:hover:bg-surface md:hover:shadow-[0_16px_40px_rgba(0,0,0,0.08)]"
+      className="group relative flex max-h-[112px] w-full flex-1 flex-row !items-center !justify-start gap-3 !rounded-xl border border-edge-strong bg-surface px-3 py-2 text-left text-ink shadow-card transition-all hover:bg-ground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 animate-home-card !min-h-[56px] md:max-h-none md:!min-h-0 md:flex-none md:flex-col md:!justify-center md:gap-3 md:!rounded-2xl md:p-5 md:text-center md:shadow-2xl md:hover:-translate-y-2 md:hover:bg-surface md:hover:shadow-[0_16px_40px_rgba(0,0,0,0.08)]"
       style={cardStyle}
       aria-label={title}
     >


### PR DESCRIPTION
@
## 目的

スマホホームのクラフトラベル型カードだけ `rounded-md`（6px）で角張っており、他ページのカード（角丸）と不統一だった。角丸を揃える。

## 変更内容

- `components/home/ActionCard.tsx`: スマホ行の角丸を `!rounded-md` → `!rounded-xl`（12px）に変更。デスクトップは従来どおり `md:!rounded-2xl`。

## 検証

- `npm run test:run -- app/page.test.tsx` → 4件合格
- lint クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@