### PR TITLE
fix: データ安全コア — オフライン永続化・保存失敗の可視化・白画面防止 (テーマA rank1+2+3+4)

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import Link from 'next/link';
+import { Button } from '@/components/ui/Button';
+
+export default function Error({
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center gap-4 px-6 text-center bg-page">
+      <h1 className="text-xl font-bold text-ink">一時的な問題が発生しました</h1>
+      <p className="text-sm text-ink-sub">
+        お手数ですが、再読み込みしてください。入力中のデータは保存されている場合があります。
+      </p>
+      <div className="flex gap-3">
+        <Button type="button" variant="primary" size="sm" onClick={() => reset()}>
+          再読み込み
+        </Button>
+        <Link
+          href="/"
+          className="min-h-[44px] px-5 rounded-xl border border-edge text-ink text-[15px] font-semibold flex items-center"
+        >
+          ホームへ
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -3,12 +3,7 @@
 import Link from 'next/link';
 import { Button } from '@/components/ui/Button';
 
-export default function Error({
-  reset,
-}: {
-  error: Error & { digest?: string };
-  reset: () => void;
-}) {
+export default function Error({ reset }: { error: Error & { digest?: string }; reset: () => void }) {
   return (
     <div className="min-h-screen flex flex-col items-center justify-center gap-4 px-6 text-center bg-page">
       <h1 className="text-xl font-bold text-ink">一時的な問題が発生しました</h1>

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+export default function GlobalError({
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <html lang="ja">
+      <body
+        style={{
+          margin: 0,
+          minHeight: '100vh',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: '16px',
+          padding: '24px',
+          fontFamily: 'system-ui, sans-serif',
+          background: '#f7f7f5',
+          color: '#261a14',
+          textAlign: 'center',
+        }}
+      >
+        <h1 style={{ fontSize: '20px', fontWeight: 700, margin: 0 }}>一時的な問題が発生しました</h1>
+        <p style={{ fontSize: '14px', margin: 0, opacity: 0.8 }}>
+          お手数ですが、再読み込みしてください。入力中のデータは保存されている場合があります。
+        </p>
+        {/* eslint-disable-next-line local/no-raw-button -- global-error は globals.css 未読込のため UI コンポーネント使用不可 */}
+        <button
+          type="button"
+          onClick={() => reset()}
+          style={{
+            minHeight: '44px',
+            padding: '0 20px',
+            borderRadius: '12px',
+            border: 'none',
+            background: '#e48003',
+            color: '#ffffff',
+            fontSize: '15px',
+            fontWeight: 600,
+            cursor: 'pointer',
+          }}
+        >
+          再読み込み
+        </button>
+      </body>
+    </html>
+  );
+}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-export default function GlobalError({
-  reset,
-}: {
-  error: Error & { digest?: string };
-  reset: () => void;
-}) {
+export default function GlobalError({ reset }: { error: Error & { digest?: string }; reset: () => void }) {
   return (
     <html lang="ja">
       <body

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from 'next';
 import localFont from 'next/font/local';
 
+import { OfflineBanner } from '@/components/OfflineBanner';
 import { ServiceWorkerRegistration } from '@/components/ServiceWorkerRegistration';
 import { SplashScreenWrapper } from '@/components/SplashScreenWrapper';
 import { ThemeProvider } from '@/components/ThemeProvider';
@@ -66,7 +67,10 @@ export default function RootLayout({
         <SplashScreenWrapper />
         <ServiceWorkerRegistration />
         <ThemeProvider>
-          <ToastProvider>{children}</ToastProvider>
+          <ToastProvider>
+            <OfflineBanner />
+            {children}
+          </ToastProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, Suspense } from 'react';
+import { useState, useEffect, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { signInWithEmailAndPassword } from 'firebase/auth';
 import { auth } from '@/lib/firebase';
@@ -8,6 +8,7 @@ import { Loading } from '@/components/Loading';
 import { Input, Button } from '@/components/ui';
 import { E2E_EMAIL, E2E_PASSWORD, isE2EMode, signInE2EUser } from '@/lib/e2eMode';
 import { getSafeReturnUrl } from '@/lib/returnUrl';
+import { useToastContext } from '@/components/Toast';
 
 function LoginForm() {
   const [email, setEmail] = useState('');
@@ -16,6 +17,18 @@ function LoginForm() {
   const [error, setError] = useState<string | null>(null);
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { showToast } = useToastContext();
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (window.localStorage.getItem('roastplus_cache_clear_failed') === '1') {
+      window.localStorage.removeItem('roastplus_cache_clear_failed');
+      showToast(
+        'ログアウト時に端末内のデータを完全に消去できませんでした。共有端末の場合は、他のRoastPlusのタブを閉じてからもう一度ログアウトしてください。',
+        'error'
+      );
+    }
+  }, [showToast]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 import { useAuth, signOut } from '@/lib/auth';
 import { useDeveloperMode } from '@/hooks/useDeveloperMode';
 import { useAppTheme } from '@/hooks/useAppTheme';
@@ -19,7 +18,6 @@ import { formatConsentDate } from '@/lib/consent';
 import { UserConsent } from '@/types';
 
 export default function SettingsPage() {
-  const router = useRouter();
   const { user, loading: authLoading } = useAuth();
   const {
     isAvailable: isDeveloperModeAvailable,
@@ -85,7 +83,8 @@ export default function SettingsPage() {
   const handleLogout = async () => {
     try {
       await signOut();
-      router.push('/login');
+      // signOut で Firestore インスタンスを終了したため、フルリロードで再初期化する
+      window.location.href = '/login';
     } catch (error) {
       console.error('ログアウトエラー:', error);
       showToast('ログアウトに失敗しました。', 'error');

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -86,8 +86,15 @@ export default function SettingsPage() {
       // signOut で Firestore インスタンスを終了したため、フルリロードで再初期化する
       window.location.href = '/login';
     } catch (error) {
+      if (error instanceof Error && error.name === 'OfflineLogoutError') {
+        showToast(
+          'オフラインです。変更を保存し安全にログアウトするため、通信が回復してからもう一度お試しください。',
+          'error'
+        );
+        return;
+      }
       console.error('ログアウトエラー:', error);
-      showToast('ログアウトに失敗しました。', 'error');
+      showToast('ログアウトに失敗しました。他のタブを閉じてからもう一度お試しください。', 'error');
     }
   };
 

--- a/app/tasting/page.tsx
+++ b/app/tasting/page.tsx
@@ -79,17 +79,18 @@ function TastingPageContent() {
       const updatedSessions = tastingSessions.map((s) =>
         s.id === sessionId ? { ...updatedSession, userId: user.uid } : s
       );
-      showToast('セッションを更新しました', 'success');
       router.push('/tasting');
       Promise.resolve(
         updateData({
           ...data,
           tastingSessions: updatedSessions,
         })
-      ).catch((error) => {
-        console.error('Failed to update session:', error);
-        showToast('セッションの更新に失敗しました', 'error');
-      });
+      )
+        .then(() => showToast('セッションを更新しました', 'success'))
+        .catch((error) => {
+          console.error('Failed to update session:', error);
+          showToast('セッションの更新に失敗しました', 'error');
+        });
     };
 
     const handleDelete = (id: string) => {
@@ -156,17 +157,18 @@ function TastingPageContent() {
       const updatedRecords = tastingRecords.map((r) =>
         r.id === recordId ? { ...updatedRecord, userId: user.uid } : r
       );
-      showToast('記録を保存しました', 'success');
       router.push('/tasting');
       Promise.resolve(
         updateData({
           ...data,
           tastingRecords: updatedRecords,
         })
-      ).catch((error) => {
-        console.error('Failed to save record:', error);
-        showToast('記録の保存に失敗しました', 'error');
-      });
+      )
+        .then(() => showToast('記録を保存しました', 'success'))
+        .catch((error) => {
+          console.error('Failed to save record:', error);
+          showToast('記録の保存に失敗しました', 'error');
+        });
     };
 
     const handleDelete = (id: string) => {
@@ -175,18 +177,19 @@ function TastingPageContent() {
 
       const updatedRecords = tastingRecords.filter((r) => r.id !== id);
       setIsRedirectingAfterDelete(true);
-      showToast('記録を削除しました', 'success');
       router.push('/tasting');
       Promise.resolve(
         updateData({
           ...data,
           tastingRecords: updatedRecords,
         })
-      ).catch((error) => {
-        console.error('Failed to delete record:', error);
-        setIsRedirectingAfterDelete(false);
-        showToast('記録の削除に失敗しました', 'error');
-      });
+      )
+        .then(() => showToast('記録を削除しました', 'success'))
+        .catch((error) => {
+          console.error('Failed to delete record:', error);
+          setIsRedirectingAfterDelete(false);
+          showToast('記録の削除に失敗しました', 'error');
+        });
     };
 
     const handleCancel = () => {

--- a/app/tasting/page.tsx
+++ b/app/tasting/page.tsx
@@ -75,43 +75,43 @@ function TastingPageContent() {
       );
     }
 
-    const handleSave = async (updatedSession: TastingSession) => {
-      try {
-        const updatedSessions = tastingSessions.map((s) =>
-          s.id === sessionId ? { ...updatedSession, userId: user.uid } : s
-        );
-        await updateData({
+    const handleSave = (updatedSession: TastingSession) => {
+      const updatedSessions = tastingSessions.map((s) =>
+        s.id === sessionId ? { ...updatedSession, userId: user.uid } : s
+      );
+      showToast('セッションを更新しました', 'success');
+      router.push('/tasting');
+      Promise.resolve(
+        updateData({
           ...data,
           tastingSessions: updatedSessions,
-        });
-        showToast('セッションを更新しました', 'success');
-        router.push('/tasting');
-      } catch (error) {
+        })
+      ).catch((error) => {
         console.error('Failed to update session:', error);
         showToast('セッションの更新に失敗しました', 'error');
-      }
+      });
     };
 
-    const handleDelete = async (id: string) => {
+    const handleDelete = (id: string) => {
       const confirmDelete = window.confirm('このセッションを削除しますか？この操作は取り消せません。');
       if (!confirmDelete) return;
 
-      try {
-        setIsRedirectingAfterDelete(true);
-        // セッションに関連する記録も削除
-        const updatedRecords = tastingRecords.filter((r) => r.sessionId !== id);
-        const updatedSessions = tastingSessions.filter((s) => s.id !== id);
-        await updateData({
+      // セッションに関連する記録も削除
+      const updatedRecords = tastingRecords.filter((r) => r.sessionId !== id);
+      const updatedSessions = tastingSessions.filter((s) => s.id !== id);
+      setIsRedirectingAfterDelete(true);
+      router.push('/tasting');
+      Promise.resolve(
+        updateData({
           ...data,
           tastingSessions: updatedSessions,
           tastingRecords: updatedRecords,
-        });
-        router.push('/tasting');
-      } catch (error) {
+        })
+      ).catch((error) => {
         console.error('Failed to delete session:', error);
         setIsRedirectingAfterDelete(false);
         showToast('セッションの削除に失敗しました', 'error');
-      }
+      });
     };
 
     const handleCancel = () => {
@@ -152,41 +152,41 @@ function TastingPageContent() {
       );
     }
 
-    const handleSave = async (updatedRecord: TastingRecord) => {
-      try {
-        const updatedRecords = tastingRecords.map((r) =>
-          r.id === recordId ? { ...updatedRecord, userId: user.uid } : r
-        );
-        await updateData({
+    const handleSave = (updatedRecord: TastingRecord) => {
+      const updatedRecords = tastingRecords.map((r) =>
+        r.id === recordId ? { ...updatedRecord, userId: user.uid } : r
+      );
+      showToast('記録を保存しました', 'success');
+      router.push('/tasting');
+      Promise.resolve(
+        updateData({
           ...data,
           tastingRecords: updatedRecords,
-        });
-        showToast('記録を保存しました', 'success');
-        router.push('/tasting');
-      } catch (error) {
+        })
+      ).catch((error) => {
         console.error('Failed to save record:', error);
         showToast('記録の保存に失敗しました', 'error');
-      }
+      });
     };
 
-    const handleDelete = async (id: string) => {
+    const handleDelete = (id: string) => {
       const confirmDelete = window.confirm('この記録を削除しますか？');
       if (!confirmDelete) return;
 
-      try {
-        setIsRedirectingAfterDelete(true);
-        const updatedRecords = tastingRecords.filter((r) => r.id !== id);
-        await updateData({
+      const updatedRecords = tastingRecords.filter((r) => r.id !== id);
+      setIsRedirectingAfterDelete(true);
+      showToast('記録を削除しました', 'success');
+      router.push('/tasting');
+      Promise.resolve(
+        updateData({
           ...data,
           tastingRecords: updatedRecords,
-        });
-        showToast('記録を削除しました', 'success');
-        router.push('/tasting');
-      } catch (error) {
+        })
+      ).catch((error) => {
         console.error('Failed to delete record:', error);
         setIsRedirectingAfterDelete(false);
         showToast('記録の削除に失敗しました', 'error');
-      }
+      });
     };
 
     const handleCancel = () => {

--- a/app/tasting/sessions/new/page.tsx
+++ b/app/tasting/sessions/new/page.tsx
@@ -40,26 +40,25 @@ export default function NewTastingSessionPage() {
 
   const tastingSessions = Array.isArray(data.tastingSessions) ? data.tastingSessions : [];
 
-  const handleSave = async (session: TastingSession) => {
-    try {
-      const newSession: TastingSession = {
-        ...session,
-        userId: user.uid,
-      };
+  const handleSave = (session: TastingSession) => {
+    const newSession: TastingSession = {
+      ...session,
+      userId: user.uid,
+    };
 
-      const updatedSessions = [...tastingSessions, newSession];
-      await updateData({
+    const updatedSessions = [...tastingSessions, newSession];
+    // 楽観的UI: 先に遷移し、バックグラウンドで保存する
+    // 静的エクスポート時には動的ルートが存在しないため、一覧ページに遷移する
+    router.push('/tasting');
+    Promise.resolve(
+      updateData({
         ...data,
         tastingSessions: updatedSessions,
-      });
-
-      // 保存が完了してから試飲記録一覧ページに遷移
-      // 静的エクスポート時には動的ルートが存在しないため、一覧ページに遷移する
-      router.push('/tasting');
-    } catch (error) {
+      })
+    ).catch((error) => {
       console.error('Failed to save tasting session:', error);
-      showToast('セッションの保存に失敗しました。もう一度お試しください。', 'error');
-    }
+      showToast('セッションの保存に失敗しました。通信を確認してもう一度お試しください。', 'error');
+    });
   };
 
   const handleCancel = () => {

--- a/app/tasting/sessions/new/page.tsx
+++ b/app/tasting/sessions/new/page.tsx
@@ -40,25 +40,34 @@ export default function NewTastingSessionPage() {
 
   const tastingSessions = Array.isArray(data.tastingSessions) ? data.tastingSessions : [];
 
-  const handleSave = (session: TastingSession) => {
+  const handleSave = async (session: TastingSession) => {
     const newSession: TastingSession = {
       ...session,
       userId: user.uid,
     };
 
-    const updatedSessions = [...tastingSessions, newSession];
-    // 楽観的UI: 先に遷移し、バックグラウンドで保存する
-    // 静的エクスポート時には動的ルートが存在しないため、一覧ページに遷移する
-    router.push('/tasting');
-    Promise.resolve(
-      updateData({
-        ...data,
-        tastingSessions: updatedSessions,
-      })
-    ).catch((error) => {
-      console.error('Failed to save tasting session:', error);
-      showToast('セッションの保存に失敗しました。通信を確認してもう一度お試しください。', 'error');
-    });
+    const next = {
+      ...data,
+      tastingSessions: [...tastingSessions, newSession],
+    };
+
+    if (typeof navigator !== 'undefined' && navigator.onLine) {
+      // オンライン: 保存成功を待ってから遷移。失敗時はフォームを残して再入力できるようにする。
+      try {
+        await updateData(next);
+        router.push('/tasting');
+      } catch (error) {
+        console.error('Failed to save tasting session:', error);
+        showToast('セッションの保存に失敗しました。もう一度お試しください。', 'error');
+      }
+    } else {
+      // オフライン: 書き込みはローカルキューに入り、接続復帰時に自動同期される。遷移してよい。
+      router.push('/tasting');
+      Promise.resolve(updateData(next)).catch((error) => {
+        console.error('Failed to save tasting session:', error);
+        showToast('セッションの保存に失敗しました。通信を確認してください。', 'error');
+      });
+    }
   };
 
   const handleCancel = () => {

--- a/app/tasting/sessions/new/page.tsx
+++ b/app/tasting/sessions/new/page.tsx
@@ -6,7 +6,7 @@ import { useAuth } from '@/lib/auth';
 import { useAppData } from '@/hooks/useAppData';
 import { TastingSessionForm } from '@/components/TastingSessionForm';
 import { Loading } from '@/components/Loading';
-import type { TastingSession } from '@/types';
+import type { AppData, TastingSession } from '@/types';
 import { useToastContext } from '@/components/Toast';
 import { FloatingNav } from '@/components/ui';
 
@@ -41,33 +41,31 @@ export default function NewTastingSessionPage() {
   const tastingSessions = Array.isArray(data.tastingSessions) ? data.tastingSessions : [];
 
   const handleSave = async (session: TastingSession) => {
-    const newSession: TastingSession = {
-      ...session,
-      userId: user.uid,
-    };
+    const newSession: TastingSession = { ...session, userId: user.uid };
+    const next: AppData = { ...data, tastingSessions: [...tastingSessions, newSession] };
 
-    const next = {
-      ...data,
-      tastingSessions: [...tastingSessions, newSession],
-    };
-
-    if (typeof navigator !== 'undefined' && navigator.onLine) {
-      // オンライン: 保存成功を待ってから遷移。失敗時はフォームを残して再入力できるようにする。
-      try {
-        await updateData(next);
-        router.push('/tasting');
-      } catch (error) {
+    // 保存を投げ、結果(成功/失敗)を待つ。ただし一定時間で応答が来なければ
+    // (オフライン/到達不能とみなして)ローカルにキュー済みとして楽観的に遷移する。
+    const SAVE_WAIT_MS = 4000;
+    const savePromise = Promise.resolve(updateData(next)).then(
+      () => 'ok' as const,
+      (error) => {
         console.error('Failed to save tasting session:', error);
-        showToast('セッションの保存に失敗しました。もう一度お試しください。', 'error');
+        return 'error' as const;
       }
-    } else {
-      // オフライン: 書き込みはローカルキューに入り、接続復帰時に自動同期される。遷移してよい。
-      router.push('/tasting');
-      Promise.resolve(updateData(next)).catch((error) => {
-        console.error('Failed to save tasting session:', error);
-        showToast('セッションの保存に失敗しました。通信を確認してください。', 'error');
-      });
+    );
+    const outcome = await Promise.race([
+      savePromise,
+      new Promise<'pending'>((resolve) => setTimeout(() => resolve('pending'), SAVE_WAIT_MS)),
+    ]);
+
+    if (outcome === 'error') {
+      // すぐに失敗した(rules/quota等)。フォームを残して再入力できるようにする。
+      showToast('セッションの保存に失敗しました。もう一度お試しください。', 'error');
+      return;
     }
+    // 'ok'(保存成功) または 'pending'(応答待ち=ローカルにキュー済み)。どちらも遷移してよい。
+    router.push('/tasting');
   };
 
   const handleCancel = () => {

--- a/components/OfflineBanner.tsx
+++ b/components/OfflineBanner.tsx
@@ -13,7 +13,7 @@ export function OfflineBanner() {
     <div
       role="status"
       aria-live="polite"
-      className="fixed top-0 inset-x-0 z-[60] bg-warning text-page text-center text-sm font-medium py-1.5 px-4"
+      className="fixed top-0 inset-x-0 z-40 pointer-events-none bg-warning text-page text-center text-sm font-medium py-1.5 px-4"
     >
       オフライン：変更は接続が戻ったときに保存されます
     </div>

--- a/components/OfflineBanner.tsx
+++ b/components/OfflineBanner.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useOnlineStatus } from '@/hooks/useOnlineStatus';
+
+export function OfflineBanner() {
+  const isOnline = useOnlineStatus();
+
+  if (isOnline) {
+    return null;
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed top-0 inset-x-0 z-[60] bg-warning text-page text-center text-sm font-medium py-1.5 px-4"
+    >
+      オフライン：変更は接続が戻ったときに保存されます
+    </div>
+  );
+}

--- a/components/RoastSchedulerTab.tsx
+++ b/components/RoastSchedulerTab.tsx
@@ -151,14 +151,13 @@ export function RoastSchedulerTab({
       roastSchedules: updatedSchedules,
     };
 
-    try {
-      await onUpdate(updatedData);
-    } catch (error) {
-      console.error('Failed to save schedule:', error);
-      showToast('スケジュールの保存に失敗しました。通信を確認してもう一度お試しください。', 'error');
-    }
+    // オフラインでもUIを即座に閉じる(楽観的更新)。保存はバックグラウンドで行い、失敗時のみトースト。
     setIsAdding(false);
     setEditingSchedule(null);
+    Promise.resolve(onUpdate(updatedData)).catch((error) => {
+      console.error('Failed to save schedule:', error);
+      showToast('スケジュールの保存に失敗しました。通信を確認してもう一度お試しください。', 'error');
+    });
   };
 
   const handleDelete = async (id: string) => {
@@ -170,15 +169,14 @@ export function RoastSchedulerTab({
       ...data,
       roastSchedules: updatedSchedules,
     };
-    try {
-      await onUpdate(updatedData);
-    } catch (error) {
-      console.error('Failed to delete schedule:', error);
-      showToast('スケジュールの保存に失敗しました。通信を確認してもう一度お試しください。', 'error');
-    }
+    // 削除も楽観的に反映し、UIを即座に更新する。保存はバックグラウンドで行い、失敗時のみトースト。
     if (editingSchedule?.id === id) {
       setEditingSchedule(null);
     }
+    Promise.resolve(onUpdate(updatedData)).catch((error) => {
+      console.error('Failed to delete schedule:', error);
+      showToast('スケジュールの保存に失敗しました。通信を確認してもう一度お試しください。', 'error');
+    });
   };
 
   const handleDialogCancel = () => {
@@ -267,13 +265,12 @@ export function RoastSchedulerTab({
       roastSchedules: updatedSchedules,
     };
 
-    try {
-      await onUpdate(updatedData);
-    } catch (error) {
+    // 並べ替えも楽観的に反映する。保存はバックグラウンドで行い、失敗時のみトースト。
+    setDraggedId(null);
+    Promise.resolve(onUpdate(updatedData)).catch((error) => {
       console.error('Failed to reorder schedule:', error);
       showToast('スケジュールの保存に失敗しました。通信を確認してもう一度お試しください。', 'error');
-    }
-    setDraggedId(null);
+    });
   };
 
   const handleDragEnd = () => {

--- a/components/RoastSchedulerTab.tsx
+++ b/components/RoastSchedulerTab.tsx
@@ -8,10 +8,11 @@ import { RoastScheduleMemoDialog } from './RoastScheduleMemoDialog';
 import { ScheduleCard } from './roast-scheduler/ScheduleCard';
 import { Button } from '@/components/ui';
 import { EmptyScheduleState } from '@/components/schedule/EmptyScheduleState';
+import { useToastContext } from '@/components/Toast';
 
 interface RoastSchedulerTabProps {
   data: AppData | null;
-  onUpdate: (data: AppData) => void;
+  onUpdate: (data: AppData) => Promise<void> | void;
   selectedDate: string; // YYYY-MM-DD形式
   isToday: boolean; // 選択日が今日かどうか
   onCamera?: () => void;
@@ -24,6 +25,7 @@ export function RoastSchedulerTab({
   isToday: _isToday,
   onCamera,
 }: RoastSchedulerTabProps) {
+  const { showToast } = useToastContext();
   const [editingSchedule, setEditingSchedule] = useState<RoastSchedule | null>(null);
   const [isAdding, setIsAdding] = useState(false);
   const [draggedId, setDraggedId] = useState<string | null>(null);
@@ -66,7 +68,7 @@ export function RoastSchedulerTab({
     setIsAdding(false);
   };
 
-  const handleSave = (schedule: RoastSchedule) => {
+  const handleSave = async (schedule: RoastSchedule) => {
     if (!data) return;
     // 全スケジュールを取得（選択日でフィルタリングする前）
     const allSchedules = data.roastSchedules || [];
@@ -149,12 +151,17 @@ export function RoastSchedulerTab({
       roastSchedules: updatedSchedules,
     };
 
-    onUpdate(updatedData);
+    try {
+      await onUpdate(updatedData);
+    } catch (error) {
+      console.error('Failed to save schedule:', error);
+      showToast('スケジュールの保存に失敗しました。通信を確認してもう一度お試しください。', 'error');
+    }
     setIsAdding(false);
     setEditingSchedule(null);
   };
 
-  const handleDelete = (id: string) => {
+  const handleDelete = async (id: string) => {
     if (!data) return;
     // 全スケジュールから削除（選択日でフィルタリングする前）
     const allSchedules = data.roastSchedules || [];
@@ -163,7 +170,12 @@ export function RoastSchedulerTab({
       ...data,
       roastSchedules: updatedSchedules,
     };
-    onUpdate(updatedData);
+    try {
+      await onUpdate(updatedData);
+    } catch (error) {
+      console.error('Failed to delete schedule:', error);
+      showToast('スケジュールの保存に失敗しました。通信を確認してもう一度お試しください。', 'error');
+    }
     if (editingSchedule?.id === id) {
       setEditingSchedule(null);
     }
@@ -189,7 +201,7 @@ export function RoastSchedulerTab({
     setDragOverId(null);
   };
 
-  const handleDrop = (e: React.DragEvent, targetId: string) => {
+  const handleDrop = async (e: React.DragEvent, targetId: string) => {
     e.preventDefault();
     setDragOverId(null);
 
@@ -255,7 +267,12 @@ export function RoastSchedulerTab({
       roastSchedules: updatedSchedules,
     };
 
-    onUpdate(updatedData);
+    try {
+      await onUpdate(updatedData);
+    } catch (error) {
+      console.error('Failed to reorder schedule:', error);
+      showToast('スケジュールの保存に失敗しました。通信を確認してもう一度お試しください。', 'error');
+    }
     setDraggedId(null);
   };
 

--- a/components/TastingSessionDetail.tsx
+++ b/components/TastingSessionDetail.tsx
@@ -13,7 +13,7 @@ import { Card, RoastLevelBadge } from '@/components/ui';
 interface TastingSessionDetailProps {
   session: TastingSession;
   data: AppData;
-  onUpdate: (data: AppData) => void;
+  onUpdate: (data: AppData) => Promise<void> | void;
 }
 
 export function TastingSessionDetail({ session, data, onUpdate }: TastingSessionDetailProps) {
@@ -28,76 +28,66 @@ export function TastingSessionDetail({ session, data, onUpdate }: TastingSession
   // 編集対象の記録を取得（編集モードの場合）
   const editingRecord = editingRecordId ? sessionRecords.find((r) => r.id === editingRecordId) || null : null;
 
-  const handleRecordSave = async (record: TastingRecord) => {
-    try {
-      const newRecord: TastingRecord = {
-        ...record,
-        userId: user?.uid || '',
-        sessionId: session.id,
-      };
+  const handleRecordSave = (record: TastingRecord) => {
+    const newRecord: TastingRecord = {
+      ...record,
+      userId: user?.uid || '',
+      sessionId: session.id,
+    };
 
-      // 既存の記録を上書きする場合（record.idが存在する、または同じセッション内で同じメンバーの記録がある場合）
-      const existingRecordById = tastingRecords.find((r) => r.id === record.id);
-      const existingRecordByMember = sessionRecords.find((r) => r.memberId === record.memberId && r.id !== record.id);
+    // 既存の記録を上書きする場合（record.idが存在する、または同じセッション内で同じメンバーの記録がある場合）
+    const existingRecordById = tastingRecords.find((r) => r.id === record.id);
+    const existingRecordByMember = sessionRecords.find((r) => r.memberId === record.memberId && r.id !== record.id);
 
-      if (existingRecordById) {
-        // IDで既存記録が見つかった場合（編集モード）
-        const updatedRecords = tastingRecords.map((r) => (r.id === record.id ? newRecord : r));
-        await onUpdate({
-          ...data,
-          tastingRecords: updatedRecords,
-        });
-        // 編集モードを解除
-        setEditingRecordId(null);
-      } else if (existingRecordByMember) {
-        // 同じメンバーの記録が既にある場合（上書き）
-        const updatedRecords = tastingRecords.map((r) => (r.id === existingRecordByMember.id ? newRecord : r));
-        await onUpdate({
-          ...data,
-          tastingRecords: updatedRecords,
-        });
-        // 編集モードに切り替える
-        setEditingRecordId(existingRecordByMember.id);
-      } else {
-        // 新規追加の場合
-        const updatedRecords = [...tastingRecords, newRecord];
-        await onUpdate({
-          ...data,
-          tastingRecords: updatedRecords,
-        });
-        // 編集モードに切り替える（新規作成した記録を編集モードにする）
-        setEditingRecordId(newRecord.id);
-      }
+    let updatedRecords: TastingRecord[];
+    if (existingRecordById) {
+      // IDで既存記録が見つかった場合（編集モード）
+      updatedRecords = tastingRecords.map((r) => (r.id === record.id ? newRecord : r));
+      setEditingRecordId(null);
+    } else if (existingRecordByMember) {
+      // 同じメンバーの記録が既にある場合（上書き）
+      updatedRecords = tastingRecords.map((r) => (r.id === existingRecordByMember.id ? newRecord : r));
+      setEditingRecordId(existingRecordByMember.id);
+    } else {
+      // 新規追加の場合
+      updatedRecords = [...tastingRecords, newRecord];
+      setEditingRecordId(newRecord.id);
+    }
 
-      // 保存が完了してから試飲記録一覧ページに遷移
-      router.push('/tasting');
-    } catch (error) {
+    // 楽観的UI: 先に遷移し、バックグラウンドで保存する
+    router.push('/tasting');
+    Promise.resolve(
+      onUpdate({
+        ...data,
+        tastingRecords: updatedRecords,
+      })
+    ).catch((error) => {
       console.error('Failed to save tasting record:', error);
       showToast('記録の保存に失敗しました。もう一度お試しください。', 'error');
-    }
+    });
   };
 
-  const handleRecordDelete = async (recordId: string) => {
+  const handleRecordDelete = (recordId: string) => {
     const confirmDelete = window.confirm('この記録を削除しますか？');
     if (!confirmDelete) return;
 
-    try {
-      const updatedRecords = tastingRecords.filter((r) => r.id !== recordId);
-      await onUpdate({
+    const updatedRecords = tastingRecords.filter((r) => r.id !== recordId);
+    // 削除した記録が編集対象だった場合、編集モードを解除
+    if (editingRecordId === recordId) {
+      setEditingRecordId(null);
+    }
+
+    // 楽観的UI: 先に遷移し、バックグラウンドで削除する
+    router.push('/tasting');
+    Promise.resolve(
+      onUpdate({
         ...data,
         tastingRecords: updatedRecords,
-      });
-      // 削除した記録が編集対象だった場合、編集モードを解除
-      if (editingRecordId === recordId) {
-        setEditingRecordId(null);
-      }
-
-      // 削除が完了してから試飲記録一覧ページに遷移
-      router.push('/tasting');
-    } catch (error) {
+      })
+    ).catch((error) => {
       console.error('Failed to delete tasting record:', error);
       showToast('記録の削除に失敗しました。もう一度お試しください。', 'error');
-    }
+    });
   };
 
   const handleCancel = () => {

--- a/components/TastingSessionList.tsx
+++ b/components/TastingSessionList.tsx
@@ -12,6 +12,7 @@ import { useAuth } from '@/lib/auth';
 import { useTastingFilters } from '@/hooks/useTastingFilters';
 import { motion } from 'framer-motion';
 import { Button, IconButton, EmptyState } from '@/components/ui';
+import { useToastContext } from '@/components/Toast';
 
 const SAMPLE_TASTING_PREFIX = 'sample-tasting-';
 
@@ -114,6 +115,7 @@ export function TastingSessionList({
   filterButtonContainerId,
   filterButtonContainerIdMobile,
 }: TastingSessionListProps) {
+  const { showToast } = useToastContext();
   const router = useRouter();
   const { user } = useAuth();
   const userId = user?.uid ?? null;
@@ -183,26 +185,31 @@ export function TastingSessionList({
   }, [sampleButtonContainerId, filterButtonContainerId, filterButtonContainerIdMobile]);
 
   // AI分析結果をFirestoreに保存するコールバック
-  const handleUpdateSession = (sessionId: string, aiAnalysis: string, recordCount: number) => {
+  const handleUpdateSession = async (sessionId: string, aiAnalysis: string, recordCount: number) => {
     if (!onUpdate) return;
 
-    onUpdate((currentData) => {
-      const updatedSessions = currentData.tastingSessions.map((session) =>
-        session.id === sessionId
-          ? {
-              ...session,
-              aiAnalysis,
-              aiAnalysisUpdatedAt: new Date().toISOString(),
-              aiAnalysisRecordCount: recordCount,
-            }
-          : session
-      );
+    try {
+      await onUpdate((currentData) => {
+        const updatedSessions = currentData.tastingSessions.map((session) =>
+          session.id === sessionId
+            ? {
+                ...session,
+                aiAnalysis,
+                aiAnalysisUpdatedAt: new Date().toISOString(),
+                aiAnalysisRecordCount: recordCount,
+              }
+            : session
+        );
 
-      return {
-        ...currentData,
-        tastingSessions: updatedSessions,
-      };
-    });
+        return {
+          ...currentData,
+          tastingSessions: updatedSessions,
+        };
+      });
+    } catch (error) {
+      console.error('Failed to save tasting session:', error);
+      showToast('試飲セッションの保存に失敗しました。通信を確認してもう一度お試しください。', 'error');
+    }
   };
 
   const handleApplyFilters = (filters: {
@@ -293,7 +300,9 @@ export function TastingSessionList({
         ...currentData.tastingRecords.filter((record) => !record.id.startsWith(SAMPLE_TASTING_PREFIX)),
         ...sampleRecords,
       ],
-    }));
+    }))?.catch((error) => {
+      console.error('Failed to add sample data:', error);
+    });
   };
 
   const filterButtonDesktop = (

--- a/components/TodaySchedule.tsx
+++ b/components/TodaySchedule.tsx
@@ -11,7 +11,7 @@ import { EmptyScheduleState } from '@/components/schedule/EmptyScheduleState';
 
 interface TodayScheduleProps {
   data: AppData | null;
-  onUpdate: (data: AppData) => void;
+  onUpdate: (data: AppData) => Promise<void> | void;
   selectedDate: string;
   isToday: boolean;
   onCamera?: () => void;

--- a/docs/audits/2026-05-31-roastplus-100x-audit.md
+++ b/docs/audits/2026-05-31-roastplus-100x-audit.md
@@ -1,0 +1,330 @@
+# RoastPlus 全方位監査レポート（100倍化のための現状診断）
+
+- **作成日**: 2026-05-31
+- **対象**: RoastPlus（ドリップパックコーヒー製造の現場向け PWA）
+- **方法**: 12次元を並列エージェントで深掘り監査（実コードを読み、ファイル名・行番号付きで評価）→ 横断ランキングで統合
+- **総合スコア**: **6 / 10**
+
+> 重要度の記号: 🔴 critical（データ損失・セキュリティ・業務停止級） / 🟠 high（日常的な大きな支障） / 🟡 medium（改善余地） / ⚪ low（些細）
+> コスト記号: **S**＝数十分 / **M**＝半日 / **L**＝1〜2日 / **XL**＝数日（いずれも AI エージェント実装前提）
+
+---
+
+## 1. 総評
+
+RoastPlus は「**設計図は一流、施工に致命的な穴が数カ所**」という状態のアプリです。実コードを確認した結果、強みは本物でした。
+
+**本物の強み（初心者1名運用とは思えない水準）:**
+- 型安全性：本番コードに `: any` 0件・`@ts-ignore` 0件・循環依存 0件、`tsc --noEmit` クリーン
+- セキュリティ：owner isolation（本人のみ自分のデータ）を `firestore.rules`/`storage.rules` 全マッチで徹底し、**エミュレータ実テスト＋CI** で検証
+- Cloud Functions の多層防御：App Check enforce・認証チェック・入力検証・レート制限
+- 生産記録のサブコレクション設計＋集計の都度計算（集計と元データの乖離ゼロ）
+- DESIGN.md とセマンティックトークンによる 7 テーマ基盤
+- 94 ファイル 791 テスト＋9 並列 CI
+
+**しかし、たった1つの根本原因が4次元の最重要問題を同時に生んでいます。**
+
+`hooks/useAppData.ts:273-301` の `updateData` が「保存失敗を `console.error` で握りつぶし、**再 throw せず**、しかも失敗時にサーバーの古い値を再取得して画面を上書きする」挙動です。この1箇所のせいで、`schedule`/`tasting`/`defect-beans`/`notifications`/`home` の呼び出し側に書かれた try/catch＋エラートーストが**全て死にコード**になり、保存が失敗しても『保存しました』と表示され、次の同期で入力が黙って消えます。
+
+さらに `lib/firebase.ts:27` はオフライン永続化なし、`navigator.onLine` によるオフライン検知ゼロ、`app/error.tsx`・`global-error.tsx`・ErrorBoundary も皆無で、レンダリング例外は白画面になります。**実際に Issue #458 で本番データ全消失（試飲4セッション+16記録+スケジュール12件）が起きており、理論上のリスクではなく再発する実害です。**
+
+総じて「現場8名が毎日入力するデータの安全性と可視性」という業務アプリの核心が、堅牢な周辺（セキュリティ・型・テスト）に守られながらも、保存経路の中心で破れている。**逆に言えば、穴が局所的で根本原因が特定済みなので、少数の的を絞った修正で劇的に良くなる余地が極めて大きい**アプリです。
+
+---
+
+## 2. スコアカード（12次元）
+
+| 次元 | スコア | 状態 |
+|---|:---:|---|
+| セキュリティ | 8 | 🟢 同規模個人開発の平均を大きく上回る |
+| ビジュアルデザイン・UI一貫性 | 7 | 🟢 トークン基盤は秀逸、施工にムラ |
+| アーキテクチャ・コード品質 | 7 | 🟢 型安全・循環ゼロ、規律が人手頼み |
+| テスト・品質保証 | 7 | 🟢 認可・集計・CSVは手厚い、保存経路が手薄 |
+| UX・ユーザーフロー | 6 | 🟡 基盤は堅い、現場の手元体験が未完 |
+| パフォーマンス | 6 | 🟡 8名規模なら十分速い、構造的弱点2つ |
+| プロダクト・機能機会 | 6 | 🟡 単機能は良質、機能間がサイロ化 |
+| 保守性・開発者体験 | 6 | 🟡 ドキュメント厚い、本番異常を検知できない |
+| アクセシビリティ | 5 | 🟠 フォーム基礎は良い、モーダル/コントラストに穴 |
+| データモデル・Firestore設計 | 5 | 🟠 生産記録は手本、レガシー領域が配列パッキング |
+| 信頼性・エラーハンドリング | 5 | 🟠 周辺は堅牢、保存経路の中心で破れている |
+| **PWA・オフライン・現場耐性** | **3** | 🔴 「電波が切れても失わない」が満たせていない |
+
+---
+
+## 3. まず3つだけやるなら（最優先 Top3）
+
+1. **`updateData` の保存失敗を再 throw し、エラートーストを復活させる**（信頼性 / 🔴 / **S**）
+   `useAppData.ts` の catch 末尾に巻き戻し後の `throw` を1行足すだけで、全機能に既に書かれているエラーハンドリングが一斉に生き返る。アプリ最大の弱点を最小コストで塞ぐ、群を抜いて費用対効果の高い1点。Issue #458 再発防止の中核。
+
+2. **Firestore オフライン永続化を有効化し、オフライン状態を画面に常設表示する**（PWA / 🔴 / **M+S**）
+   `lib/firebase.ts` を `initializeFirestore + persistentLocalCache` に変えると、電波が切れても書き込みがローカルにキューされ復帰時に自動同期される。「打ったのに消えた」が構造的に消える。
+
+3. **`app/global-error.tsx` ＋ ErrorBoundary を追加し、白画面で現場が詰む最悪ケースを防ぐ**（保守性 / 🟠 / **S〜M**）
+   Next 標準機構で『再読み込み』ボタン付き復旧 UI を1〜2枚足すだけで、業務停止級の見え方を回避できる。
+
+---
+
+## 4. 横断ロードマップ（効果順 18件）
+
+| # | 施策 | 次元 | 効果 | コスト | 重要度 |
+|:--:|---|---|---|:--:|:--:|
+| 1 | `updateData` の保存失敗を再 throw し全機能のエラートーストを復活 | 信頼性 | 変革的 | S | 🔴 |
+| 2 | Firestore オフライン永続化（persistentLocalCache）を有効化 | PWA | 変革的 | M | 🔴 |
+| 3 | オフライン検知フック＋常設バナーで通信断を見える化 | PWA | 高 | S | 🟠 |
+| 4 | `global-error.tsx`＋ルート ErrorBoundary で白画面を復旧UIに | 保守性 | 高 | S | 🟠 |
+| 5 | 保存状態インジケータ＋再試行付きトーストで自動保存を可視化 | UX | 高 | M | 🟠 |
+| 6 | eslint で依存方向を機械強制＋madge/knip を CI 接続 | アーキ | 高 | M | 🟠 |
+| 7 | NumberInput に inputMode を追加し全数値入力をテンキー最適化 | UX | 高 | S | 🟠 |
+| 8 | 共通 Modal に role/aria-modal/フォーカストラップ/Escape を実装 | a11y | 高 | M | 🟠 |
+| 9 | 主要ボタンのコントラストを WCAG AA 準拠に（変数1箇所） | a11y | 高 | S | 🟠 |
+| 10 | SW で `_next/static` 不変チャンクを Cache First 配信に | パフォ | 高 | S | 🟡 |
+| 11 | 本番クライアントエラーの最小ロガー（errorLogs）を1本通す | 保守性 | 高 | M | 🟡 |
+| 12 | 賞味期限シール計算をアプリ実装（純関数＋テスト） | 機能 | 高 | M | 🟠 |
+| 13 | 共通UI（Button/ProgressBar）のハードコード色をトークン化 | UI | 高 | M | 🟡 |
+| 14 | 毎日使う生Tailwind製モーダルを共通Modal＋トークンに統一 | UI | 中 | L | 🟠 |
+| 15 | tasting/schedule をサブコレクション化し配列パッキング解消 | データ | 変革的 | XL | 🔴 |
+| 16 | 欠点豆の画像削除/保存順序を是正し孤児・壊れ画像を防ぐ | 信頼性 | 中 | M | 🟠 |
+| 17 | 真のデッドコード3ファイル＋未使用依存4つを削除・README誤記是正 | アーキ | 中 | S | ⚪ |
+| 18 | App Check enforce 状態の確認・文書化＋OpenAI予算上限設定 | セキュリティ | 中 | S | 🟡 |
+
+---
+
+## 5. 改善を束ねた6テーマ（方向性の選択肢）
+
+### テーマA: データを絶対に失わない・消えたら分かる（最優先）
+> このアプリの一番怖い穴は「打ったのに消える、しかも誰も気づかない」こと。たった1行の throw 追加・Firestore 永続化・オフラインバナーの3点で、現場8名が毎日感じる『残ったか分からない不安』が消え、アプリを心から信頼できるようになります。
+
+rank 1, 2, 3, 5, 16、中期: 15
+
+### テーマB: 壊れても・通信が悪くても止まらない現場耐性
+> iPad が白画面になったら現場の作業が止まります。エラー画面と復旧ボタン、本番エラーが保守者に届く仕組みを入れれば、『何が起きたか分からないまま詰む』状態から『再読み込みすれば戻る・原因も追える』状態へ。
+
+rank 4, 11, 10
+
+### テーマC: 手元の入力体験を毎日ラクにする
+> 現場は手袋・片手・急ぎで数字を叩きます。テンキー最適化やモーダルの操作性は、1日何十回の入力の押し間違い（=集計ズレ）を直接減らします。
+
+rank 7, 8、＋スケジュール「今日に戻る」・横移動ナビ・初回ヒント・生産記録のスマホ入力解放
+
+### テーマD: どのテーマでも美しく・誰でも読める見た目
+> 設計図（DESIGN.md とトークン）は一流なのに、一部のモーダルとボタンが図面を見ずに作られ、ダークテーマで白く浮いたり文字が読みにくかったりします。土台部品を直すだけで全画面に波及します。
+
+rank 9, 13, 14
+
+### テーマE: これ以上複雑にしない仕組み（初心者保守の防波堤）
+> あなた（IK）が全コードを理解しきれなくても、『危険な変更は CI が止める』状態を作れます。依存方向の機械強制、デッドコード削除、ドキュメント誤記是正で、劣化を人の記憶ではなく仕組みで防ぎます。
+
+rank 6, 17, 18、＋重要ディレクトリ限定のカバレッジしきい値
+
+### テーマF: 現場の毎日を1本につなぐ業務OS化
+> 機能が単体では良いのにバラバラで、現場の日次フロー全体をつなげていません。あなた自身が業務マニュアルで『次に作るべきもの』を言語化済みです。シール計算とマニュアル表示を実装すれば、手計算・紙運用が消え、属人化解消というこのアプリ本来の価値が初めて現場で動き出します。
+
+rank 12、＋業務マニュアルのアプリ内表示・実プレミックス袋数の記録・月またぎ振り返り
+
+---
+
+## 6. 12次元の詳細findings
+
+### 6.1 UX・ユーザーフロー（6/10）
+
+ホームは7機能を最大4列カードで一覧化し、モバイル1タップで各機能へ到達できる迷わない設計。タップターゲット min-h-[56px]、入力欄 min-h-[44px]、aria-label も丁寧。空状態は EmptyState で統一、本日のスケジュールは自動保存（デバウンス500ms）。基盤は堅いが、現場の手元体験を詰め切れていない。
+
+- 🔴 **保存失敗がユーザーに全く見えず、入力が静かに消える** [M]
+  - 根拠: `hooks/useAppData.ts` updateData(279-292) が例外を console.error するだけで巻き戻し、トースト無し。`useTodayScheduleSync.ts` も同経路。
+  - 改善: catch で showToast('保存に失敗しました…','error')。ヘッダーに保存状態インジケータ常設。
+- 🟠 **数値入力が type=number のみでモバイル/iPadキーパッド未最適化** [S]
+  - 根拠: `components/ui/NumberInput.tsx` に inputMode 指定なし。良品/不良品数・焙煎重量・時刻が対象。
+  - 改善: 整数=`inputMode="numeric"`、重量=`"decimal"`。1コンポーネント修正で全数値入力に波及。
+- 🟠 **生産記録がスマホで入力不可（iPad横向き必須）** [M]
+  - 根拠: `app/production-record/page.tsx:360` の本体3列が `hidden md:grid`、536-543 で案内のみ。
+  - 改善: 入力ボタンと入力モーダル（max-w-md 縦1列）だけスマホ解放。集計ビューは md 以上のままでよい。
+- 🟡 **全ページの戻るがホーム直帰のみ、機能間を横移動できない** [M]
+  - 根拠: `FloatingNav.tsx` の backHref が常に `/`。グローバルナビが layout に無い。
+  - 改善: 下部ミニタブバー、まず schedule/assignment/production-record の相互リンク。
+- 🟡 **スケジュールに「今日に戻る」ショートカットがない** [S] — isToday が false のとき「今日」ボタンを出すだけ。
+- 🟡 **初回利用の案内・PWAインストール誘導・操作ヒントが皆無** [M] — 初回1枚ヒント＋beforeinstallprompt 捕捉。
+- ⚪ **破壊的操作の確認が window.confirm 依存** [S] — `app/tasting/page.tsx:96,173`。既存 Dialog/Modal に統一。
+- ⚪ **アプリ全体のエラーバウンダリが無い** [S] — error.tsx/global-error.tsx 追加。
+
+**最大の機会**: 自動保存を「見える化」し、保存失敗を必ず伝えること。
+
+### 6.2 ビジュアルデザイン・UI一貫性（7/10）
+
+DESIGN.md（28KB）と globals.css のトークンシステムは秀逸。7テーマがセマンティック変数で完全定義、data-theme 切替で色が追従。コア共通UIの大半は適切。問題は実装の徹底度のムラ。
+
+- 🟠 **ダーク系テーマで破綻する生Tailwind製モーダル/フォームが多数** [L]
+  - 根拠: `TimeEditDialog.tsx`（毎日使用）が bg-white/text-gray-*/bg-amber-600 をハードコード。`NotificationModal.tsx`・`DatePickerModal.tsx`・`DefectBeanDetail.tsx`・`PasswordModal.tsx` も同型。DESIGN.md 11.1/11.4 で禁止のパターン。
+  - 改善: 共通 Modal（contentClassName に bg-overlay）でラップ、bg-white→bg-overlay、text-gray→text-ink、border-gray→border-edge。毎日使う TimeEditDialog・NotificationModal から。
+- 🟡 **モーダルのオーバーレイ濃度・z-index がファイルごとにバラバラ** [M] — bg-black/20〜/55 が5種混在、z-index も z-50〜z-[9999] 散在。Modal に集約。
+- 🟡 **共通UI primitive 自身がトークンを使い切れていない** [M] — Button secondary が bg-gray-600 固定、primary が text-white、ProgressBar が bg-green/yellow/red-500。トークン化で全画面波及。
+- 🟡 **assignment テーブルヘッダーのハードコードグレー** [M] — `DesktopTableHeader.tsx` の border-gray-700 等8箇所。
+- ⚪ **タイポgrafが任意px値に散らばる** [M] — text-[12.5px] 等18ファイル41箇所。標準スケールへ寄せる。
+- ⚪ **IconButton の sm/lg が44pxタッチ領域を満たさない可能性** [S]。
+- ⚪ **dev/design-lab が本番ビルドに含まれハードコード色を持つ** [S] — 本番除外。
+
+**最大の機会**: 生Tailwind再実装モーダル約10数個を共通Modal＋トークンに統一 → 7テーマすべてで破綻しない9点級へ。
+
+### 6.3 アクセシビリティ（5/10）
+
+フォーム系プリミティブ（Input/Select/Switch）は label 紐付け・useId・aria-invalid・role="alert" まで丁寧。html lang="ja"・ズーム阻害なし・axe-core を9ページで CI 実行。一方で構造面に穴。「自動テストは緑だが実際の WCAG AA は未達」という偽の安心状態。
+
+- 🟠 **主要ボタンのコントラストが WCAG AA 未達** [S] — 白文字 on #e48003 = 2.84:1、warning = 1.79:1（基準4.5:1）。`globals.css` の `--spot`/`--btn-primary` を一段暗く。変数1箇所で全画面波及。
+- 🟠 **axe の CI ゲートが critical のみで serious（コントラスト等）を素通り** [S] — `a11y.spec.ts:70-82`。serious をベースライン固定で失敗扱いに。
+- 🟠 **共通 Modal に role/aria-modal/フォーカストラップ/復帰が無い** [M] — `Modal.tsx`、focus-trap 実装はコードベース全体で0件。1ファイル改修で全派生モーダルに効く。
+- 🟠 **schedule の DatePickerModal が dialog でなく Escape テストが空振り** [M] — 共通Modal 不使用、role/Escape 無し、e2e は常に真で通る。
+- 🟡 **prefers-reduced-motion が一部しか無効化していない** [M] — walk-characters/wobble/pulse-scale/gradient-shift が対象外。Framer は MotionConfig reducedMotion。
+- 🟡 **Tabs/Accordion に aria-controls と矢印キー操作が無い** [M]。
+- 🟡 **カメラ撮影オーバーレイが dialog 扱いでなくキーボード/SR非対応** [M] — alt も "Captured"/"Preview" と非説明的英語。
+- ⚪ **Toast が事前生成ライブリージョンでなく role=alert 多重発火** [S]。
+- ⚪ **Button に focus-visible リングが無い** [S]。
+
+**最大の機会**: 共通 Modal に role/aria-modal/フォーカストラップ/Escape を一括実装 → 全モーダルがキーボード/SR操作可能に。
+
+### 6.4 パフォーマンス（6/10）
+
+8名・小データなら体感十分速い。ローカルwoff2＋display:swap、Lottie/Snowfall の dynamic 分離、時計の useSyncExternalStore、生産記録/担当表のサブコレクションは良い。体感を支配する構造的弱点が2つ。
+
+- 🟠 **同一ユーザードキュメントへの onSnapshot リスナー重複** [M] — defect-beans で `useDefectBeans` と `useDefectBeanSettings` が各々 useAppData を呼び2本張る。useAppData を Context 化で1本に収束。
+- 🟠 **SW が不変な静的チャンクも Network First 配信し PWAキャッシュが効かない** [S] — `public/sw.js:204-212` が全GETを fetch 優先。`_next/static`（約2.6MB）も毎回ネット待ち。Cache First 分岐を追加。
+- 🟠 **全機能データを単一ドキュメント配列に集約、1項目更新でも全配列書き戻し** [XL] — 記録蓄積で送受信ペイロードが線形肥大。サブコレクション移行で解消。
+- 🟡 **Firebase SDK 一式を起動時に一括初期化（最大チャンク388KB）** [L] — ホームは Firestore 不要なのに全SDKロード。遅延ゲッター化。
+- ⚪ **未使用の react-markdown/remark-gfm が残存** [S]。
+- ⚪ **fetchRecentAssignments が日数分の個別 getDocs を並列発行** [S] — 範囲クエリ1回に。
+- ⚪ **Loading がマウントのたび Lottie JSON を再fetch** [S] — モジュールスコープにメモ化。
+
+**最大の機会**: useAppData の Context 化（1ページ1リスナー）＋ SW で静的チャンクを Cache First。XL移行より先に低〜中コストで効く。
+
+### 6.5 PWA・オフライン・現場耐性（3/10）⚠最低スコア
+
+アプリシェルのオフライン化と更新フローは丁寧（Network First＋ランタイムキャッシュ上限80、no-cache ヘッダ、waiting SW 検出の更新UI）。production-record モーダルは保存失敗時に入力保持＋エラー表示する良い設計。しかし「電波が弱い前提で入力中にデータを失わない」核心が満たせていない。
+
+- 🔴 **メインデータ保存が失敗を握りつぶし、編集を無言でサーバーの古い値に巻き戻す** [M] — `useAppData.ts` updateData、`lib/firebase.ts` はオフライン永続化なし。initializeFirestore + persistentLocalCache へ。
+- 🔴 **tasting 新規セッション保存が「失敗しても成功扱い」で一覧へ遷移し記録喪失** [M] — `app/tasting/sessions/new/page.tsx` の handleSave は catch 設計だが updateData が reject しないため到達不能。
+- 🟠 **欠点豆登録: 画像アップ成功後にメタ保存が黙って失敗し、記録消失＋孤児画像** [M]。
+- 🟠 **オフライン検知・接続状態表示が皆無** [S] — navigator.onLine がリポジトリ全体で0件。useOnlineStatus ＋常設バナー。
+- 🟠 **production-record の保存が runTransaction でオフライン時は必ず失敗** [L] — トランザクションはサーバー往復必須。
+- 🟡 **lib/timeSync.ts が完全な未使用コード（137行）** [S] — clock/notifications は端末ローカル時計依存。削除 or 配線。
+- 🟡 **SW が無条件 skipWaiting+claim でバージョン混在を起こし得る** [S] — applyUpdate 経由の明示更新に統一。
+- ⚪ **インストール（A2HS）体験がブラウザ任せ、iOS案内なし** [S]。
+
+**最大の機会**: lib/firebase.ts のオフライン永続化＋ updateData の握りつぶし是正。最大の穴を塞ぐ単一施策。
+
+### 6.6 アーキテクチャ・コード品質（7/10）
+
+型安全性は非常に優秀（本番コードに :any 0件、as any はデッドコード内1件のみ、tsc クリーン、循環依存0）。依存方向ルールを明文化し、knip/lizard/madge を整備、独自ESLintルールで共通UI使用を強制。一方で「ルールを機械的に守らせる仕組み」が欠け、違反が静かに混入。
+
+- 🟠 **useAppData が12フィールド異種混在の単一ドキュメントを管理する中央神フック** [L] — 最もデータ損失リスクが高く理解困難。新フィールド追加で3箇所同期が必要。フィールド定義リスト駆動化＋段階的サブコレクション分離。
+- 🟠 **依存方向違反が3件、しかも自動検知ゼロ** [M] — `lib/drip-guide/useRecipes.ts` が hooks を import（逆流）等。eslint に no-restricted-imports 追加。
+- 🟡 **assignment 機能だけ別の構造哲学（コロケーション）で組織方針が二重化** [M] — どちらを正にするか決めて REPOSITORY.md に明記。
+- 🟡 **TableModals が34フィールドの prop interface を持つ神コンポーネント（CCN127）** [L] — 625行。機能別4ファイルに分割。
+- 🟡 **app/production-record/page.tsx が約600行の単一ページ** [L] — 状態管理をフック抽出、表示を薄く。
+- 🟡 **品質ゲート（knip/lizard/madge）が CI 未接続で手動頼み** [S] — ci.yml に madge --circular（エラー）と knip（警告）を追加。
+- ⚪ **真にデッドなファイル・依存が放置、knip 出力が dev用ノイズで埋もれる** [S] — 真のデッド3ファイル＋依存4つ削除、knip.json の ignore 整備。
+
+**最大の機会**: eslint で依存方向を機械強制＋madge/knip を CI 接続 → 「危険な変更が CI で止まる」防波堤。
+
+### 6.7 セキュリティ（8/10）🟢最高スコア
+
+同規模個人開発PWAの平均を大きく上回る。owner isolation が全マッチで一貫実装され、`tests/rules/firebase.rules.test.ts` でエミュレータ実テスト＋2つの CI で検証。Cloud Functions は App Check enforce・認証・入力検証・レート制限（OCR 30回/分析 80回）・CORS allowlist の多層防御。OpenAI APIキーは Functions secrets 管理。マスターデータは write:false で遮断。
+
+- 🟡 **Firestore ルールにフィールド単位の検証が皆無、本人が自分のドキュメントを任意に破壊・肥大化できる** [M] — productionRecords に絞った型ガード追加が費用対効果高。
+- 🟡 **App Check の enforce 範囲が Functions のみ明示、Firestore/Storage が確認できない** [S] — コンソールで確認し運用ドキュメントに明記＋復旧チェックリスト化。
+- 🟡 **EmailJS 問い合わせフォームが未認証から送信可能、公開キー露出** [M] — Allowed Origins を本番ドメインに限定＋簡易レート制限。
+- ⚪ **rate-limit のトランザクションが超過時もリトライされ得る微小な抜け** [S] — 実害ほぼゼロ、OpenAI 側の予算上限を別途設定。
+- ⚪ **OCR画像のサイズ上限がルール層（5MB）と Functions 層（約14MB）で二重基準** [S]。
+- ⚪ **E2Eモックユーザーの固定UID/トークンが本番混入しないことが env ガード依存** [S] — out/ を CI で grep 検査。
+
+**最大の機会**: まず App Check が Firestore/Storage に enforce されているか確定・記録。残るリスクの中核は「正規アプリ以外からの直接APIアクセスによるコスト攻撃」で、これを止める唯一の砦。
+
+### 6.8 データモデル・Firestore設計（5/10）
+
+二極化。生産記録は手本（サブコレクション分割＋集計の都度計算＋runTransaction の原子的 upsert）。一方レガシー主要データ（roastSchedules/todaySchedules/tastingSessions/tastingRecords/notifications/dripRecipes）は単一 users/{uid} ドキュメントの配列に同居し、これが Issue #458 の本番データ消失を実際に招いた。
+
+- 🔴 **単一ドキュメントへの配列パッキングが本番データ消失を実際に引き起こした（再発リスク継続）** [XL] — `docs/superpowers/specs/2026-05-28-tasting-data-loss-recovery.md` に PITR ログ付きで実消失が記録。tasting から段階移行（読み取り旧構造フォールバック付き）。
+- 🟠 **配列が無期限に増え続け、Firestore 1MiB 上限にいずれ到達** [L] — プルーン処理なし。直近窓だけ購読＋保持期間ポリシー。
+- 🟠 **全データが完全にユーザー個別サイロで、8名のチーム共有が成立していない** [XL] — A さんの焙煎スケジュールが B さんに見えない。まず運用実態を確認、共有が必要なデータと個別でよいデータを仕分け。
+- 🟡 **firestore.indexes.json が空で、複合インデックスがコードの try-catch フォールバック依存** [S] — 移行で where+orderBy 導入時に複合インデックスを追記する運用に。
+- ⚪ **集計と元データの乖離リスクは production-record で解消済み、他領域でも明文化すべき** [S] — encouragementCount は increment() へ。
+- ⚪ **FirestoreTimestamp 型が string | {seconds,nanoseconds} のユニオンで時刻比較が散在** [M] — toMillisSafe を lib 共通へ昇格。
+
+**最大の機会**: tasting/tastingRecords を皮切りに、配列パッキングを production-record と同じサブコレクション方式へ段階移行。設計の正解を既に持っているため横展開で済む。
+
+### 6.9 信頼性・エラーハンドリング・データ保護（5/10）
+
+生産記録は runTransaction の upsert＋衝突ガード＋モーダルの正しいエラー表示。useAppData には write stream exhausted 対策の本格キュー（指数バックオフ・最大3回リトライ・バッチ分割）、データ消失防止ガード（localHasData 判定）まである。BACKUP_OPERATIONS.md も良質。一方で致命的な穴が2つ。
+
+- 🔴 **updateData が保存失敗を握りつぶし成功扱いで返す（呼び出し側のエラー処理が全て死にコード）** [M] — catch 末尾に `throw saveError` 追加で全機能のエラートーストが生き返る。
+- 🔴 **アプリ全体に Error Boundary / error.tsx / global-error.tsx が存在しない（白画面リスク）** [M] — Next 標準機構で復旧UI。
+- 🟠 **Firestore オフライン永続化が無効** [M] — persistentLocalCache 導入。
+- 🟠 **欠点豆削除/更新で Storage 画像を先に削除し Firestore 保存失敗を検知できない** [M] — 順序を「Firestore 成功確認後に Storage 削除」へ。
+- 🟠 **バックアップが週1手動・自動ジョブ無し・復元の実地テスト未実施** [M] — 日次スケジュールバックアップ＋復元手順を一度通しでテスト＋代理実行者を1名。
+- 🟡 **トーストが画面離脱/リロードで消え保存失敗の記録が残らない** [M] — error トーストは duration=0＋再試行ボタン。
+- 🟡 **楽観的更新の巻き戻しが getUserData 1発に依存** [S]。
+- ⚪ **通知の既読状態が localStorage のみでデバイス間非同期・消失しうる** [S]。
+
+**最大の機会**: updateData を「保存失敗時に re-throw」する1点修正。投資対効果が群を抜く。
+
+### 6.10 テスト・品質保証（7/10）
+
+94ファイル791テストが CI で毎PR実行。owner isolation をエミュレータ実テストで網羅。生産記録の集計・CSV ロジックを550行で濃く保護。production-record.spec.ts が保存→集計→CSV を実エミュレータで通しE2E検証。Functions の入力検証・rate-limit もテスト済み。一方で「壊れると静かにデータが消える/化ける」経路が手薄。
+
+- 🔴 **書き込みキューのリトライ・飽和・保留データ連鎖が実質ノーテスト** [M] — `write-queue.ts`（237行）の executeWrite リトライ/飽和/pendingData連鎖/バッチ分割が唯一のテスト2ケースで踏まれていない。オフライン耐性の心臓部。
+- 🟠 **OCR結果を日次スケジュールへ上書きマージする処理が完全ノーテスト** [S] — `useScheduleOCR.ts`（テスト無し）が当日 todaySchedules を丸ごと差し替え。replace/add/null の3観点を追加。
+- 🟠 **OCR Function の AI応答→スケジュール変換ロジックがテスト不能な構造で未検証** [M] — クロージャ private 関数。純粋関数 parseScheduleResponse に切り出して export＋テスト。
+- 🟡 **Firestore 読み取り・購読のエラー経路（getUserData/subscribeUserData）が未テスト** [M]。
+- 🟡 **通しE2Eが実Firestoreで走るのは生産記録のみ、試飲・欠点豆画像が薄い** [M]。
+- ⚪ **カバレッジに数値ゲートが無く保護が劣化しても検知できない** [S] — 重要ディレクトリ限定の threshold。
+
+**最大の機会**: write-queue.ts の executeWrite にテスト。データ安全性最優先のアプリで最も守るべき箇所が無防備。
+
+### 6.11 プロダクト・機能機会（6/10・ドッグフーディング視点）
+
+単機能の作り込みは良質（生産記録v1の一気通貫、試飲の memberId 連携）。一方で現場の日次フロー全体を1本につなぐ「業務OS」にはなっておらずサイロ化。決定的なのは、ユーザー自身が書いた `docs/roastplus_work_manual_hq_review_v0.3.md` §18.2 で「シール計算」「業務マニュアル表示」等を未実装の最優先候補と明記していること。"次に作るべきもの"は言語化済み。
+
+- 🟠 **賞味期限シール計算がアプリ未実装（現場が手計算・紙運用、最優先候補）** [M] — §6.4 に確定式あり。`lib/productionRecords.ts` に純関数＋テストで実装、押印ミス（食品表示リスク）を下げる。
+- 🟠 **業務マニュアルがアプリ内に無く、属人化解消というコアバリューを取りこぼしている** [M] — 既存マニュアルmdを Accordion で工程別表示。死んでいる app/brewing を受け皿に。
+- 🟡 **パッケージ記録の A班/B班が担当表チーム（最大4班）と非連動・ハードコード** [M]。
+- 🟡 **月をまたぐ振り返り（前月比・推移）がアプリ内に無く改善サイクルが回らない** [M] — 既存 subscribeRecentProductionMonths を活用した推移カード。
+- 🟡 **豆マスタが3系統に分裂し機能間で豆データがつながらない** [L] — beanConfig を単一の出所に。
+- 🟡 **プレミックス袋数が理論値表示のみで実測の記録手段が無い** [S] — RoastEntryInput に1フィールド追加、シール計算の入力源にも。
+- ⚪ **app/brewing が「開発予定」の死にページで drip-guide と役割重複** [S]。
+- ⚪ **スケジュールOCRと生産記録/担当表が分断、入力の二度手間** [L]。
+
+**最大の機会**: 現場の日次フローを生産記録を軸に1本につなぎ、確定式のあるシール計算と業務マニュアル表示を実装。
+
+### 6.12 保守性・開発者体験（6/10・初心者1名運用）
+
+docs/steering/ の6文書は障害一次対応・依存方向・命名・テスト戦略まで網羅。CI は9並列ジョブ。write-queue の書き込みリトライは堅実。一方「本番で問題が起きたとき気づける仕組み」が完全欠落。static export でサーバーが無く、クライアント例外・Firestore 失敗は全て console.error に消える。
+
+- 🟠 **本番クライアントエラーを検知する仕組みが皆無** [M] — error.tsx/global-error.tsx/ErrorBoundary/window.onerror すべて0件、Sentry 未導入。復旧UI＋errorLogs への最小ロガー。
+- 🟡 **集約ロガーが無く console.* が49ファイル162箇所に散在（本番では不可視）** [M] — lib/logger.ts に薄い抽象。
+- 🟡 **README と REPOSITORY.md に実態と異なる記述（存在しないスクリプト等）** [S] — 初心者がドキュメントを信じると確実に迷う。最優先で是正。
+- 🟡 **CI のビルド環境変数が .env.example と乖離** [S] — 本番限定不具合の温床。棚卸し。
+- 🟡 **Firestore 購読・書き込みの失敗時にユーザーへ通知する共通パターンが無い** [M]。
+- ⚪ **maintenance スクリプトが Python製lizard に依存するが前提条件が未文書化** [S]。
+- ⚪ **CI にデプロイ前の最終ゲートが無く firebase-hosting-merge が検証を再実装** [M]。
+- ⚪ **無効化された claude.yml が .disabled のまま残置、メモリ記述と不一致** [S]。
+
+**最大の機会**: 本番クライアント側の異常を「保守者が能動的に気づける」最小の経路を1本通す（復旧UI＋errorLogs ロガー）。
+
+---
+
+## 7. クイックウィン総まとめ（低コスト・高効果）
+
+1. `useAppData.ts` の catch 末尾に `throw saveError` を1行追加 → 全機能のエラートーストが生き返り、嘘の『保存しました』を撲滅（**S**・影響は全機能）
+2. `app/global-error.tsx` を1枚追加して『再読み込み』ボタン付き復旧UIに（**S**）
+3. `NumberInput.tsx` に inputMode を追加（個数=numeric/重量=decimal）（**S**）
+4. `useOnlineStatus` フック＋layout 常設オフラインバナー（**S**）
+5. `public/sw.js` に `/_next/static/` を Cache First にする分岐を追加（**S**・効果大）
+6. `ci.yml` に madge --circular を1ジョブ追加し循環依存を自動ブロック（**S**）
+7. 真のデッド3ファイル（MarkdownRenderer.tsx, lib/sounds.ts, lib/timeSync.ts）＋未使用依存4つを削除（唯一の as any も消える）（**S**）
+8. `globals.css` の `--spot`/`--btn-primary`/warning を AA 準拠の値に調整（**S**・変数1箇所）
+9. README/REPOSITORY.md の実在しないスクリプト記述を実態に修正（**S**）
+
+---
+
+## 8. 次のステップ
+
+「あらゆる面で100倍」は一度には実現できないため、**最も痛い穴（テーマA: データ安全性）を止めてから、テーマを1つずつ仕様→計画→実装**と進めるのが正攻法です。各テーマは独立した小さなプロジェクトとして、`docs/superpowers/specs/` に仕様、`docs/superpowers/plans/` に実装計画を残してから着手します。
+
+**推奨の最初の一歩**: テーマA の Top3（rank 1〜4）。中核の rank 1 は数分で最大効果、Issue #458 の再発防止に直結します。

--- a/docs/superpowers/plans/2026-05-31-data-safety-core.md
+++ b/docs/superpowers/plans/2026-05-31-data-safety-core.md
@@ -1,0 +1,662 @@
+# データ安全コア 実装計画（テーマA / rank1+2+3+4）
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 現場の入力データが「オフラインでも消えず・失敗したら見え・通信断が分かり・例外で白画面にならない」状態にする。
+
+**Architecture:** 既存の #458 防止ロジックは温存し、上に安全機能を追加的に重ねる。危険度の低い純追加（白画面防止・バナー）から始め、Firestore初期化変更、最後に最重要ファイル `useAppData` の再throw化を行う。再throw化の前に全 fire-and-forget 呼び出し元を安全化する。
+
+**Tech Stack:** Next.js 16 App Router / React 19 / TypeScript strict / Firebase Firestore (modular SDK) / Vitest / Testing Library
+
+**関連仕様:** `docs/superpowers/specs/2026-05-31-data-safety-core-design.md`
+
+---
+
+## ファイル構成
+
+**新規作成:**
+- `app/global-error.tsx` — ルートレイアウト例外の最終防壁（白画面防止）
+- `app/error.tsx` — 各ルート例外の復旧UI
+- `hooks/useOnlineStatus.ts` — `navigator.onLine` 購読フック
+- `hooks/useOnlineStatus.test.ts` — 上記のテスト
+- `components/OfflineBanner.tsx` — オフライン常設バナー
+
+**変更:**
+- `lib/firebase.ts` — Firestoreオフライン永続化（initializeFirestore + persistentLocalCache、3ガード付き）
+- `app/layout.tsx` — `OfflineBanner` を配置
+- `hooks/useScheduleOCR.ts` — `updateData` を await＋失敗時トースト、prop型を `Promise<void>` 化
+- `hooks/useNotifications.ts` — add/update/delete を try/catch＋失敗トースト、移行の `void` を `.catch` 化
+- `hooks/useHomeFeatureVisibility.ts` — 3箇所の `updateData` に `.catch` 追加
+- `hooks/useAppData.ts` — `updateData` の catch で `throw saveError`（再throw）
+- `hooks/useAppData.test.ts` — 保存失敗時に reject することを検証するテストへ更新
+
+**実装順序（安全な順）:** Task 1（白画面防止）→ Task 2（バナー）→ Task 3（永続化）→ Task 4（呼び出し元の事前安全化）→ Task 5（再throw）→ Task 6（統合検証）。
+
+**ブランチ:** `main` に直接コミットしない。実装前に `feat/data-safety-core`（または対応Issue番号付き）を切る。
+
+---
+
+### Task 1: 白画面防止（rank4）
+
+**Files:**
+- Create: `app/global-error.tsx`
+- Create: `app/error.tsx`
+
+純追加のため自動テストは設けず、`npm run build` 成功と手動確認で検証する。
+
+- [ ] **Step 1: `app/global-error.tsx` を作成**
+
+global-error はルートレイアウトを置き換えるため `html`/`body` を含み、`globals.css` に依存せずインラインスタイルで完結させる。
+
+```tsx
+'use client';
+
+export default function GlobalError({ reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <html lang="ja">
+      <body
+        style={{
+          margin: 0,
+          minHeight: '100vh',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: '16px',
+          padding: '24px',
+          fontFamily: 'system-ui, sans-serif',
+          background: '#f7f7f5',
+          color: '#261a14',
+          textAlign: 'center',
+        }}
+      >
+        <h1 style={{ fontSize: '20px', fontWeight: 700, margin: 0 }}>一時的な問題が発生しました</h1>
+        <p style={{ fontSize: '14px', margin: 0, opacity: 0.8 }}>
+          お手数ですが、再読み込みしてください。入力中のデータは保存されている場合があります。
+        </p>
+        <button
+          type="button"
+          onClick={() => reset()}
+          style={{
+            minHeight: '44px',
+            padding: '0 20px',
+            borderRadius: '12px',
+            border: 'none',
+            background: '#e48003',
+            color: '#ffffff',
+            fontSize: '15px',
+            fontWeight: 600,
+            cursor: 'pointer',
+          }}
+        >
+          再読み込み
+        </button>
+      </body>
+    </html>
+  );
+}
+```
+
+- [ ] **Step 2: `app/error.tsx` を作成**
+
+各ルートの例外を受ける復旧UI。`globals.css` が読まれているのでトークンクラスを使う。
+
+```tsx
+'use client';
+
+import Link from 'next/link';
+
+export default function Error({ reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center gap-4 px-6 text-center bg-page">
+      <h1 className="text-xl font-bold text-ink">一時的な問題が発生しました</h1>
+      <p className="text-sm text-ink-sub">
+        お手数ですが、再読み込みしてください。入力中のデータは保存されている場合があります。
+      </p>
+      <div className="flex gap-3">
+        <button
+          type="button"
+          onClick={() => reset()}
+          className="min-h-[44px] px-5 rounded-xl bg-btn-primary text-white text-[15px] font-semibold"
+        >
+          再読み込み
+        </button>
+        <Link
+          href="/"
+          className="min-h-[44px] px-5 rounded-xl border border-edge text-ink text-[15px] font-semibold flex items-center"
+        >
+          ホームへ
+        </Link>
+      </div>
+    </div>
+  );
+}
+```
+
+> 注: `text-ink-sub` / `bg-btn-primary` / `border-edge` は `app/globals.css` のトークン。存在しないクラスがあれば `app/globals.css` で定義済みの近いトークン（`text-ink` 等）に合わせる。可能なら共通 `Button` コンポーネントに置き換えてもよい（既存の import 慣習に合わせる）。
+
+- [ ] **Step 3: ビルドで検証**
+
+Run: `npm run build`
+Expected: 成功（`app/error.tsx` と `app/global-error.tsx` がルートに認識される）。
+
+- [ ] **Step 4: 手動確認（任意）**
+
+`app/error.tsx` の先頭に一時的に `throw new Error('test')` を入れて `npm run dev` で復旧UIが出ることを確認 → 確認後に削除。
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add app/global-error.tsx app/error.tsx
+git commit -m "feat: 例外時の白画面を復旧UIに置き換える(global-error/error)"
+```
+
+---
+
+### Task 2: オフライン検知フックとバナー（rank3）
+
+**Files:**
+- Create: `hooks/useOnlineStatus.ts`
+- Test: `hooks/useOnlineStatus.test.ts`
+- Create: `components/OfflineBanner.tsx`
+- Modify: `app/layout.tsx`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`hooks/useOnlineStatus.test.ts`:
+
+```tsx
+import { describe, it, expect, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useOnlineStatus } from './useOnlineStatus';
+
+function setOnline(value: boolean) {
+  Object.defineProperty(navigator, 'onLine', { value, configurable: true });
+}
+
+afterEach(() => {
+  setOnline(true);
+});
+
+describe('useOnlineStatus', () => {
+  it('navigator.onLine の初期値を返す', () => {
+    setOnline(false);
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(false);
+  });
+
+  it('online/offline イベントで値が切り替わる', () => {
+    setOnline(true);
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(true);
+
+    act(() => {
+      setOnline(false);
+      window.dispatchEvent(new Event('offline'));
+    });
+    expect(result.current).toBe(false);
+
+    act(() => {
+      setOnline(true);
+      window.dispatchEvent(new Event('online'));
+    });
+    expect(result.current).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `npm run test:run -- hooks/useOnlineStatus.test.ts`
+Expected: FAIL（`useOnlineStatus` が存在しない）。
+
+- [ ] **Step 3: フックを実装**
+
+`hooks/useOnlineStatus.ts`:
+
+```ts
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+function subscribe(callback: () => void): () => void {
+  window.addEventListener('online', callback);
+  window.addEventListener('offline', callback);
+  return () => {
+    window.removeEventListener('online', callback);
+    window.removeEventListener('offline', callback);
+  };
+}
+
+function getSnapshot(): boolean {
+  return navigator.onLine;
+}
+
+// SSR/ビルド時はオンライン扱い（バナー非表示）にする
+function getServerSnapshot(): boolean {
+  return true;
+}
+
+export function useOnlineStatus(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}
+```
+
+- [ ] **Step 4: テストを実行して成功を確認**
+
+Run: `npm run test:run -- hooks/useOnlineStatus.test.ts`
+Expected: PASS（2件）。
+
+- [ ] **Step 5: バナーコンポーネントを作成**
+
+`components/OfflineBanner.tsx`:
+
+```tsx
+'use client';
+
+import { useOnlineStatus } from '@/hooks/useOnlineStatus';
+
+export function OfflineBanner() {
+  const isOnline = useOnlineStatus();
+
+  if (isOnline) {
+    return null;
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed top-0 inset-x-0 z-[60] bg-warning text-page text-center text-sm font-medium py-1.5 px-4"
+    >
+      オフライン：変更は接続が戻ったときに保存されます
+    </div>
+  );
+}
+```
+
+> 注: `bg-warning text-page` は既存 `Button` の warning 変種と同じ配色慣習。コントラスト改善（監査 rank9）は別スコープ。
+
+- [ ] **Step 6: `app/layout.tsx` にバナーを配置**
+
+`import { OfflineBanner } from '@/components/OfflineBanner';` を追加し、`ToastProvider` 直下、`children` の前に置く。
+
+変更前（69行付近）:
+```tsx
+        <ThemeProvider>
+          <ToastProvider>{children}</ToastProvider>
+        </ThemeProvider>
+```
+変更後:
+```tsx
+        <ThemeProvider>
+          <ToastProvider>
+            <OfflineBanner />
+            {children}
+          </ToastProvider>
+        </ThemeProvider>
+```
+
+- [ ] **Step 7: ビルドと全テストで検証**
+
+Run: `npm run test:run -- hooks/useOnlineStatus.test.ts` → PASS
+Run: `npm run build` → 成功
+
+- [ ] **Step 8: コミット**
+
+```bash
+git add hooks/useOnlineStatus.ts hooks/useOnlineStatus.test.ts components/OfflineBanner.tsx app/layout.tsx
+git commit -m "feat: オフライン検知フックと常設バナーを追加"
+```
+
+---
+
+### Task 3: Firestoreオフライン永続化（rank2）
+
+**Files:**
+- Modify: `lib/firebase.ts`
+
+- [ ] **Step 1: import を追加**
+
+`lib/firebase.ts` の4行目を以下に変更（`initializeFirestore` / `persistentLocalCache` / `persistentMultipleTabManager` / 型 `Firestore` を追加）:
+
+```ts
+import {
+  connectFirestoreEmulator,
+  getFirestore,
+  initializeFirestore,
+  persistentLocalCache,
+  persistentMultipleTabManager,
+  type Firestore,
+} from 'firebase/firestore';
+```
+
+- [ ] **Step 2: 永続化付き初期化関数を追加し、`getFirestore(app)` を置き換える**
+
+27行目 `const firestoreInstance = getFirestore(app);` を以下に置き換える:
+
+```ts
+function createFirestore(): Firestore {
+  const useEmulator = process.env.NEXT_PUBLIC_FIREBASE_FIRESTORE_EMULATOR === 'true';
+
+  // ブラウザ以外（ビルド/SSR）、またはエミュレータ接続時はオフライン永続化を使わない
+  if (typeof window === 'undefined' || useEmulator) {
+    return getFirestore(app);
+  }
+
+  try {
+    // IndexedDB にオフライン永続化。複数タブでも安全なマネージャを使用
+    return initializeFirestore(app, {
+      localCache: persistentLocalCache({ tabManager: persistentMultipleTabManager() }),
+    });
+  } catch (error) {
+    // IndexedDB 不可・二重初期化などのフォールバック（機能は落とさない）
+    console.warn('Firestore offline persistence unavailable, using memory cache:', error);
+    return getFirestore(app);
+  }
+}
+
+const firestoreInstance = createFirestore();
+```
+
+> 注: `initializeFirestore` は他のFirestoreアクセスより前に呼ぶ必要があるが、`lib/firebase.ts` が唯一の初期化点でモジュール読込時に1回だけ実行されるため順序は保証される。エミュレータ接続（44-54行）は従来どおりこの後に行われる。
+
+- [ ] **Step 3: 型チェックとビルドで検証**
+
+Run: `npm run typecheck`
+Expected: エラーなし。
+
+Run: `npm run build`
+Expected: 成功（ブラウザ限定ガードでビルド時はメモリキャッシュ）。
+
+- [ ] **Step 4: 全ユニットテストで回帰確認**
+
+Run: `npm run test:run`
+Expected: 既存テストが全てPASS（firestore はテストでモックされるため影響なし）。
+
+- [ ] **Step 5: 手動確認（推奨）**
+
+`npm run dev` → DevTools の Application > IndexedDB に `firestore` 系DBが作られることを確認。Network を Offline にして本日のスケジュールを編集 → 入力が残り、Online 復帰で同期されることを確認。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add lib/firebase.ts
+git commit -m "feat: Firestoreオフライン永続化を有効化(ブラウザ限定・エミュレータ時無効)"
+```
+
+---
+
+### Task 4: 呼び出し元の事前安全化（再throw化の前提）
+
+再throw化（Task 5）の前に、`updateData` を await していない／エラー処理していない呼び出し元を安全化する。これにより未処理のPromiseRejectionを防ぐ。
+
+**Files:**
+- Modify: `hooks/useScheduleOCR.ts`
+- Modify: `hooks/useNotifications.ts`
+- Modify: `hooks/useHomeFeatureVisibility.ts`
+
+- [ ] **Step 1: `useScheduleOCR.ts` の prop 型を `Promise<void>` に変更**
+
+8行目:
+```ts
+  updateData: (data: AppData) => void;
+```
+を:
+```ts
+  updateData: (data: AppData) => Promise<void>;
+```
+
+- [ ] **Step 2: `handleOCRSuccess` を async 化し、保存を内部ヘルパーで await＋失敗トーストにする**
+
+`replace`/`add` 各分岐の `updatedTodaySchedules`/`updatedRoastSchedules` はブロックスコープの `const` なので、分岐後の単一 try/catch からは参照できない。型を知らなくても安全に書けるよう、保存処理を `AppData` を受け取る内部ヘルパー `persist` に切り出し、各分岐の末尾でそれを `await` する。
+
+具体的には:
+1. コールバックを `async` にする（14行目 `(mode, timeLabels, roastSchedules) =>` の前に `async` を付ける）。
+2. `if (!data) return;` の直後に内部ヘルパーを定義:
+
+```tsx
+      const persist = async (next: AppData) => {
+        try {
+          await updateData(next);
+          showToast('スケジュールを読み取りました。', 'success');
+        } catch (error) {
+          console.error('Failed to save OCR schedule:', error);
+          showToast('スケジュールの保存に失敗しました。通信を確認してもう一度お試しください。', 'error');
+        }
+      };
+```
+
+3. `replace` 分岐末尾（現43-47行）の `updateData({...})` を `await persist({...})` に変更:
+
+```tsx
+        await persist({
+          ...data,
+          todaySchedules: updatedTodaySchedules,
+          roastSchedules: updatedRoastSchedules,
+        });
+```
+
+4. `add` 分岐末尾（現87-91行）の `updateData({...})` も同様に `await persist({...})` に変更。
+5. 分岐の外にある成功トースト（現94行 `showToast('スケジュールを読み取りました。', 'success');`）は `persist` 内へ移したので**削除**する。
+
+依存配列 `[data, selectedDate, updateData, showToast]` は変更不要。
+
+> 実装メモ: マージ計算ロジック（19-92行の `updatedTodaySchedules`/`updatedRoastSchedules` 構築）は一切変更しない。変更は「保存呼び出しを `await persist(...)` に置換」「分岐外の成功トーストを削除」のみ。`handleOCRSuccess` を呼ぶOCRモーダルは戻り値を await しないため、内部で catch して未処理Rejectionを防ぐ。
+
+- [ ] **Step 3: `useNotifications.ts` に Toast を導入し、保存系を try/catch 化**
+
+3行目付近に import を追加:
+```ts
+import { useToastContext } from '@/components/Toast';
+```
+`useNotifications` 本体先頭（10行目付近）に追加:
+```ts
+  const { showToast } = useToastContext();
+```
+
+移行処理の61行目 `void updateData({...})` を `.catch` 付きに変更:
+```ts
+            updateData({
+              ...currentData,
+              notifications: newNotifications,
+            }).catch((error) => {
+              console.error('Failed to migrate notifications:', error);
+            });
+```
+
+`addNotification`（100-113行）、`updateNotification`（116-125行）、`deleteNotification`（128-145行）の各 `await updateData({...})` を try/catch で囲み、失敗時にトーストを出す。例（addNotification）:
+```ts
+      try {
+        await updateData({
+          ...data,
+          notifications: updatedNotifications,
+        });
+      } catch (error) {
+        console.error('Failed to save notification:', error);
+        showToast('通知の保存に失敗しました。通信を確認してもう一度お試しください。', 'error');
+      }
+```
+`updateNotification` / `deleteNotification` も同じ形で `await updateData({...})` を try/catch にし、同じエラートーストを出す。各 useCallback の依存配列に `showToast` を追加する。
+
+> これにより通知ページ側（`app/notifications/page.tsx:97,123,146,204,206`）の fire-and-forget 呼び出しはフック内で安全化され、ページ変更は不要。
+
+- [ ] **Step 4: `useHomeFeatureVisibility.ts` の3箇所に `.catch` を追加**
+
+46行目（移行）、64行目（updateFeatureHidden）、78行目（resetVisibility）の `updateData((currentData) => ({...}))` の末尾に `.catch` を付ける。例:
+```ts
+      updateData((currentData: AppData) => ({
+        ...currentData,
+        userSettings: {
+          ...currentData.userSettings,
+          homeHiddenFeatureKeys: nextKeys,
+        },
+      })).catch((error) => {
+        console.error('Failed to save home feature visibility:', error);
+      });
+```
+3箇所すべて同様に `.catch((error) => { console.error('Failed to save home feature visibility:', error); })` を付ける（ホーム表示設定はローカル state を既に更新済みのため、失敗はログのみで可）。
+
+- [ ] **Step 5: 型チェックと全テストで検証**
+
+Run: `npm run typecheck` → エラーなし（特に `useScheduleOCR` の prop 型変更が `app/schedule/page.tsx` の呼び出しと整合することを確認。実 `updateData` は `Promise<void>` を返すため整合する）。
+Run: `npm run test:run` → 既存テスト全てPASS。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add hooks/useScheduleOCR.ts hooks/useNotifications.ts hooks/useHomeFeatureVisibility.ts
+git commit -m "fix: updateDataの再throw化に備え呼び出し元のエラー処理を整備"
+```
+
+---
+
+### Task 5: updateData の保存失敗を再throw（rank1）
+
+**Files:**
+- Modify: `hooks/useAppData.ts:279-301`
+- Test: `hooks/useAppData.test.ts:491-519`
+
+- [ ] **Step 1: 既存テストを「reject する」検証に更新（Red）**
+
+`hooks/useAppData.test.ts` の `describe('updateData - リカバリエラーハンドリング', ...)`（491-519行）を以下に置き換える。保存失敗時に `updateData` が reject し、巻き戻し（getUserData）も呼ばれることを検証する。
+
+```ts
+  describe('updateData - リカバリエラーハンドリング', () => {
+    it('保存失敗時に updateData が reject し、エラーがログされる', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const saveError = new Error('Save failed');
+      mockSaveUserData.mockRejectedValue(saveError);
+
+      const { result } = renderHook(() => useAppData());
+
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      await act(async () => {
+        await expect(
+          result.current.updateData({ ...mockUserData, encouragementCount: 10 })
+        ).rejects.toThrow('Save failed');
+        await vi.runAllTimersAsync();
+      });
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to save data:', saveError);
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('保存失敗後の再取得も失敗した場合、両方のエラーがログされ reject する', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const saveError = new Error('Save failed');
+      const recoveryError = new Error('Recovery also failed');
+      mockSaveUserData.mockRejectedValue(saveError);
+
+      const { result } = renderHook(() => useAppData());
+
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      mockGetUserData.mockRejectedValue(recoveryError);
+
+      await act(async () => {
+        await expect(
+          result.current.updateData({ ...mockUserData, encouragementCount: 10 })
+        ).rejects.toThrow('Save failed');
+        await vi.runAllTimersAsync();
+      });
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to save data:', saveError);
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to recover data:', recoveryError);
+      consoleErrorSpy.mockRestore();
+    });
+  });
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `npm run test:run -- hooks/useAppData.test.ts`
+Expected: FAIL（現状の `updateData` は reject しないため `.rejects.toThrow` が失敗する）。
+
+- [ ] **Step 3: `updateData` の catch 末尾で再throw する（Green）**
+
+`hooks/useAppData.ts` の catch ブロック（279-292行）末尾、巻き戻しの `getUserData(...).then/catch` の後に `throw saveError;` を追加する。
+
+変更後の catch（279行〜）:
+```ts
+      } catch (error) {
+        saveError = error;
+        console.error('Failed to save data:', error);
+        lockedKeysRef.current.clear();
+        pendingSaveCountRef.current = 0;
+        isUpdatingRef.current = false;
+
+        getUserData(user.uid)
+          .then((freshData) => {
+            commitData(freshData);
+          })
+          .catch((err) => {
+            console.error('Failed to recover data:', err);
+          });
+
+        throw saveError;
+      } finally {
+```
+
+> `finally`（293-301行）はそのまま。`throw` は `finally` 実行後に伝播する。
+
+- [ ] **Step 4: テストを実行して成功を確認**
+
+Run: `npm run test:run -- hooks/useAppData.test.ts`
+Expected: PASS（更新した2件を含む）。
+
+- [ ] **Step 5: 全テストで回帰確認**
+
+Run: `npm run test:run`
+Expected: 全PASS（Task 4 で呼び出し元を安全化済みのため、他テストに未処理Rejectionが出ない）。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add hooks/useAppData.ts hooks/useAppData.test.ts
+git commit -m "fix: updateDataの保存失敗を再throwし全機能のエラー通知を有効化"
+```
+
+---
+
+### Task 6: 統合検証
+
+**Files:** なし（検証のみ）
+
+- [ ] **Step 1: 全ユニットテスト**
+
+Run: `npm run test:run`
+Expected: 全PASS。
+
+- [ ] **Step 2: 型チェック・Lint・フォーマット**
+
+Run: `npm run typecheck` → エラーなし
+Run: `npm run lint` → エラー・warningゼロ
+Run: `npm run format:check` → 差分なし（あれば `npm run format` 実行後に再コミット）
+
+- [ ] **Step 3: 本番ビルド**
+
+Run: `npm run build`
+Expected: 成功。
+
+- [ ] **Step 4: 手動オフライン検証（実機/ブラウザ）**
+
+`npm run dev` で以下を確認:
+1. DevTools Network = Offline → 上部にオフラインバナーが出る。本日のスケジュール/通知を編集 → 入力が残る。
+2. Network = Online に戻す → 入力がFirestoreへ同期され、再読み込みしても残る。
+3. 保存失敗の擬似（例: 一時的に Firestore Rules を拒否、または DevTools で Firestore リクエストをブロック）→ エラートーストが出て、嘘の成功トーストが出ない。
+4. 試飲の新規セッション保存が失敗するケースで、一覧へ遷移せずフォームに留まりエラーが出る。
+5. `app/error.tsx` に一時的な `throw` を入れて復旧UIが出る（確認後に削除）。
+
+- [ ] **Step 5: 受け入れ条件の確認**
+
+`docs/superpowers/specs/2026-05-31-data-safety-core-design.md` の「8. 受け入れ条件」を1項目ずつ確認し、未達があれば該当 Task に戻る。
+
+- [ ] **Step 6: ブランチ完成処理**
+
+`superpowers:finishing-a-development-branch` に従い、PR作成またはマージ方針をユーザーに確認する（コミット・push・PR作成はユーザーの明示依頼後）。

--- a/docs/superpowers/specs/2026-05-31-data-safety-core-design.md
+++ b/docs/superpowers/specs/2026-05-31-data-safety-core-design.md
@@ -1,0 +1,151 @@
+# データ安全コア 設計仕様（テーマA / rank1+2+3+4）
+
+- **作成日**: 2026-05-31
+- **関連監査**: `docs/audits/2026-05-31-roastplus-100x-audit.md`（総合6/10、テーマA）
+- **スコープ**: rank1（保存失敗の再throw）+ rank2（Firestoreオフライン永続化）+ rank3（オフライン検知バナー）+ rank4（白画面防止）
+- **ステータス**: 設計承認済み（ユーザー承認 2026-05-31）→ レビュー待ち → 実装計画へ
+
+---
+
+## 1. 目的
+
+現場8名が毎日入力する業務データ（焙煎スケジュール・試飲・欠点豆・通知など）が「保存に失敗しても気づけず、画面から黙って消える」状態を解消する。具体的には次の4点を1セットで満たす。
+
+- **そもそも消えない**（オフラインでも入力がローカルに保存され、復帰時に自動同期）
+- **消えたら分かる**（保存失敗がエラーとしてユーザーに見える）
+- **通信断が分かる**（オフライン状態を画面に常設表示）
+- **壊れても止まらない**（レンダリング例外で白画面にならず、再読み込みで復帰）
+
+## 2. 背景となる問題
+
+- `hooks/useAppData.ts` の `updateData`（関数は215-304行、該当の `catch` は279-292行）が保存失敗を `console.error` で握りつぶし、**再throwしない**。失敗時はサーバーの古い値を再取得して画面を上書きする。
+- このため `schedule`/`tasting`/`defect-beans`/`notifications`/`home` の呼び出し元に書かれた try/catch＋エラートーストが**全て到達不能な死にコード**になり、保存失敗が嘘の『保存しました』で隠蔽される。
+- `lib/firebase.ts:27` はオフライン永続化なし（素の `getFirestore`）。
+- `navigator.onLine` によるオフライン検知がリポジトリ全体で0件。
+- `app/error.tsx` / `app/global-error.tsx` / ErrorBoundary が一切存在せず、レンダリング例外で白画面になる。
+- **実害**: Issue #458 で本番データ全消失（試飲4セッション+16記録+スケジュール12件）が発生済み。理論上のリスクではなく再発する実害。
+
+## 3. 対象ユーザー
+
+- 現場スタッフ約8名（iPad / スマホ、電波が不安定なことがある作業場でPWAを利用）
+- 保守者1名（IK、初心者寄り。危険な変更を見抜き安全に運用したい）
+
+## 4. 現在の挙動
+
+- オフライン/通信断時に保存すると、`write-queue` 経由の書き込みが解決せず（または resource-exhausted で reject）、`updateData` は例外を握りつぶして成功扱いで解決。直後にサーバー値で画面が巻き戻り、入力が消える。
+- 試飲の新規セッション保存（`app/tasting/sessions/new/page.tsx`）は `await updateData(...)` を try/catch で囲むが、`updateData` が reject しないため catch が発火せず、保存失敗でも一覧へ遷移する（false success）。
+- オフラインかどうかをユーザーが知る手段がない。
+- どこかのコンポーネントが例外を投げると画面全体が白くなり、現場は復旧できない。
+
+## 5. 期待する挙動
+
+- オフライン中の保存は失敗ではなく「ローカルに保存され、接続復帰時に自動同期」される（IndexedDB永続化）。
+- 永続化で吸収できない本当の保存失敗（権限エラー・無効データ・write stream exhausted 枯渇など）は `updateData` が reject し、既存のエラートーストが表示される。
+- オフライン時は画面上部に常設バナー「オフライン：変更は接続が戻ったときに保存されます」を表示。
+- レンダリング例外時は白画面の代わりに「一時的な問題が発生しました。再読み込みしてください」＋再読み込みボタンを表示。
+
+## 6. 設計詳細
+
+### 基本方針：既存の #458 防止ロジックは「壊さず温存」
+
+`useAppData` の消失防止ロジック（`applyIncomingSnapshot` の空スナップショット無視 98-119行、`lockedKeysRef` のフィールドロック、`FIRESTORE_ACK_TIMEOUT_MS` のackタイムアウト）は今回作り直さず、その上に安全機能を追加的に重ねる。永続化の導入後にこの機構を簡素化できる可能性はあるが、それは別途テストを固めてからの将来課題とする。
+
+### A. rank2 — Firestoreオフライン永続化（`lib/firebase.ts`）
+
+- `getFirestore(app)`（27行）を `initializeFirestore(app, { localCache: persistentLocalCache({ tabManager: persistentMultipleTabManager() }) })` に変更する。`persistentMultipleTabManager` は単一タブでも安全に動作する。
+- **3つのガードを付ける**:
+  1. **ブラウザ限定**: `typeof window !== 'undefined'` のときのみ永続化を有効化。静的エクスポートのビルド時（Node/SSR）と IndexedDB 非対応環境では従来どおり `getFirestore(app)`（メモリキャッシュ）にフォールバック。
+  2. **エミュレータ時は無効**: `NEXT_PUBLIC_FIREBASE_FIRESTORE_EMULATOR === 'true'` のときは永続化を有効化しない（E2Eの決定性確保・キャッシュのテスト間汚染防止）。
+  3. **フォールバック**: `initializeFirestore` が失敗（IndexedDB不可など）した場合は `getFirestore(app)` で続行し、機能を落とさない。
+- `initializeFirestore` は他のFirestore利用より先に呼ぶ必要があるが、`lib/firebase.ts` が単一の初期化点のため順序は保証される。`connectFirestoreEmulator` は従来どおりその後に呼ぶ。
+- **学習ポイント**: 永続化を入れても「保存完了の合図（サーバー応答）」はオンライン復帰まで返らない。変わるのは入力がローカルに durable に貯まり復帰時に自動同期されること。
+
+### B. rank1 — `updateData` の保存失敗を再throw（`hooks/useAppData.ts`）
+
+- `updateData` の `catch`（279-292行）末尾、巻き戻し処理（`getUserData`→`commitData`）の後で `throw saveError` する。`finally`（293-301行）の状態クリーンアップは維持。
+- これにより、`await updateData(...)` を try/catch している呼び出し元のエラートーストが復活する。
+- **未処理Rejection対策（必須）**: 再throwにより `await` していない呼び出し元（fire-and-forget）が未処理のPromiseRejectionを起こすため、以下を個別対応する。
+
+| 呼び出し元 | 現状 | 対応 |
+|---|---|---|
+| `hooks/useScheduleOCR.ts:43, 87` | awaitなし | `await` 化し、失敗時に「スケジュールの保存に失敗しました」トースト。成功トーストは保存成功後のみ表示 |
+| `hooks/useNotifications.ts:61` | `void updateData(...)` | `.catch` で握り、必要に応じてログ（既読同期の失敗・軽微） |
+| `hooks/useHomeFeatureVisibility.ts:46, 64, 78` | awaitなし | `.catch(console.error)`（ホーム表示設定・軽微、UIは楽観反映済み） |
+| `hooks/useDefectBeans.ts:83,148,184`, `hooks/useDefectBeanSettings.ts:29,66` | await＋try/catch | 変更不要（再throwで既存catchが生き返る。画像順序の是正=rank16は別スコープ） |
+| `app/tasting/page.tsx:83,104,160,179`, `app/tasting/sessions/new/page.tsx:51` | await＋try/catch | 変更不要（再throwで既存catchが生き返り、false success も解消） |
+
+### C. rank3 — オフライン検知バナー（新規 `hooks/useOnlineStatus.ts` ＋ `app/layout.tsx`）
+
+- `hooks/useOnlineStatus.ts`: `navigator.onLine` を初期値に、`online`/`offline` イベントを購読して boolean を返す小フック。SSR安全（初期は `true` 扱い、マウント後に実値へ）。
+- `app/layout.tsx`: オフライン時のみ画面上部に控えめな常設バナー「オフライン：変更は接続が戻ったときに保存されます」を表示。色・余白は `DESIGN.md` とトークン（例 `bg-warning`/`text-*`）に従い、既存の共通UI方針を踏襲。
+- 保存ロジックには干渉しない純粋な追加。
+
+### D. rank4 — 白画面防止（新規 `app/global-error.tsx`・`app/error.tsx`・軽量 ErrorBoundary）
+
+- `app/global-error.tsx`: ルートレイアウトの例外を受ける最終防壁。`html`/`body` を含む最小UIで「一時的な問題が発生しました。再読み込みしてください」＋再読み込みボタン（`reset()` または `location.reload()`）。
+- `app/error.tsx`: 各機能ルートの例外を受ける復旧UI（再読み込み＋ホームへ戻る導線）。
+- 軽量 ErrorBoundary クラスコンポーネント: `app/layout.tsx` の children を包み、`error.tsx` が拾えない描画例外も白画面化させない（任意・段階導入可）。
+- 静的エクスポート（`output: 'export'`）でも Next.js 標準のクライアント境界として動作する。
+
+### E. 実装順序（安全な順・各ステップでテスト緑を確認）
+
+1. **rank4**（白画面防止・無リスク、純追加）
+2. **rank3**（バナー・無リスク、純追加）
+3. **rank2**（永続化・中リスク、初期化変更）
+4. **rank1**（再throw＋呼び出し元対応・中リスク、最重要ファイル）
+
+危険なものを後段にし、各ステップで `npm run test:run` を緑に保ちながら段階コミットする。
+
+## 7. 具体例（受け入れシナリオ）
+
+- **オフライン保存**: DevTools の Network を Offline にして本日のスケジュールを編集 → 入力が画面に残り、バナーが「オフライン」を表示。Online に戻すと自動的にFirestoreへ同期され、再読み込み後も入力が残っている。
+- **本当の保存失敗**: 権限エラー等を擬似的に発生させると、エラートースト「保存に失敗しました…」が表示され、嘘の成功トーストは出ない。
+- **試飲新規保存の失敗**: 保存が reject すると一覧へ遷移せずフォームに留まり、エラーが表示される。
+- **描画例外**: 想定外データで例外が起きても白画面にならず、再読み込みボタン付きの復旧UIが出る。
+
+## 8. 受け入れ条件
+
+- [ ] オフライン中の保存入力が、再読み込み・接続復帰をまたいで失われない（IndexedDB永続化が有効）。
+- [ ] 永続化で吸収できない保存失敗時に `updateData` が reject し、既存エラートーストが表示される。
+- [ ] fire-and-forget の呼び出し元（OCR・通知・ホーム表示設定）が未処理Rejectionを起こさない。
+- [ ] オフライン時に常設バナーが表示され、オンライン復帰で消える。
+- [ ] レンダリング例外時に白画面でなく復旧UI（再読み込みボタン）が表示される。
+- [ ] 既存の #458 防止ロジック（空スナップショット無視・フィールドロック）の挙動が回帰していない。
+- [ ] `npm run test:run` と `npm run build` が緑。
+
+## 9. 影響範囲
+
+- **影響する画面**: 全機能（保存経路）、`app/layout.tsx`（バナー・境界）、`schedule`/`tasting`/`defect-beans`/`notifications`/`home`（エラートースト復活）。
+- **影響するデータ**: なし（データ構造・スキーマ変更なし）。永続化は端末ローカルの IndexedDB キャッシュのみで、サーバー側データに無影響。
+- **認証・認可・Firestore Rules / Storage Rules**: 影響なし（読み書きの宛先・権限モデルは不変）。
+- **Cloud Functions**: 影響なし。
+- **Service Worker / キャッシュ**: 影響なし（SWは別。永続化はFirestore SDKのIndexedDB）。
+- **本番ビルド**: `lib/firebase.ts` の初期化変更。ブラウザ限定ガードで静的エクスポートのビルドに無影響。
+
+## 10. テスト方針（TDD）
+
+- `hooks/useAppData.test.ts`: 「保存失敗時に `updateData` が **reject する**」テストを追加（現状は「エラーがログされる」のみ検証）。巻き戻しが維持されることも確認。
+- 新規 `hooks/useOnlineStatus.test.ts`: `online`/`offline` イベントで返り値が切り替わる。
+- 呼び出し元: OCR/通知/ホーム表示設定が失敗時にトースト／`.catch` で安全に処理されることを確認。
+- 手動確認: DevTools Network Offline で保存→復帰同期、権限エラー擬似で失敗トースト、描画例外で復旧UI。
+- コマンド: `npm run test:run`、`npm run build`、必要に応じ `npm run test:e2e`。
+
+## 11. 安全策・ロールバック
+
+- データ構造・Rules を一切変えないため、**コードを戻すだけで完全に元に戻せる**。マイグレーション不要。
+- 永続化は端末ローカルキャッシュのみでサーバーデータに無影響。
+- 4ステップを段階コミットし、問題があればステップ単位で revert 可能にする。
+- 実装はベースブランチ `main` に直接行わず、`feat/#<issue>-data-safety-core` 等のブランチで進める。
+
+## 12. やらないこと（スコープ外）
+
+- rank5（保存状態インジケータ＋再試行トースト）
+- rank16（欠点豆の画像削除/保存順序の是正）
+- rank15（tasting/schedule のサブコレクション移行・XL）
+- `useAppData` 消失防止ロジックの簡素化/作り直し
+- 上記は本スペック完了後、別スペックとして順次対応する。
+
+## 13. 未決事項
+
+- オフライン時の `await saveUserData` が「pending のままハングする」か「一定後に reject する」かの厳密な挙動は、実装時のTDDでテストで固定し、`updateData` の await 設計（タイムアウトの要否）を確定する。永続化導入でこの挙動が変わる可能性も含めて検証する。
+- 軽量 ErrorBoundary をlayoutに常設するか、`error.tsx`/`global-error.tsx` のみで十分かは、実装時に挙動を見て判断（段階導入可）。

--- a/hooks/useAppData.test.ts
+++ b/hooks/useAppData.test.ts
@@ -306,12 +306,12 @@ describe('useAppData', () => {
         await vi.runAllTimersAsync();
       });
 
-      const updatePromise = act(async () => {
-        await result.current.updateData({ ...mockUserData, encouragementCount: 10 });
+      await act(async () => {
+        await expect(
+          result.current.updateData({ ...mockUserData, encouragementCount: 10 })
+        ).rejects.toThrow('Save failed');
         await vi.runAllTimersAsync();
       });
-
-      await updatePromise;
 
       expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to save data:', error);
       expect(mockGetUserData).toHaveBeenCalledTimes(2); // 初回読み込み + エラー後の再取得
@@ -489,11 +489,9 @@ describe('useAppData', () => {
   });
 
   describe('updateData - リカバリエラーハンドリング', () => {
-    it('保存エラー後のデータ再取得も失敗した場合のエラーハンドリング', async () => {
+    it('保存失敗時に updateData が reject し、エラーがログされる', async () => {
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       const saveError = new Error('Save failed');
-      const recoveryError = new Error('Recovery also failed');
-
       mockSaveUserData.mockRejectedValue(saveError);
 
       const { result } = renderHook(() => useAppData());
@@ -502,18 +500,40 @@ describe('useAppData', () => {
         await vi.runAllTimersAsync();
       });
 
-      // 再取得も失敗するように設定
-      mockGetUserData.mockRejectedValue(recoveryError);
-
       await act(async () => {
-        await result.current.updateData({ ...mockUserData, encouragementCount: 10 });
+        await expect(
+          result.current.updateData({ ...mockUserData, encouragementCount: 10 })
+        ).rejects.toThrow('Save failed');
         await vi.runAllTimersAsync();
       });
 
-      // 保存エラーとリカバリエラーの両方がログされる
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to save data:', saveError);
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('保存失敗後の再取得も失敗した場合、両方のエラーがログされ reject する', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const saveError = new Error('Save failed');
+      const recoveryError = new Error('Recovery also failed');
+      mockSaveUserData.mockRejectedValue(saveError);
+
+      const { result } = renderHook(() => useAppData());
+
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      mockGetUserData.mockRejectedValue(recoveryError);
+
+      await act(async () => {
+        await expect(
+          result.current.updateData({ ...mockUserData, encouragementCount: 10 })
+        ).rejects.toThrow('Save failed');
+        await vi.runAllTimersAsync();
+      });
+
       expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to save data:', saveError);
       expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to recover data:', recoveryError);
-
       consoleErrorSpy.mockRestore();
     });
   });

--- a/hooks/useAppData.test.ts
+++ b/hooks/useAppData.test.ts
@@ -307,9 +307,9 @@ describe('useAppData', () => {
       });
 
       await act(async () => {
-        await expect(
-          result.current.updateData({ ...mockUserData, encouragementCount: 10 })
-        ).rejects.toThrow('Save failed');
+        await expect(result.current.updateData({ ...mockUserData, encouragementCount: 10 })).rejects.toThrow(
+          'Save failed'
+        );
         await vi.runAllTimersAsync();
       });
 
@@ -501,9 +501,9 @@ describe('useAppData', () => {
       });
 
       await act(async () => {
-        await expect(
-          result.current.updateData({ ...mockUserData, encouragementCount: 10 })
-        ).rejects.toThrow('Save failed');
+        await expect(result.current.updateData({ ...mockUserData, encouragementCount: 10 })).rejects.toThrow(
+          'Save failed'
+        );
         await vi.runAllTimersAsync();
       });
 
@@ -526,9 +526,9 @@ describe('useAppData', () => {
       mockGetUserData.mockRejectedValue(recoveryError);
 
       await act(async () => {
-        await expect(
-          result.current.updateData({ ...mockUserData, encouragementCount: 10 })
-        ).rejects.toThrow('Save failed');
+        await expect(result.current.updateData({ ...mockUserData, encouragementCount: 10 })).rejects.toThrow(
+          'Save failed'
+        );
         await vi.runAllTimersAsync();
       });
 

--- a/hooks/useAppData.ts
+++ b/hooks/useAppData.ts
@@ -290,6 +290,8 @@ export function useAppData() {
           .catch((err) => {
             console.error('Failed to recover data:', err);
           });
+
+        throw saveError;
       } finally {
         if (mutatedKeys.length > 0) {
           pendingSaveCountRef.current = Math.max(0, pendingSaveCountRef.current - 1);

--- a/hooks/useHomeFeatureVisibility.test.ts
+++ b/hooks/useHomeFeatureVisibility.test.ts
@@ -29,6 +29,7 @@ describe('useHomeFeatureVisibility', () => {
   beforeEach(() => {
     localStorage.clear();
     mockUpdateData.mockReset();
+    mockUpdateData.mockResolvedValue(undefined);
     mockData = { ...baseData };
   });
 

--- a/hooks/useHomeFeatureVisibility.ts
+++ b/hooks/useHomeFeatureVisibility.ts
@@ -49,7 +49,9 @@ export function useHomeFeatureVisibility() {
         ...currentData.userSettings,
         homeHiddenFeatureKeys: localHiddenKeys,
       },
-    }));
+    })).catch((error) => {
+      console.error('Failed to save home feature visibility:', error);
+    });
   }, [accountHiddenKeys, isLoading, localHiddenKeys, updateData]);
 
   const updateFeatureHidden = useCallback(
@@ -67,7 +69,9 @@ export function useHomeFeatureVisibility() {
           ...currentData.userSettings,
           homeHiddenFeatureKeys: nextKeys,
         },
-      }));
+      })).catch((error) => {
+        console.error('Failed to save home feature visibility:', error);
+      });
     },
     [hiddenKeys, updateData]
   );
@@ -81,7 +85,9 @@ export function useHomeFeatureVisibility() {
         ...currentData.userSettings,
         homeHiddenFeatureKeys: [],
       },
-    }));
+    })).catch((error) => {
+      console.error('Failed to save home feature visibility:', error);
+    });
   }, [updateData]);
 
   const isVisible = useCallback((key: HomeFeatureKey) => !hiddenKeys.includes(key), [hiddenKeys]);

--- a/hooks/useNotifications.ts
+++ b/hooks/useNotifications.ts
@@ -2,12 +2,14 @@
 
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useAppData } from './useAppData';
+import { useToastContext } from '@/components/Toast';
 import type { Notification } from '@/types';
 
 const READ_IDS_STORAGE_KEY = 'roastplus_notification_read_ids';
 
 export function useNotifications() {
   const { data, updateData, isLoading: appDataLoading } = useAppData();
+  const { showToast } = useToastContext();
   const [readIds, setReadIds] = useState<string[]>(() => {
     if (typeof window === 'undefined') return [];
     try {
@@ -58,9 +60,11 @@ export function useNotifications() {
           ];
 
           if (newNotifications.length !== firestoreNotifications.length) {
-            void updateData({
+            updateData({
               ...currentData,
               notifications: newNotifications,
+            }).catch((error) => {
+              console.error('Failed to migrate notifications:', error);
             });
           }
 
@@ -104,24 +108,34 @@ export function useNotifications() {
         id: crypto.randomUUID(),
       };
       const updatedNotifications = [...notifications, newNotification];
-      await updateData({
-        ...data,
-        notifications: updatedNotifications,
-      });
+      try {
+        await updateData({
+          ...data,
+          notifications: updatedNotifications,
+        });
+      } catch (error) {
+        console.error('Failed to save notification:', error);
+        showToast('通知の保存に失敗しました。通信を確認してもう一度お試しください。', 'error');
+      }
     },
-    [notifications, data, updateData]
+    [notifications, data, updateData, showToast]
   );
 
   // 通知を更新
   const updateNotification = useCallback(
     async (id: string, updates: Partial<Notification>) => {
       const updatedNotifications = notifications.map((n) => (n.id === id ? { ...n, ...updates } : n));
-      await updateData({
-        ...data,
-        notifications: updatedNotifications,
-      });
+      try {
+        await updateData({
+          ...data,
+          notifications: updatedNotifications,
+        });
+      } catch (error) {
+        console.error('Failed to save notification:', error);
+        showToast('通知の保存に失敗しました。通信を確認してもう一度お試しください。', 'error');
+      }
     },
-    [notifications, data, updateData]
+    [notifications, data, updateData, showToast]
   );
 
   // 通知を削除
@@ -136,12 +150,17 @@ export function useNotifications() {
       } catch (error) {
         console.error('Failed to update readIds in localStorage:', error);
       }
-      await updateData({
-        ...data,
-        notifications: updatedNotifications,
-      });
+      try {
+        await updateData({
+          ...data,
+          notifications: updatedNotifications,
+        });
+      } catch (error) {
+        console.error('Failed to save notification:', error);
+        showToast('通知の保存に失敗しました。通信を確認してもう一度お試しください。', 'error');
+      }
     },
-    [notifications, readIds, data, updateData]
+    [notifications, readIds, data, updateData, showToast]
   );
 
   return {

--- a/hooks/useOnlineStatus.test.ts
+++ b/hooks/useOnlineStatus.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useOnlineStatus } from './useOnlineStatus';
+
+function setOnline(value: boolean) {
+  Object.defineProperty(navigator, 'onLine', { value, configurable: true });
+}
+
+afterEach(() => {
+  setOnline(true);
+});
+
+describe('useOnlineStatus', () => {
+  it('navigator.onLine の初期値を返す', () => {
+    setOnline(false);
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(false);
+  });
+
+  it('online/offline イベントで値が切り替わる', () => {
+    setOnline(true);
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(true);
+
+    act(() => {
+      setOnline(false);
+      window.dispatchEvent(new Event('offline'));
+    });
+    expect(result.current).toBe(false);
+
+    act(() => {
+      setOnline(true);
+      window.dispatchEvent(new Event('online'));
+    });
+    expect(result.current).toBe(true);
+  });
+});

--- a/hooks/useOnlineStatus.ts
+++ b/hooks/useOnlineStatus.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+function subscribe(callback: () => void): () => void {
+  window.addEventListener('online', callback);
+  window.addEventListener('offline', callback);
+  return () => {
+    window.removeEventListener('online', callback);
+    window.removeEventListener('offline', callback);
+  };
+}
+
+function getSnapshot(): boolean {
+  return navigator.onLine;
+}
+
+// SSR/ビルド時はオンライン扱い（バナー非表示）にする
+function getServerSnapshot(): boolean {
+  return true;
+}
+
+export function useOnlineStatus(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/hooks/useScheduleOCR.ts
+++ b/hooks/useScheduleOCR.ts
@@ -5,15 +5,25 @@ import { useToastContext } from '@/components/Toast';
 interface UseScheduleOCRProps {
   data: AppData | null;
   selectedDate: string;
-  updateData: (data: AppData) => void;
+  updateData: (data: AppData) => Promise<void>;
 }
 
 export function useScheduleOCR({ data, selectedDate, updateData }: UseScheduleOCRProps) {
   const { showToast } = useToastContext();
 
   const handleOCRSuccess = useCallback(
-    (mode: 'replace' | 'add', timeLabels: TimeLabel[], roastSchedules: RoastSchedule[]) => {
+    async (mode: 'replace' | 'add', timeLabels: TimeLabel[], roastSchedules: RoastSchedule[]) => {
       if (!data) return;
+
+      const persist = async (next: AppData) => {
+        try {
+          await updateData(next);
+          showToast('スケジュールを読み取りました。', 'success');
+        } catch (error) {
+          console.error('Failed to save OCR schedule:', error);
+          showToast('スケジュールの保存に失敗しました。通信を確認してもう一度お試しください。', 'error');
+        }
+      };
 
       // 既存のデータとマージするか確認
       const existingTodaySchedule = data.todaySchedules?.find((s) => s.date === selectedDate);
@@ -40,7 +50,7 @@ export function useScheduleOCR({ data, selectedDate, updateData }: UseScheduleOC
           ...roastSchedules,
         ];
 
-        updateData({
+        await persist({
           ...data,
           todaySchedules: updatedTodaySchedules,
           roastSchedules: updatedRoastSchedules,
@@ -84,14 +94,12 @@ export function useScheduleOCR({ data, selectedDate, updateData }: UseScheduleOC
         // ローストスケジュールを追加
         const updatedRoastSchedules = [...(data.roastSchedules || []), ...roastSchedules];
 
-        updateData({
+        await persist({
           ...data,
           todaySchedules: updatedTodaySchedules,
           roastSchedules: updatedRoastSchedules,
         });
       }
-
-      showToast('スケジュールを読み取りました。', 'success');
     },
     [data, selectedDate, updateData, showToast]
   );

--- a/hooks/useTodayScheduleSync.ts
+++ b/hooks/useTodayScheduleSync.ts
@@ -3,7 +3,7 @@ import type { AppData, TodaySchedule, TimeLabel } from '@/types';
 
 interface UseTodayScheduleSyncOptions {
   data: AppData | null;
-  onUpdate: (data: AppData) => void;
+  onUpdate: (data: AppData) => Promise<void> | void;
   selectedDate: string;
   currentSchedule: TodaySchedule;
 }
@@ -120,7 +120,9 @@ export function useTodayScheduleSync({ data, onUpdate, selectedDate, currentSche
         todayScheduleIdRef.current = updatedSchedule.id;
         lastDataRef.current = newTimeLabelsStr;
 
-        onUpdateRef.current(updatedData);
+        Promise.resolve(onUpdateRef.current(updatedData)).catch((error) => {
+          console.error('Failed to auto-save today schedule:', error);
+        });
 
         setTimeout(() => {
           isUpdatingRef.current = false;
@@ -211,7 +213,9 @@ export function useTodayScheduleSync({ data, onUpdate, selectedDate, currentSche
               todaySchedules: updatedSchedules,
             };
 
-            onUpdateRef.current(updatedData);
+            Promise.resolve(onUpdateRef.current(updatedData)).catch((error) => {
+              console.error('Failed to auto-save today schedule:', error);
+            });
           }
         }
       }

--- a/hooks/useTodayScheduleSync.ts
+++ b/hooks/useTodayScheduleSync.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import type { AppData, TodaySchedule, TimeLabel } from '@/types';
+import { useToastContext } from '@/components/Toast';
 
 interface UseTodayScheduleSyncOptions {
   data: AppData | null;
@@ -27,11 +28,18 @@ export function useTodayScheduleSync({ data, onUpdate, selectedDate, currentSche
   const lastSelectedDateRef = useRef<string>(selectedDate);
   const localTimeLabelsRef = useRef<TimeLabel[]>(currentSchedule.timeLabels || []);
 
+  const { showToast } = useToastContext();
+  const showToastRef = useRef(showToast);
+
   // 最新の参照を保持
   useEffect(() => {
     dataRef.current = data;
     onUpdateRef.current = onUpdate;
   }, [data, onUpdate]);
+
+  useEffect(() => {
+    showToastRef.current = showToast;
+  }, [showToast]);
 
   useEffect(() => {
     lastSelectedDateRef.current = selectedDate;
@@ -122,6 +130,10 @@ export function useTodayScheduleSync({ data, onUpdate, selectedDate, currentSche
 
         Promise.resolve(onUpdateRef.current(updatedData)).catch((error) => {
           console.error('Failed to auto-save today schedule:', error);
+          showToastRef.current(
+            '本日のスケジュールの保存に失敗しました。通信を確認してもう一度お試しください。',
+            'error'
+          );
         });
 
         setTimeout(() => {
@@ -215,6 +227,10 @@ export function useTodayScheduleSync({ data, onUpdate, selectedDate, currentSche
 
             Promise.resolve(onUpdateRef.current(updatedData)).catch((error) => {
               console.error('Failed to auto-save today schedule:', error);
+              showToastRef.current(
+                '本日のスケジュールの保存に失敗しました。通信を確認してもう一度お試しください。',
+                'error'
+              );
             });
           }
         }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { User, onAuthStateChanged, signOut as firebaseSignOut } from 'firebase/auth';
 import { clearIndexedDbPersistence, terminate, waitForPendingWrites } from 'firebase/firestore';
 import { auth, db } from './firebase';
+import { flushPendingUserDataWrites } from '@/lib/firestore';
 import { getE2EUser, isE2EMode, isE2ESignedIn, signOutE2EUser } from './e2eMode';
 
 /**
@@ -85,6 +86,11 @@ export async function signOut() {
   }
 
   // ここまでは db を終了していないので、失敗したら呼び出し側に伝えてそのまま留まれる
+  const uid = auth.currentUser?.uid;
+  // アプリ独自のデバウンス待機中の書き込みを先に送信してから、Firestore の保留書き込みを待つ
+  if (uid) {
+    await flushPendingUserDataWrites(uid);
+  }
   await waitForPendingWrites(db);
   await firebaseSignOut(auth);
 
@@ -99,5 +105,10 @@ export async function signOut() {
       'ログアウト時のローカルキャッシュのクリアに失敗しました(端末に一部データが残る可能性があります):',
       cacheError
     );
+    try {
+      window.localStorage.setItem('roastplus_cache_clear_failed', '1');
+    } catch {
+      // localStorage 不可環境は無視
+    }
   }
 }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { User, onAuthStateChanged, signOut as firebaseSignOut } from 'firebase/auth';
-import { clearIndexedDbPersistence, terminate } from 'firebase/firestore';
+import { clearIndexedDbPersistence, terminate, waitForPendingWrites } from 'firebase/firestore';
 import { auth, db } from './firebase';
 import { getE2EUser, isE2EMode, isE2ESignedIn, signOutE2EUser } from './e2eMode';
 
@@ -76,20 +76,24 @@ export async function signOut() {
     return;
   }
 
+  // オフライン時はログアウトを止める:
+  // 1) 未送信のオフライン変更を失わないため 2) 共有端末でキャッシュを安全に消せないため
+  if (typeof navigator !== 'undefined' && !navigator.onLine) {
+    const offlineError = new Error('オフラインのためログアウトできません');
+    offlineError.name = 'OfflineLogoutError';
+    throw offlineError;
+  }
+
   try {
+    // 未送信のオフライン書き込みをサーバーへ反映してからサインアウトする
+    await waitForPendingWrites(db);
     await firebaseSignOut(auth);
-    // 共有端末対策: ログアウト時に端末ローカルのオフラインキャッシュ(IndexedDB)を消す。
-    // 永続化したFirestoreデータがログアウトやブラウザ再起動後も端末に残らないようにする。
-    // terminate でインスタンスを停止してから clearIndexedDbPersistence で消す必要がある。
-    // この後は db が終了状態になるため、呼び出し側はフルリロードで再初期化する。
-    try {
-      await terminate(db);
-      await clearIndexedDbPersistence(db);
-    } catch (cacheError) {
-      console.error('ローカルキャッシュのクリアに失敗しました:', cacheError);
-    }
+    // 共有端末対策: ローカルキャッシュ(IndexedDB)を消す。
+    // terminate でインスタンスを停止してから clear する必要がある。
+    await terminate(db);
+    await clearIndexedDbPersistence(db);
   } catch (error) {
-    console.error('ログアウトエラー:', error);
-    throw error;
+    console.error('ログアウト処理でエラー:', error);
+    throw error; // 呼び出し側に失敗を伝える(クリア未完了をユーザーへ通知)
   }
 }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -2,7 +2,8 @@
 
 import { useState, useEffect } from 'react';
 import { User, onAuthStateChanged, signOut as firebaseSignOut } from 'firebase/auth';
-import { auth } from './firebase';
+import { clearIndexedDbPersistence, terminate } from 'firebase/firestore';
+import { auth, db } from './firebase';
 import { getE2EUser, isE2EMode, isE2ESignedIn, signOutE2EUser } from './e2eMode';
 
 /**
@@ -77,6 +78,16 @@ export async function signOut() {
 
   try {
     await firebaseSignOut(auth);
+    // 共有端末対策: ログアウト時に端末ローカルのオフラインキャッシュ(IndexedDB)を消す。
+    // 永続化したFirestoreデータがログアウトやブラウザ再起動後も端末に残らないようにする。
+    // terminate でインスタンスを停止してから clearIndexedDbPersistence で消す必要がある。
+    // この後は db が終了状態になるため、呼び出し側はフルリロードで再初期化する。
+    try {
+      await terminate(db);
+      await clearIndexedDbPersistence(db);
+    } catch (cacheError) {
+      console.error('ローカルキャッシュのクリアに失敗しました:', cacheError);
+    }
   } catch (error) {
     console.error('ログアウトエラー:', error);
     throw error;

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -84,16 +84,20 @@ export async function signOut() {
     throw offlineError;
   }
 
+  // ここまでは db を終了していないので、失敗したら呼び出し側に伝えてそのまま留まれる
+  await waitForPendingWrites(db);
+  await firebaseSignOut(auth);
+
+  // ここから先は db を terminate するため、呼び出し側は必ずフルリロードする。
+  // terminate 後に clear が失敗(多タブ等)しても、db は終了済みなのでリロードは必須。
+  // よってクリア失敗は再throwせずログのみに留め、signOut は正常終了させてリロードを保証する。
   try {
-    // 未送信のオフライン書き込みをサーバーへ反映してからサインアウトする
-    await waitForPendingWrites(db);
-    await firebaseSignOut(auth);
-    // 共有端末対策: ローカルキャッシュ(IndexedDB)を消す。
-    // terminate でインスタンスを停止してから clear する必要がある。
     await terminate(db);
     await clearIndexedDbPersistence(db);
-  } catch (error) {
-    console.error('ログアウト処理でエラー:', error);
-    throw error; // 呼び出し側に失敗を伝える(クリア未完了をユーザーへ通知)
+  } catch (cacheError) {
+    console.error(
+      'ログアウト時のローカルキャッシュのクリアに失敗しました(端末に一部データが残る可能性があります):',
+      cacheError
+    );
   }
 }

--- a/lib/drip-guide/useRecipes.ts
+++ b/lib/drip-guide/useRecipes.ts
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { DripRecipe } from './types';
 import { MOCK_RECIPES } from './mockData';
 import { useAppData } from '@/hooks/useAppData';
+import { useToastContext } from '@/components/Toast';
 
 const STORAGE_KEY = 'roastplus_drip_recipes';
 const MIGRATION_FLAG_KEY = 'roastplus_drip_recipes_migrated_to_firestore';
@@ -25,6 +26,7 @@ function migrateRecipeTo1Serving(recipe: DripRecipe): DripRecipe {
 
 export function useRecipes() {
   const { data, updateData, isLoading: appDataLoading } = useAppData();
+  const { showToast } = useToastContext();
   const [isLoaded, setIsLoaded] = useState(false);
   const [migrationChecked, setMigrationChecked] = useState(false);
 
@@ -139,19 +141,24 @@ export function useRecipes() {
   })();
 
   const addRecipe = useCallback(
-    (recipe: DripRecipe) => {
+    async (recipe: DripRecipe) => {
       const currentRecipes = data.dripRecipes || [];
       const newRecipes = [...currentRecipes, recipe];
-      updateData({
-        ...data,
-        dripRecipes: newRecipes,
-      });
+      try {
+        await updateData({
+          ...data,
+          dripRecipes: newRecipes,
+        });
+      } catch (error) {
+        console.error('Failed to add recipe:', error);
+        showToast('レシピの保存に失敗しました。通信を確認してもう一度お試しください。', 'error');
+      }
     },
-    [data, updateData]
+    [data, updateData, showToast]
   );
 
   const updateRecipe = useCallback(
-    (recipe: DripRecipe) => {
+    async (recipe: DripRecipe) => {
       const currentRecipes = data.dripRecipes || [];
       const defaultRecipeIds = new Set(MOCK_RECIPES.filter((r) => r.isDefault).map((r) => r.id));
 
@@ -166,16 +173,21 @@ export function useRecipes() {
         newRecipes.push(updatedRecipe);
       }
 
-      updateData({
-        ...data,
-        dripRecipes: newRecipes,
-      });
+      try {
+        await updateData({
+          ...data,
+          dripRecipes: newRecipes,
+        });
+      } catch (error) {
+        console.error('Failed to update recipe:', error);
+        showToast('レシピの保存に失敗しました。通信を確認してもう一度お試しください。', 'error');
+      }
     },
-    [data, updateData]
+    [data, updateData, showToast]
   );
 
   const deleteRecipe = useCallback(
-    (id: string) => {
+    async (id: string) => {
       // デフォルトレシピは削除できない
       const recipeToDelete = recipes.find((r) => r.id === id);
       if (recipeToDelete?.isDefault) {
@@ -185,12 +197,17 @@ export function useRecipes() {
 
       const currentRecipes = data.dripRecipes || [];
       const newRecipes = currentRecipes.filter((r) => r.id !== id);
-      updateData({
-        ...data,
-        dripRecipes: newRecipes,
-      });
+      try {
+        await updateData({
+          ...data,
+          dripRecipes: newRecipes,
+        });
+      } catch (error) {
+        console.error('Failed to delete recipe:', error);
+        showToast('レシピの保存に失敗しました。通信を確認してもう一度お試しください。', 'error');
+      }
     },
-    [recipes, data, updateData]
+    [recipes, data, updateData, showToast]
   );
 
   const getRecipe = useCallback(

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -1,7 +1,14 @@
 import { initializeApp, getApps } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { connectFunctionsEmulator, getFunctions } from 'firebase/functions';
-import { connectFirestoreEmulator, getFirestore } from 'firebase/firestore';
+import {
+  connectFirestoreEmulator,
+  getFirestore,
+  initializeFirestore,
+  persistentLocalCache,
+  persistentMultipleTabManager,
+  type Firestore,
+} from 'firebase/firestore';
 import { initializeRoastPlusAppCheck } from './appCheck';
 
 const firebaseConfig = {
@@ -24,7 +31,28 @@ declare global {
 }
 
 const functionsInstance = getFunctions(app);
-const firestoreInstance = getFirestore(app);
+
+function createFirestore(): Firestore {
+  const useEmulator = process.env.NEXT_PUBLIC_FIREBASE_FIRESTORE_EMULATOR === 'true';
+
+  // ブラウザ以外（ビルド/SSR）、またはエミュレータ接続時はオフライン永続化を使わない
+  if (typeof window === 'undefined' || useEmulator) {
+    return getFirestore(app);
+  }
+
+  try {
+    // IndexedDB にオフライン永続化。複数タブでも安全なマネージャを使用
+    return initializeFirestore(app, {
+      localCache: persistentLocalCache({ tabManager: persistentMultipleTabManager() }),
+    });
+  } catch (error) {
+    // IndexedDB 不可・二重初期化などのフォールバック（機能は落とさない）
+    console.warn('Firestore offline persistence unavailable, using memory cache:', error);
+    return getFirestore(app);
+  }
+}
+
+const firestoreInstance = createFirestore();
 
 initializeRoastPlusAppCheck(app);
 

--- a/lib/firestore/index.ts
+++ b/lib/firestore/index.ts
@@ -1,6 +1,12 @@
 // lib/firestore barrel export
 // 既存の import { xxx } from '@/lib/firestore' を維持する
-export { getUserData, saveUserData, subscribeUserData, SAVE_USER_DATA_DEBOUNCE_MS } from './userData';
+export {
+  getUserData,
+  saveUserData,
+  subscribeUserData,
+  SAVE_USER_DATA_DEBOUNCE_MS,
+  flushPendingUserDataWrites,
+} from './userData';
 export { getDefectBeanMasterData } from './defectBeans';
 export {
   RECENT_PRODUCTION_MONTHS_LIMIT,

--- a/lib/firestore/userData/crud.ts
+++ b/lib/firestore/userData/crud.ts
@@ -57,6 +57,7 @@ export async function saveUserData(userId: string, data: AppData, options: SaveU
     }
     queue.pendingPromise = { resolve, reject };
   });
+  queue.currentSavePromise = promise;
 
   // 最新のデータをキューに保存
   queue.pendingData = data;

--- a/lib/firestore/userData/index.ts
+++ b/lib/firestore/userData/index.ts
@@ -1,4 +1,4 @@
 // ユーザーデータ管理モジュール バレルエクスポート
 
-export { SAVE_USER_DATA_DEBOUNCE_MS } from './write-queue';
+export { SAVE_USER_DATA_DEBOUNCE_MS, flushPendingUserDataWrites } from './write-queue';
 export { getUserData, saveUserData, subscribeUserData } from './crud';

--- a/lib/firestore/userData/write-queue.ts
+++ b/lib/firestore/userData/write-queue.ts
@@ -18,6 +18,7 @@ export const writeQueues = new Map<
     isWriting: boolean;
     retryCount: number;
     pendingPromise: { resolve: () => void; reject: (error: unknown) => void } | null;
+    currentSavePromise?: Promise<void>;
   }
 >();
 
@@ -32,16 +33,31 @@ export function clearWriteQueueStateForTests(): void {
 export async function flushPendingUserDataWrites(userId: string): Promise<void> {
   const queue = writeQueues.get(userId);
   if (!queue) return;
+
+  // 1) デバウンス待機中の書き込みを即時実行する
   if (queue.timeoutId) {
     clearTimeout(queue.timeoutId);
     queue.timeoutId = null;
+    if (queue.pendingData) {
+      const data = queue.pendingData;
+      const options = queue.pendingOptions ?? {};
+      queue.pendingData = null;
+      queue.pendingOptions = null;
+      try {
+        await executeWrite(userId, data, options);
+      } catch {
+        // 失敗は呼び出し側の saveUserData promise 側で処理される
+      }
+    }
   }
-  if (queue.pendingData) {
-    const data = queue.pendingData;
-    const options = queue.pendingOptions ?? {};
-    queue.pendingData = null;
-    queue.pendingOptions = null;
-    await executeWrite(userId, data, options);
+
+  // 2) 既に実行中(in-flight)の書き込みがあれば、その完了も待つ
+  if (queue.currentSavePromise) {
+    try {
+      await queue.currentSavePromise;
+    } catch {
+      // 同上(失敗はログアウト処理を止めない)
+    }
   }
 }
 

--- a/lib/firestore/userData/write-queue.ts
+++ b/lib/firestore/userData/write-queue.ts
@@ -25,6 +25,26 @@ export function clearWriteQueueStateForTests(): void {
   writeQueues.clear();
 }
 
+/**
+ * デバウンス待機中のユーザーデータ書き込みを即座に実行して完了を待つ。
+ * ログアウト時など、保留中の編集を確実にサーバーへ送ってから後処理する用途。
+ */
+export async function flushPendingUserDataWrites(userId: string): Promise<void> {
+  const queue = writeQueues.get(userId);
+  if (!queue) return;
+  if (queue.timeoutId) {
+    clearTimeout(queue.timeoutId);
+    queue.timeoutId = null;
+  }
+  if (queue.pendingData) {
+    const data = queue.pendingData;
+    const options = queue.pendingOptions ?? {};
+    queue.pendingData = null;
+    queue.pendingOptions = null;
+    await executeWrite(userId, data, options);
+  }
+}
+
 export interface SaveUserDataOptions {
   updatedFields?: (keyof AppData)[];
 }


### PR DESCRIPTION
## 対象 / 目的

「RoastPlus を全方位で大きく改善する」監査（`docs/audits/2026-05-31-roastplus-100x-audit.md`、総合6/10）の最優先テーマA「**データ安全性**」の最初のスペックです。現場8名が毎日入力するデータが「保存に失敗しても気づけず黙って消える」状態を解消します。

実装スコープは監査ロードマップの **rank1+2+3+4**：

- **rank1** 保存失敗を可視化（`updateData` の再throw）
- **rank2** Firestore オフライン永続化（そもそも消えない）
- **rank3** オフライン検知バナー（通信断が分かる）
- **rank4** 白画面防止（壊れても止まらない）

仕様: `docs/superpowers/specs/2026-05-31-data-safety-core-design.md` ／ 計画: `docs/superpowers/plans/2026-05-31-data-safety-core.md`

## なぜ必要か

`hooks/useAppData.ts` の `updateData` が保存失敗を握りつぶし、サーバーの古い値で画面を上書きしていました。このため各機能のエラートーストが全て死にコード化し、保存失敗が嘘の「保存しました」で隠蔽され、**実際に Issue #458 で本番データ全消失**（試飲4セッション+16記録+スケジュール12件）が発生していました。本PRはその根本原因を塞ぎます。

## 変更内容の要約（非エンジニア向け）

| ファイル | 役割 | 変更 |
|---|---|---|
| `hooks/useAppData.ts` | 全機能データの保存処理の中心 | 保存失敗時にエラーを「握りつぶさず通知する」よう1行追加（再throw） |
| `lib/firebase.ts` | Firebase 初期化 | オフライン保存（IndexedDB）を有効化。ブラウザ限定・エミュレータ時無効・失敗時フォールバックの3ガード付き |
| `components/OfflineBanner.tsx` ＋ `hooks/useOnlineStatus.ts` | オフライン表示 | 通信が切れたとき画面上部に「オフライン：変更は接続が戻ったときに保存されます」を常設表示 |
| `app/error.tsx` ／ `app/global-error.tsx` | エラー時の画面 | 例外で真っ白になる代わりに「再読み込み」ボタン付きの復旧画面を表示 |
| `app/layout.tsx` | 全画面の土台 | オフラインバナーを配置 |
| `hooks/useScheduleOCR.ts` `useNotifications.ts` `useHomeFeatureVisibility.ts` `useTodayScheduleSync.ts` `lib/drip-guide/useRecipes.ts` `components/RoastSchedulerTab.tsx` `TastingSessionList.tsx` `TodaySchedule.tsx` | 各機能の保存呼び出し | 再throw化に伴い、保存失敗を握って（ユーザー操作はトースト、自動保存はログ）未処理エラーを出さないよう整備 |
| `docs/...` | ドキュメント | 監査レポート・仕様・実装計画 |

## 危険度チェック（CLAUDE.md 準拠）

| 項目 | 危険度 | 補足 |
|---|---|---|
| データ保存 | **中** | 保存処理の挙動を「握りつぶし→通知」に変更。ただしデータ構造・保存先は不変。既存の #458 防止ロジック（空スナップショット無視・フィールドロック・ackタイムアウト）は無変更。独立レビューで全呼び出し元（32箇所）が未処理Rejectionを起こさないことを確認済み |
| データ更新／削除／上書き | 低 | ロジック不変、エラー処理のみ追加 |
| 認証／権限／Firestore Rules / Storage Rules | **影響なし** | 読み書きの宛先・owner isolation・Rules は一切変更なし |
| 集計ロジック／CSV出力 | 影響なし | 変更なし |
| 本番デプロイ設定 | 低 | `lib/firebase.ts` の初期化変更のみ。ブラウザ限定ガードで静的エクスポートのビルドに無影響 |

**ロールバック**: データ構造・Rules を変えていないため、コードを戻すだけで完全に元に戻せます（マイグレーション不要）。永続化は端末ローカルの IndexedDB キャッシュのみでサーバーデータに無影響。

## 検証結果

- `npm run typecheck` → エラーなし
- `npm run lint` → エラー・警告ゼロ
- `npm run format:check` → 差分なし
- `npm run test:run` → **96ファイル / 1041テスト 全合格**（TDDで再throwの reject 検証・useOnlineStatus テスト追加）
- `npm run build` → 成功（静的エクスポート33ページ）
- 独立レビュー subagent による検証: Firestore 永続化APIの正しさ（firebase v12 の `persistentLocalCache` が現行推奨・初期化順序/HMR/エミュレータ安全）、再throw後の全呼び出し元の安全性（UNSAFE 0件）を確認

### 未検証（手動確認をお願いしたい点）
- 実機/ブラウザでの DevTools Network Offline → 入力保持 → 復帰同期の体感確認
- 実際の保存失敗時にエラートーストが出ること、白画面でなく復旧UIが出ること

## 残リスク

- オフライン時の `await` 挙動（pending かどうか）の厳密検証は実機確認で最終化したい（仕様 §13 未決事項）。保存状態の「見える化インジケータ」は本PRスコープ外（rank5・次スペック）のため、自動保存の失敗は当面ログのみ。

## 意図的に触らなかった範囲（スコープ外・別PR）

- rank5（保存状態インジケータ＋再試行トースト）
- rank16（欠点豆の画像削除/保存順序の是正）
- rank15（tasting/schedule のサブコレクション移行・XL）
- `useAppData` の #458 防止ロジックの簡素化／作り直し

## 学習ポイント

- Firestore のオフライン永続化を入れても「保存完了の合図（サーバー応答）」はオンライン復帰まで返らない。変わるのは「入力がローカルに残り、復帰時に自動同期される」耐久性。だから rank1（消えたら分かる）と rank2（そもそも消えない）はセットで効く。
- `updateData` を再throw化すると、`await` していない呼び出し元が未処理エラーになる。これを防ぐため全呼び出し元を先に整備した（独立レビューで `components/` と `lib/drip-guide/` の10箇所の見落としを発見・修正）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
