### PR TITLE
docs: FirestoreとStorageの最低限のバックアップ運用手順を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ Remove-Item Env:E2E_PORT
 
 ---
 
+## 運用ドキュメント
+
+- [バックアップ運用手順](docs/steering/BACKUP_OPERATIONS.md) — Firestore / Storage の手動バックアップ・復元手順
+
+---
+
 ## ライセンス
 
 社内運用向けの実用コードとして管理し、利用範囲や導入方針はリポジトリ内の運用ルールに従って判断してください。

--- a/docs/steering/BACKUP_OPERATIONS.md
+++ b/docs/steering/BACKUP_OPERATIONS.md
@@ -1,0 +1,167 @@
+# バックアップ運用手順
+
+**最終更新**: 2026-05-31
+
+Firestore / Storage の最低限のバックアップ・復元手順をまとめる。
+小規模・手動運用を前提とし、まずは「迷わず実行・復元できる」ことを優先する。
+
+---
+
+## 前提・運用方針
+
+| 項目 | 内容 |
+|---|---|
+| 対象 | Firestore（全コレクション） + Storage（アップロード画像など） |
+| 方法 | 手動マネージドエクスポート（自動ジョブは作らない） |
+| 実行頻度 | **週1回**（曜日を固定して実施。例: 毎週月曜） |
+| 保存先 | GCS バックアップ用バケット `gs://roastplus-72fa6-backups` |
+| 担当者 | IK |
+| プロジェクト | `roastplus-72fa6` |
+
+> このドキュメントは「手順を決める」ことが目的です。
+> 実際の本番 export / import や Firebase・Google Cloud の本番設定変更は、**別途ユーザー（IK）の承認のうえで実施**します。コマンドを載せていますが、内容を理解せずそのまま流さないでください。
+
+### やらないこと（このフェーズの範囲外）
+
+- 自動バックアップジョブ（スケジュールバックアップ）の構築
+- 本番データの実 export / import の実行
+- Firebase / Google Cloud の本番設定変更
+
+---
+
+## 事前準備（初回のみ）
+
+### 1. gcloud CLI のインストールとログイン
+
+```powershell
+# インストール済みかの確認
+gcloud --version
+
+# Google アカウントでログイン（ブラウザが開く）
+gcloud auth login
+
+# 対象プロジェクトを選択
+gcloud config set project roastplus-72fa6
+
+# Firebase 側でも対象プロジェクトを確認
+firebase use
+firebase projects:list
+```
+
+### 2. バックアップ用バケットの作成
+
+Firestore のデータと同じリージョンに作るのが安全です（リージョンが異なると export 先に指定できない場合があります）。
+
+```powershell
+# 既存バケット一覧の確認（Storage の本番バケット名もここで分かる）
+gcloud storage ls
+
+# バックアップ用バケットを作成（リージョンは Firestore に合わせる。例: 東京 asia-northeast1）
+gcloud storage buckets create gs://roastplus-72fa6-backups --location=asia-northeast1
+```
+
+> Storage の本番バケット名は `roastplus-72fa6.firebasestorage.app` または `roastplus-72fa6.appspot.com` のいずれかです。上記 `gcloud storage ls` の結果で実際の名前を確認してください（以降 `<STORAGE_BUCKET>` と表記）。
+
+### 3. 権限
+
+実行アカウントに以下のロールが必要です（足りない場合は Google Cloud コンソールで付与）。
+
+- `roles/datastore.importExportAdmin`（Firestore の export / import）
+- バックアップ用バケットへの書き込み権限（`roles/storage.admin` など）
+
+---
+
+## Firestore のバックアップ手順
+
+全コレクションを日付付きフォルダにエクスポートします。
+
+```powershell
+# 日付文字列を用意（例: 20260531）
+$date = Get-Date -Format "yyyyMMdd"
+
+# Firestore 全データを GCS へエクスポート
+gcloud firestore export "gs://roastplus-72fa6-backups/firestore/$date"
+```
+
+- 出力先は `gs://roastplus-72fa6-backups/firestore/<日付>/` 配下に作られます。
+- 完了確認:
+
+```powershell
+gcloud storage ls "gs://roastplus-72fa6-backups/firestore/"
+```
+
+---
+
+## Storage のバックアップ手順
+
+本番 Storage バケットの中身を、バックアップ用バケットへ複製します。
+
+```powershell
+$date = Get-Date -Format "yyyyMMdd"
+
+# <STORAGE_BUCKET> は事前準備で確認した本番バケット名に置き換える
+gcloud storage rsync -r "gs://<STORAGE_BUCKET>" "gs://roastplus-72fa6-backups/storage/$date"
+```
+
+- `-r` はサブフォルダも含めて再帰的にコピーする指定です。
+- 完了確認:
+
+```powershell
+gcloud storage ls "gs://roastplus-72fa6-backups/storage/"
+```
+
+---
+
+## 復元手順と注意
+
+> ⚠️ **復元は本番データを壊しうる操作です。いきなり本番へ import しないでください。**
+
+### 復元の基本方針
+
+1. **まず本番以外で確認する**
+   復元したいデータは、別の Firestore データベース（テスト用）や別プロジェクトに import して内容を確認してから判断します。本番への反映はそのあと。
+2. **本番への import は都度ユーザー（IK）承認が必須**
+   import は既存データへの上書き・追加になり得ます。実行前に「何を・どこへ・なぜ戻すか」を確認してから行います。
+3. **作業前に現状をもう一度バックアップ**
+   復元前の本番状態も別フォルダに export しておくと、切り戻しできます。
+
+### Firestore の復元（参考コマンド）
+
+```powershell
+# 例: 2026-05-31 のバックアップを戻す
+gcloud firestore import "gs://roastplus-72fa6-backups/firestore/20260531"
+```
+
+### Storage の復元（参考コマンド）
+
+```powershell
+# バックアップ用バケットから本番バケットへ戻す（上書きに注意）
+gcloud storage rsync -r "gs://roastplus-72fa6-backups/storage/20260531" "gs://<STORAGE_BUCKET>"
+```
+
+> コマンドの正確な構文・オプションは実行前に必ず公式ドキュメントで最新版を確認してください。
+> - Firestore: <https://firebase.google.com/docs/firestore/manage-data/export-import>
+> - Cloud Storage: <https://cloud.google.com/storage/docs/gsutil/commands/rsync>
+
+---
+
+## 実行記録（任意）
+
+実施したら以下に1行残すと、頻度と担当の管理が楽になります。
+
+| 実施日 | 担当 | 対象 | 保存先パス | 備考 |
+|---|---|---|---|---|
+| 2026-05-31（例） | IK | Firestore + Storage | `.../firestore/20260531`, `.../storage/20260531` | 初回 |
+
+---
+
+## 確認コマンド（本番操作なし）
+
+現状の確認だけ行いたいときに使います。データは変更しません。
+
+```powershell
+firebase use
+firebase projects:list
+gcloud config get-value project
+gcloud storage ls
+```


### PR DESCRIPTION
## 対象Issue
Closes #454

## 変更したファイル
- `docs/steering/BACKUP_OPERATIONS.md`（新規）
- `README.md`（運用ドキュメントへのリンク1行追加）

## 変更内容
小規模・手動運用を前提に、Firestore / Storage のバックアップ・復元手順をドキュメント化した。

決定した方針（ユーザー承認済み）:
- **Firestore**: 手動マネージドエクスポート（`gcloud firestore export`）。自動ジョブは作らない
- **Storage**: バックアップ対象に含める（`gcloud storage rsync`）
- **頻度**: 週1回
- **保存先**: `gs://roastplus-72fa6-backups`（日付付きフォルダ）
- **担当者**: IK

## なぜこの修正が必要か
全体監査で、バックアップの実行頻度・保存先・担当者・復元手順がコードからは確認できなかった。運用で迷わないよう最低限の手順を明文化する。

## issue完了条件の充足
- [x] 手動バックアップの手順がドキュメント化されている
- [x] 復元時にいきなり本番へ import しない注意を明記（⚠️付き）
- [x] 本番操作が必要な場合は別途ユーザー承認が必要だと明記

## 実行した確認
- `npm run format:check` → グリーン（※ `.md` は Prettier 対象外。build/test/lint も今回の変更対象外）

## 残っているリスク・意図的に触らなかった範囲
- issueの「やらないこと」に従い、自動バックアップジョブの構築・実データの export/import・本番設定変更は**行っていない**
- ドキュメント内のコマンドは未実行（本番操作は別途ユーザー承認のうえで実施する前提）
- Storage の本番バケット名は環境で確認する想定で `<STORAGE_BUCKET>` プレースホルダ表記にしている

🤖 Generated with [Claude Code](https://claude.com/claude-code)