### PR TITLE
fix(defect-beans): 欠点豆図鑑の無限ローディングを修正

### DIFF
--- a/hooks/useDefectBeans.test.ts
+++ b/hooks/useDefectBeans.test.ts
@@ -167,6 +167,51 @@ describe('useDefectBeans - isLoading', () => {
   });
 });
 
+describe('useDefectBeans - 無限ローディング防止（リグレッション）', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockUseAuth.mockReturnValue({ user: mockUser, loading: false });
+    mockUseAppData.mockReturnValue({
+      data: INITIAL_APP_DATA,
+      updateData: mockUpdateData,
+      isLoading: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('user変更でeffectが再実行され古いフェッチがキャンセルされても、フェッチ完了でローディングが解除される', async () => {
+    // 1回目: あとで解決するフェッチ / 2回目以降: 解決しない（ハングする）フェッチ
+    let resolveFirst: (value: DefectBean[]) => void = () => {};
+    const firstFetch = new Promise<DefectBean[]>((resolve) => {
+      resolveFirst = resolve;
+    });
+    mockGetDefectBeanMasterData.mockReturnValueOnce(firstFetch).mockReturnValue(new Promise(() => {}));
+
+    const { result, rerender } = renderHook(() => useDefectBeans());
+
+    // 1回目フェッチ進行中はローディング
+    expect(result.current.isLoading).toBe(true);
+
+    // user参照が変わりeffectが再実行される（1回目フェッチをキャンセル、2回目フェッチ＝ハング開始）
+    const refreshedUser = { uid: 'test-user-id', email: 'test@example.com', displayName: 'Test User' };
+    mockUseAuth.mockReturnValue({ user: refreshedUser, loading: false });
+    rerender();
+
+    // 1回目フェッチが完了する
+    await act(async () => {
+      resolveFirst([MASTER_BEAN]);
+      await vi.runAllTimersAsync();
+    });
+
+    // 2回目フェッチは未解決のままだが、無限ローディングにならずローディングが解除されている
+    expect(result.current.isLoading).toBe(false);
+  });
+});
+
 describe('useDefectBeans - マスターデータのロード', () => {
   beforeEach(() => {
     vi.useFakeTimers();

--- a/hooks/useDefectBeans.ts
+++ b/hooks/useDefectBeans.ts
@@ -42,9 +42,16 @@ export function useDefectBeans() {
     const loadMasterData = async () => {
       try {
         const masterData = await getDefectBeanMasterData();
-        if (cancelled) return;
-        setMasterDefectBeans(masterData);
-        setCachedMasterDefectBeans(masterData);
+        // 古いフェッチ（再実行でキャンセル済み）は新しいデータを上書きしない
+        if (!cancelled) {
+          setMasterDefectBeans(masterData);
+        }
+        // 取得できたデータをキャッシュに保存する。
+        // 空配列は一時的なエラー（getDefectBeanMasterDataは失敗時に[]を返す）の
+        // 可能性があるため保存しない（空のキャッシュで図鑑が空表示になるのを防ぐ）。
+        if (masterData.length > 0) {
+          setCachedMasterDefectBeans(masterData);
+        }
       } catch (error) {
         console.error('Failed to load master defect beans:', error);
         // キャッシュがある場合はそのまま表示を維持し、なければ空配列を設定
@@ -52,9 +59,10 @@ export function useDefectBeans() {
           setMasterDefectBeans([]);
         }
       } finally {
-        if (!cancelled) {
-          setMasterLoading(false);
-        }
+        // ローディングは常に解除する。
+        // effectの再実行で古いフェッチがキャンセルされても確実に解除し、
+        // 無限ローディングを防ぐ（アンマウント後のsetStateは安全なno-op）。
+        setMasterLoading(false);
       }
     };
 


### PR DESCRIPTION
## 概要

PR #474（マスターデータのキャッシュ導入）後に発生した、**欠点豆図鑑の無限ローディング**を修正します。

## 原因

#474 で `finally` の `setMasterLoading(false)` に `if (!cancelled)` ガードを付けたことが原因です。

- **変更前**: `finally` で**無条件に** `setMasterLoading(false)` していたため、どのフェッチが完了してもローディングは必ず解除されていた。
- **変更後**: 「最後の（キャンセルされていない）フェッチが完了したときだけ」解除されるようになった。

`useDefectBeans` の effect は `[user, authLoading]` 依存で、Firebase の `onAuthStateChanged` は初回認証直後に user オブジェクトを再発行することがよくあります。これで effect が再実行されると：

1. 1回目のフェッチがキャンセルされる（`cancelled = true`）
2. 1回目が完了しても `if (!cancelled)` で**ローディング解除がスキップ**される
3. 2回目のフェッチが遅い／ハングすると、**ローディングが永久に解除されない** → 無限ローディング

## 修正

- **ローディング解除は常に行う**: `finally` の `setMasterLoading(false)` から `cancelled` ガードを外す。`cancelled` は「古いフェッチで新しいデータを上書きしない」ためのデータ反映 (`setMasterDefectBeans`) のみに限定。アンマウント後の `setState` は React 18 では安全な no-op。
- **空配列をキャッシュしない**: `getDefectBeanMasterData` は失敗時に `[]` を返すため、一時エラー由来の空配列をキャッシュすると図鑑が空表示のままになる。`length > 0` のときのみキャッシュする。

## テスト

- **リグレッションテストを追加**: user 変更で effect が再実行され古いフェッチがキャンセルされても、フェッチ完了でローディングが解除されることを検証。修正前のコードでは fail（無限ローディングを再現）、修正後は pass することを確認済み。
- 全テスト 1051 件パス / `tsc --noEmit` パス / eslint パス

https://claude.ai/code/session_019p2qniHH7U8JuVHD1yvT1e

---
_Generated by [Claude Code](https://claude.ai/code/session_019p2qniHH7U8JuVHD1yvT1e)_