### PR TITLE
fix: 日付キーのJST早朝ズレと配合比率の浮動小数点誤判定を修正

### DIFF
--- a/lib/dateUtils.test.ts
+++ b/lib/dateUtils.test.ts
@@ -3,21 +3,32 @@ import { formatDateString } from './dateUtils';
 
 describe('formatDateString', () => {
   it('Dateオブジェクトを YYYY-MM-DD 形式に変換する', () => {
-    const date = new Date('2024-12-25T15:30:00Z');
+    // ローカル時刻でDateを生成し、ローカル暦日が返ることを確認（タイムゾーン非依存）
+    const date = new Date(2024, 11, 25, 15, 30, 0);
     expect(formatDateString(date)).toBe('2024-12-25');
   });
 
   it('日付の時刻部分は無視される', () => {
-    const morning = new Date('2024-01-15T09:00:00Z');
-    const evening = new Date('2024-01-15T21:00:00Z');
+    const morning = new Date(2024, 0, 15, 9, 0, 0);
+    const evening = new Date(2024, 0, 15, 21, 0, 0);
 
     expect(formatDateString(morning)).toBe('2024-01-15');
     expect(formatDateString(evening)).toBe('2024-01-15');
   });
 
-  it('引数なしの場合は現在日時を使用する', () => {
-    // 現在日時をモック
-    const mockDate = new Date('2024-06-15T12:00:00Z');
+  it('JST早朝(0〜8時台)でも前日にならずローカル暦日を返す', () => {
+    // toISOString()(UTC基準)実装では JST 06:00 が前日(UTC 前日21:00)に化ける。
+    // 早朝稼働の焙煎現場でデフォルト日付が前日になる回帰を防ぐ。
+    const earlyMorning = new Date(2026, 4, 30, 6, 0, 0); // ローカル 2026-05-30 06:00
+    expect(formatDateString(earlyMorning)).toBe('2026-05-30');
+
+    const justAfterMidnight = new Date(2026, 4, 30, 0, 30, 0); // ローカル 2026-05-30 00:30
+    expect(formatDateString(justAfterMidnight)).toBe('2026-05-30');
+  });
+
+  it('引数なしの場合は現在日時(ローカル暦日)を使用する', () => {
+    // 現在日時をモック（ローカル早朝でも当日になることを確認）
+    const mockDate = new Date(2024, 5, 15, 6, 0, 0);
     vi.setSystemTime(mockDate);
 
     expect(formatDateString()).toBe('2024-06-15');
@@ -27,13 +38,13 @@ describe('formatDateString', () => {
   });
 
   it('閏年の日付を正しく処理する', () => {
-    const leapDay = new Date('2024-02-29T00:00:00Z');
+    const leapDay = new Date(2024, 1, 29, 0, 0, 0);
     expect(formatDateString(leapDay)).toBe('2024-02-29');
   });
 
   it('年末年始の日付を正しく処理する', () => {
-    const newYear = new Date('2024-01-01T00:00:00Z');
-    const newYearEve = new Date('2024-12-31T23:59:59Z');
+    const newYear = new Date(2024, 0, 1, 0, 0, 0);
+    const newYearEve = new Date(2024, 11, 31, 23, 59, 59);
 
     expect(formatDateString(newYear)).toBe('2024-01-01');
     expect(formatDateString(newYearEve)).toBe('2024-12-31');

--- a/lib/dateUtils.ts
+++ b/lib/dateUtils.ts
@@ -4,9 +4,16 @@
 
 /**
  * DateオブジェクトをYYYY-MM-DD形式の文字列に変換
+ *
+ * ローカルタイムゾーンの暦日を返す。toISOString()(UTC基準)を使うと
+ * JST(UTC+9)の早朝(0:00〜8:59)に前日へずれるため、ローカルの年月日から組み立てる。
+ *
  * @param date 変換対象の日付（省略時は現在日時）
  * @returns YYYY-MM-DD形式の文字列
  */
 export function formatDateString(date: Date = new Date()): string {
-  return date.toISOString().split('T')[0];
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
 }

--- a/lib/productionRecords.test.ts
+++ b/lib/productionRecords.test.ts
@@ -437,6 +437,27 @@ describe('validateBlendItems', () => {
       ])
     ).toThrow();
   });
+
+  it('浮動小数点で合計が約100%(33.3+33.3+33.4)の配合を許可する', () => {
+    // sum !== 100 の厳密等価では 100.00000000000001 となり正当な配合が誤って弾かれる
+    expect(() =>
+      validateBlendItems([
+        { beanName: 'a', ratioPercent: 33.3 },
+        { beanName: 'b', ratioPercent: 33.3 },
+        { beanName: 'c', ratioPercent: 33.4 },
+      ])
+    ).not.toThrow();
+  });
+
+  it('合計が明確に100%から外れる場合(誤差0.01超)はエラー', () => {
+    expect(() =>
+      validateBlendItems([
+        { beanName: 'a', ratioPercent: 33.3 },
+        { beanName: 'b', ratioPercent: 33.3 },
+        { beanName: 'c', ratioPercent: 33.3 },
+      ])
+    ).toThrow();
+  });
 });
 
 describe('buildProductionRecordMonth', () => {

--- a/lib/productionRecords.ts
+++ b/lib/productionRecords.ts
@@ -228,7 +228,9 @@ export function validateBlendItems(items: BlendItem[]): void {
     sum += item.ratioPercent;
   }
 
-  if (sum !== 100) {
+  // 浮動小数点の丸め誤差(例: 33.3+33.3+33.4=100.00000000000001)で正当な配合が
+  // 弾かれないよう、厳密等価ではなく許容誤差で合計100%を判定する。
+  if (Math.abs(sum - 100) > 0.01) {
     throw new Error(BLEND_ITEMS_ERROR);
   }
 }


### PR DESCRIPTION
## 対象

多次元コード監査で検出・実コードで裏取りした correctness バグ2件を、TDD で修正しました。いずれも純粋関数の修正で、static export / Firebase / 既存の呼び出し元の前提を壊しません。

## 変更内容

### 1. `formatDateString` の JST 早朝の日付ズレ（`lib/dateUtils.ts`）
- **問題**: `date.toISOString().split('T')[0]` は常に UTC 基準のため、JST(UTC+9)環境で 0:00〜8:59 に呼ぶと前日の `YYYY-MM-DD` を返していました。例: ローカル `2026-05-30 06:00 JST` → `2026-05-29`。
- **影響**: 試飲記録フォーム（`TastingSessionForm` / `TastingRecordForm`）が引数なし `formatDateString()` を「今日」の初期値に使っており、**早朝稼働の現場で前日付が初期表示される**経路がありました。
- **修正**: `getFullYear` / `getMonth` / `getDate` でローカル暦日を組み立てる方式に変更。

### 2. 配合比率の浮動小数点による誤判定（`lib/productionRecords.ts`）
- **問題**: `validateBlendItems` の合計判定が `sum !== 100` の厳密等価で、`33.3 + 33.3 + 33.4` のような小数配合が IEEE754 の丸め誤差（`100.00000000000001`）で誤って弾かれ、月次レコードが保存できなくなる可能性がありました。
- **修正**: `Math.abs(sum - 100) > 0.01` の許容誤差判定に変更。

## テスト（TDD: Red → Green を確認）

- `lib/dateUtils.test.ts`: JST 早朝（06:00 / 00:30）でも当日を返す回帰テストを追加。既存テストもローカル時刻ベースに統一。
- `lib/productionRecords.test.ts`: 小数合計100%（33.3×3）が許可され、明確に外れる場合（誤差0.01超）はエラーになることを追加。**修正を外すと新テストがちょうど1件 Red になることを確認済み**。

## 危険度チェック

| 項目 | 危険度 | 補足 |
|---|---|---|
| データ保存ロジック | 低 | 純粋関数の修正のみ。保存パス自体は不変 |
| 集計ロジック | 低 | 日付キー生成がローカル暦日に正確化（むしろ正しくなる） |
| 認証 / Rules / 削除 / 上書き | なし | 変更なし |

## 検証

- `npm run typecheck` ✅ (exit 0)
- `npm run test:run` ✅ (全テスト合格)
- `npm run build` ✅ (static export 成功)
- `npm run format:check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)