### PR TITLE
perf(defect-beans): 欠点豆図鑑マスターデータをキャッシュして高速表示

### DIFF
--- a/hooks/useDefectBeans.test.ts
+++ b/hooks/useDefectBeans.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useDefectBeans } from './useDefectBeans';
+import { clearCachedMasterDefectBeans } from '@/lib/defectBeanCache';
 import type { AppData, DefectBean } from '@/types';
+
+// 各テストはマスターデータのキャッシュが無い状態から開始する
+// （メモリ/localStorageキャッシュがテスト間で持ち越されないようにする）
+beforeEach(() => {
+  clearCachedMasterDefectBeans();
+});
 
 // モック関数（vi.mockファクトリ内で参照可能なようにmockプレフィックスを使用）
 const mockUseAuth = vi.fn();

--- a/hooks/useDefectBeans.ts
+++ b/hooks/useDefectBeans.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '@/lib/auth';
 import { getDefectBeanMasterData } from '@/lib/firestore';
+import { getCachedMasterDefectBeans, setCachedMasterDefectBeans } from '@/lib/defectBeanCache';
 import { uploadDefectBeanImage, deleteDefectBeanImage } from '@/lib/storage';
 import { compressImage } from '@/lib/imageCompression';
 import { useAppData } from './useAppData';
@@ -14,7 +15,9 @@ export function useDefectBeans() {
   const [masterDefectBeans, setMasterDefectBeans] = useState<DefectBean[]>([]);
   const [masterLoading, setMasterLoading] = useState(true);
 
-  // マスターデータを取得
+  // マスターデータを取得（stale-while-revalidate）
+  // キャッシュがあれば即座に表示してローディングを終了し、裏で最新を取得して更新する。
+  // これにより図鑑を開くたびのフルフェッチ待ちをなくし、高速に表示できる。
   useEffect(() => {
     // 認証チェックが完了するまで待つ
     if (authLoading) {
@@ -27,20 +30,39 @@ export function useDefectBeans() {
       return;
     }
 
+    let cancelled = false;
+
+    // キャッシュがあれば即座に反映（スピナーを出さずに表示）
+    const cached = getCachedMasterDefectBeans();
+    if (cached) {
+      setMasterDefectBeans(cached);
+      setMasterLoading(false);
+    }
+
     const loadMasterData = async () => {
       try {
         const masterData = await getDefectBeanMasterData();
+        if (cancelled) return;
         setMasterDefectBeans(masterData);
+        setCachedMasterDefectBeans(masterData);
       } catch (error) {
         console.error('Failed to load master defect beans:', error);
-        // エラー時も空配列を設定してローディングを終了
-        setMasterDefectBeans([]);
+        // キャッシュがある場合はそのまま表示を維持し、なければ空配列を設定
+        if (!cancelled && !cached) {
+          setMasterDefectBeans([]);
+        }
       } finally {
-        setMasterLoading(false);
+        if (!cancelled) {
+          setMasterLoading(false);
+        }
       }
     };
 
     loadMasterData();
+
+    return () => {
+      cancelled = true;
+    };
   }, [user, authLoading]);
 
   // 全欠点豆（マスター + ユーザー追加）を取得

--- a/lib/defectBeanCache.test.ts
+++ b/lib/defectBeanCache.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  getCachedMasterDefectBeans,
+  setCachedMasterDefectBeans,
+  clearCachedMasterDefectBeans,
+} from './defectBeanCache';
+import type { DefectBean } from '@/types';
+
+const BEAN_A: DefectBean = {
+  id: 'master-1',
+  name: 'カビ豆',
+  imageUrl: 'https://example.com/master-1.jpg',
+  characteristics: 'カビが生えた豆',
+  tasteImpact: '不快な味',
+  removalReason: 'カビは品質を著しく低下させる',
+  isMaster: true,
+  order: 1,
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+};
+
+const BEAN_B: DefectBean = {
+  ...BEAN_A,
+  id: 'master-2',
+  name: '虫食い豆',
+  order: 2,
+};
+
+describe('defectBeanCache', () => {
+  beforeEach(() => {
+    clearCachedMasterDefectBeans();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    clearCachedMasterDefectBeans();
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('キャッシュが空の場合は null を返す', () => {
+    expect(getCachedMasterDefectBeans()).toBeNull();
+  });
+
+  it('保存したデータを取得できる', () => {
+    setCachedMasterDefectBeans([BEAN_A, BEAN_B]);
+    expect(getCachedMasterDefectBeans()).toEqual([BEAN_A, BEAN_B]);
+  });
+
+  it('空配列もキャッシュとして保存・取得できる', () => {
+    setCachedMasterDefectBeans([]);
+    expect(getCachedMasterDefectBeans()).toEqual([]);
+  });
+
+  it('clearでキャッシュが破棄される', () => {
+    setCachedMasterDefectBeans([BEAN_A]);
+    clearCachedMasterDefectBeans();
+    expect(getCachedMasterDefectBeans()).toBeNull();
+  });
+
+  it('localStorageから復元できる（メモリキャッシュを使わない経路）', () => {
+    setCachedMasterDefectBeans([BEAN_A]);
+    // メモリキャッシュをクリアしてlocalStorageのみの状態にする
+    clearCachedMasterDefectBeans();
+    // localStorageに直接書き戻して復元経路を検証
+    localStorage.setItem(
+      'roastplus_defect_beans_master_cache',
+      JSON.stringify({ version: 1, cachedAt: Date.now(), data: [BEAN_A] })
+    );
+    expect(getCachedMasterDefectBeans()).toEqual([BEAN_A]);
+  });
+
+  it('バージョン不一致のキャッシュは無効として null を返す', () => {
+    localStorage.setItem(
+      'roastplus_defect_beans_master_cache',
+      JSON.stringify({ version: 999, cachedAt: Date.now(), data: [BEAN_A] })
+    );
+    expect(getCachedMasterDefectBeans()).toBeNull();
+  });
+
+  it('壊れたJSONの場合は null を返す', () => {
+    localStorage.setItem('roastplus_defect_beans_master_cache', '{ broken json');
+    expect(getCachedMasterDefectBeans()).toBeNull();
+  });
+
+  it('dataが配列でない場合は null を返す', () => {
+    localStorage.setItem(
+      'roastplus_defect_beans_master_cache',
+      JSON.stringify({ version: 1, cachedAt: Date.now(), data: 'not-an-array' })
+    );
+    expect(getCachedMasterDefectBeans()).toBeNull();
+  });
+
+  it('localStorageが容量超過でも例外を投げない', () => {
+    const spy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+    expect(() => setCachedMasterDefectBeans([BEAN_A])).not.toThrow();
+    // メモリキャッシュには反映される
+    expect(getCachedMasterDefectBeans()).toEqual([BEAN_A]);
+    spy.mockRestore();
+  });
+});

--- a/lib/defectBeanCache.ts
+++ b/lib/defectBeanCache.ts
@@ -1,0 +1,93 @@
+// 欠点豆マスターデータのクライアントキャッシュ
+//
+// 欠点豆図鑑を開くたびに Firestore からコレクション全体を取得すると、
+// 表示までに時間がかかり、画像も順次読み込まれてバラバラに見える。
+// マスターデータはめったに変化しないため、メモリ + localStorage にキャッシュし、
+// stale-while-revalidate（キャッシュを即時表示しつつ裏で最新を取得）で高速化する。
+
+import type { DefectBean } from '@/types';
+
+const CACHE_KEY = 'roastplus_defect_beans_master_cache';
+/** キャッシュ構造を変更した場合はインクリメントして古いキャッシュを無効化する */
+const CACHE_VERSION = 1;
+
+interface CacheEntry {
+  version: number;
+  cachedAt: number;
+  data: DefectBean[];
+}
+
+// セッション中のクライアント遷移をまたいで即座に参照できるメモリキャッシュ
+let memoryCache: DefectBean[] | null = null;
+
+/**
+ * キャッシュされたマスターデータを取得する。
+ * メモリキャッシュを優先し、なければ localStorage から復元する。
+ * キャッシュが存在しない / 破損している場合は null を返す。
+ */
+export function getCachedMasterDefectBeans(): DefectBean[] | null {
+  if (memoryCache !== null) {
+    return memoryCache;
+  }
+
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    if (!raw) {
+      return null;
+    }
+
+    const entry = JSON.parse(raw) as CacheEntry;
+    if (entry.version !== CACHE_VERSION || !Array.isArray(entry.data)) {
+      return null;
+    }
+
+    memoryCache = entry.data;
+    return entry.data;
+  } catch {
+    // パース失敗や localStorage アクセス不可は致命的ではない
+    return null;
+  }
+}
+
+/**
+ * マスターデータをキャッシュに保存する（メモリ + localStorage）。
+ */
+export function setCachedMasterDefectBeans(data: DefectBean[]): void {
+  memoryCache = data;
+
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    const entry: CacheEntry = {
+      version: CACHE_VERSION,
+      cachedAt: Date.now(),
+      data,
+    };
+    localStorage.setItem(CACHE_KEY, JSON.stringify(entry));
+  } catch {
+    // 容量超過やシリアライズ失敗は無視（メモリキャッシュは有効なまま）
+  }
+}
+
+/**
+ * キャッシュを破棄する（メモリ + localStorage）。主にテストや明示的な無効化で使用。
+ */
+export function clearCachedMasterDefectBeans(): void {
+  memoryCache = null;
+
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    localStorage.removeItem(CACHE_KEY);
+  } catch {
+    // 無視
+  }
+}


### PR DESCRIPTION
## 概要

欠点豆図鑑を開いた際、「表示がバラバラで遅い」という不具合を、キャッシュの導入で改善します。

## 原因

`useDefectBeans` は図鑑を開くたびに `getDefectBeanMasterData()` で Firestore の `defectBeans` コレクション全体を再取得しており、その間ページ全体が `<Loading />` 表示になっていました。マスターデータはめったに変化しないのに毎回フルフェッチしていたため、

- **遅い**: ネットワーク往復のたびにスピナー待ちが発生
- **バラバラ**: ローディング後にカードが出て、各画像が個別に lazy load + opacity フェードで順次現れる

という体感になっていました。

## 対応

マスターデータに **stale-while-revalidate** 方式のクライアントキャッシュ（メモリ + localStorage）を導入しました。

- `lib/defectBeanCache.ts`（新規）: マスターデータのキャッシュ取得・保存・破棄ユーティリティ。`CACHE_VERSION` によるバージョン管理、破損/容量超過時のフォールバックを備える。
- `hooks/useDefectBeans.ts`: キャッシュがあれば即座に表示してローディングを終了し、裏で `getDefectBeanMasterData()` を実行して最新化＆キャッシュ更新。

### 効果

- 2回目以降の表示・リロード後はスピナーなしで即座にカードが表示される
- 最新性は裏側の再取得で担保（オフライン時もキャッシュで表示可能）
- ユーザー追加豆（`appData.defectBeans`）は対象外のため、追加/更新/削除の挙動は不変

## テスト

- `lib/defectBeanCache.test.ts`（新規）: 保存/取得/破棄、localStorage 復元、バージョン不一致、破損 JSON、容量超過フォールバックを検証
- `hooks/useDefectBeans.test.ts`: キャッシュ持ち越し防止のため `beforeEach` でキャッシュをクリア
- 全テスト 1050 件パス / `tsc --noEmit` パス / eslint パス

https://claude.ai/code/session_019p2qniHH7U8JuVHD1yvT1e

---
_Generated by [Claude Code](https://claude.ai/code/session_019p2qniHH7U8JuVHD1yvT1e)_