### PR TITLE
fix(filter): iPad向けフィルター画面レイアウト改善

### DIFF
--- a/components/TastingSessionFilterModal.tsx
+++ b/components/TastingSessionFilterModal.tsx
@@ -168,24 +168,20 @@ export function TastingSessionFilterModal({
       {/* 日付範囲 */}
       <FilterSection label="日付範囲">
         <div className="grid grid-cols-2 gap-2">
-          <div className="flex flex-col gap-1">
-            <span className="text-[11px] text-ink-muted">開始日</span>
-            <Input
-              type="date"
-              value={tempDateFrom}
-              onChange={(e) => setTempDateFrom(e.target.value)}
-              className={inputControlClassName}
-            />
-          </div>
-          <div className="flex flex-col gap-1">
-            <span className="text-[11px] text-ink-muted">終了日</span>
-            <Input
-              type="date"
-              value={tempDateTo}
-              onChange={(e) => setTempDateTo(e.target.value)}
-              className={inputControlClassName}
-            />
-          </div>
+          <Input
+            type="date"
+            label="開始日"
+            value={tempDateFrom}
+            onChange={(e) => setTempDateFrom(e.target.value)}
+            className={inputControlClassName}
+          />
+          <Input
+            type="date"
+            label="終了日"
+            value={tempDateTo}
+            onChange={(e) => setTempDateTo(e.target.value)}
+            className={inputControlClassName}
+          />
         </div>
       </FilterSection>
 

--- a/components/TastingSessionFilterModal.tsx
+++ b/components/TastingSessionFilterModal.tsx
@@ -149,19 +149,18 @@ export function TastingSessionFilterModal({
 
       {/* ソート */}
       <FilterSection label="ソート">
-        <div className="grid grid-cols-3 gap-1.5">
+        <div className="flex flex-col gap-1">
           {sortOptions.map((opt) => (
-            <FilterOptionButton
+            <FilterSortOption
               key={opt.id}
               selected={tempSortOption === opt.id}
+              icon={opt.icon}
               type="button"
               aria-pressed={tempSortOption === opt.id}
               onClick={() => setTempSortOption(opt.id)}
-              className="!min-h-[40px] !px-1 !text-[12px] whitespace-nowrap gap-1"
             >
-              {opt.icon}
               {opt.label}
-            </FilterOptionButton>
+            </FilterSortOption>
           ))}
         </div>
       </FilterSection>

--- a/components/TastingSessionFilterModal.tsx
+++ b/components/TastingSessionFilterModal.tsx
@@ -149,18 +149,19 @@ export function TastingSessionFilterModal({
 
       {/* ソート */}
       <FilterSection label="ソート">
-        <div className="flex flex-col gap-1">
+        <div className="grid grid-cols-3 gap-1.5">
           {sortOptions.map((opt) => (
-            <FilterSortOption
+            <FilterOptionButton
               key={opt.id}
               selected={tempSortOption === opt.id}
-              icon={opt.icon}
               type="button"
               aria-pressed={tempSortOption === opt.id}
               onClick={() => setTempSortOption(opt.id)}
+              className="!min-h-[40px] !px-1 !text-[12px] whitespace-nowrap gap-1"
             >
+              {opt.icon}
               {opt.label}
-            </FilterSortOption>
+            </FilterOptionButton>
           ))}
         </div>
       </FilterSection>
@@ -168,18 +169,24 @@ export function TastingSessionFilterModal({
       {/* 日付範囲 */}
       <FilterSection label="日付範囲">
         <div className="grid grid-cols-2 gap-2">
-          <Input
-            type="date"
-            value={tempDateFrom}
-            onChange={(e) => setTempDateFrom(e.target.value)}
-            className={inputControlClassName}
-          />
-          <Input
-            type="date"
-            value={tempDateTo}
-            onChange={(e) => setTempDateTo(e.target.value)}
-            className={inputControlClassName}
-          />
+          <div className="flex flex-col gap-1">
+            <span className="text-[11px] text-ink-muted">開始日</span>
+            <Input
+              type="date"
+              value={tempDateFrom}
+              onChange={(e) => setTempDateFrom(e.target.value)}
+              className={inputControlClassName}
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-[11px] text-ink-muted">終了日</span>
+            <Input
+              type="date"
+              value={tempDateTo}
+              onChange={(e) => setTempDateTo(e.target.value)}
+              className={inputControlClassName}
+            />
+          </div>
         </div>
       </FilterSection>
 


### PR DESCRIPTION
## Summary

- ソートオプションを縦積みレイアウトから **3列グリッド** に変更し、iPadの広い画面幅を有効活用
- 日付範囲の各入力フィールドに **「開始日」「終了日」** のサブラベルを追加し、iPadで空白ボックスに見える問題を解消

## 変更内容

| Before | After |
|---|---|
| ソート: 縦積みフルwidthボタン | ソート: 3列グリッドのチップ |
| 日付: ラベルなしで空白ボックス2つ | 日付: 「開始日」「終了日」ラベル付き |

## Test plan

- [ ] iPhoneでフィルター画面を開き、ソート/日付範囲が正常表示されること
- [ ] iPadでフィルター画面を開き、ソートが3列表示・日付にラベルが表示されること
- [ ] ソートの選択状態（ハイライト）が正常に動作すること
- [ ] 日付範囲フィルターの適用が正常に動作すること

https://claude.ai/code/session_01SetiavLeX7FYa9VFjhRySm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SetiavLeX7FYa9VFjhRySm)_