### PR TITLE
fix(clock): 時計チャイムがiPad PWAで鳴らない問題を修正

### DIFF
--- a/hooks/useWorkChime.test.tsx
+++ b/hooks/useWorkChime.test.tsx
@@ -5,12 +5,14 @@ import { useWorkChime } from './useWorkChime';
 
 const playWorkChimeMock = vi.fn();
 const unlockWorkChimeAudioMock = vi.fn(() => Promise.resolve(true));
+const resumeWorkChimeAudioMock = vi.fn(() => Promise.resolve(true));
 const isWorkChimeAudioReadyMock = vi.fn(() => true);
 
 vi.mock('@/lib/workChimeAudio', () => ({
   isWorkChimeAudioReady: () => isWorkChimeAudioReadyMock(),
   playWorkChime: (...args: unknown[]) => playWorkChimeMock(...args),
   unlockWorkChimeAudio: () => unlockWorkChimeAudioMock(),
+  resumeWorkChimeAudio: () => resumeWorkChimeAudioMock(),
 }));
 
 const createLocalStorageMock = () => {
@@ -40,11 +42,15 @@ describe('useWorkChime', () => {
     playWorkChimeMock.mockResolvedValue(true);
     unlockWorkChimeAudioMock.mockReset();
     unlockWorkChimeAudioMock.mockResolvedValue(true);
+    resumeWorkChimeAudioMock.mockReset();
+    resumeWorkChimeAudioMock.mockResolvedValue(true);
     isWorkChimeAudioReadyMock.mockReset();
     isWorkChimeAudioReadyMock.mockReturnValue(true);
   });
 
-  it('音の有効化前でも該当時刻は通知を表示する', () => {
+  it('音の有効化前（AudioContext未準備）は鳴らさず通知だけ表示する', () => {
+    isWorkChimeAudioReadyMock.mockReturnValue(false);
+
     const { result } = renderHook(() => useWorkChime(localDate(10, 45)));
 
     expect(playWorkChimeMock).not.toHaveBeenCalled();
@@ -102,6 +108,8 @@ describe('useWorkChime', () => {
   });
 
   it('PWA復帰などで区切り時刻の秒をまたいでも通知を表示する', () => {
+    isWorkChimeAudioReadyMock.mockReturnValue(false);
+
     const { result, rerender } = renderHook(({ now }) => useWorkChime(now), {
       initialProps: { now: localDate(10, 44, 59) },
     });
@@ -163,7 +171,7 @@ describe('useWorkChime', () => {
     expect(result.current.activeChime).toBeNull();
   });
 
-  it('AudioContextが停止した状態で復帰したら音の有効化を解除する', async () => {
+  it('復帰時にAudioContextを再開できれば音の有効化を維持する', async () => {
     const { result } = renderHook(() => useWorkChime(localDate(10, 40)));
 
     await act(async () => {
@@ -172,12 +180,53 @@ describe('useWorkChime', () => {
     });
     expect(result.current.isAudioEnabled).toBe(true);
 
+    // iOS で suspended/interrupted になった想定。focus で resume を試みて成功する。
     isWorkChimeAudioReadyMock.mockReturnValue(false);
+    resumeWorkChimeAudioMock.mockResolvedValue(true);
 
-    act(() => {
+    await act(async () => {
       window.dispatchEvent(new Event('focus'));
+      await Promise.resolve();
+    });
+
+    expect(resumeWorkChimeAudioMock).toHaveBeenCalled();
+    expect(result.current.isAudioEnabled).toBe(true);
+  });
+
+  it('復帰時にAudioContextを再開できなければ音の有効化を解除する', async () => {
+    const { result } = renderHook(() => useWorkChime(localDate(10, 40)));
+
+    await act(async () => {
+      result.current.enableAudio();
+      await Promise.resolve();
+    });
+    expect(result.current.isAudioEnabled).toBe(true);
+
+    // resume が失敗（suspended でユーザー操作が必要）した想定。
+    isWorkChimeAudioReadyMock.mockReturnValue(false);
+    resumeWorkChimeAudioMock.mockResolvedValue(false);
+
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'));
+      await Promise.resolve();
     });
 
     expect(result.current.isAudioEnabled).toBe(false);
+  });
+
+  it('画面上のユーザー操作（pointerdown）でオーディオを自動有効化する', async () => {
+    isWorkChimeAudioReadyMock.mockReturnValue(false);
+    unlockWorkChimeAudioMock.mockResolvedValue(true);
+
+    const { result } = renderHook(() => useWorkChime(localDate(10, 40)));
+    expect(result.current.isAudioEnabled).toBe(false);
+
+    await act(async () => {
+      document.dispatchEvent(new Event('pointerdown'));
+      await Promise.resolve();
+    });
+
+    expect(unlockWorkChimeAudioMock).toHaveBeenCalled();
+    expect(result.current.isAudioEnabled).toBe(true);
   });
 });

--- a/hooks/useWorkChime.ts
+++ b/hooks/useWorkChime.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { isWorkChimeAudioReady, playWorkChime, unlockWorkChimeAudio } from '@/lib/workChimeAudio';
+import { isWorkChimeAudioReady, playWorkChime, resumeWorkChimeAudio, unlockWorkChimeAudio } from '@/lib/workChimeAudio';
 import {
   getCurrentWorkChimePeriod,
   getDueWorkChimeSince,
@@ -120,10 +120,17 @@ export function useWorkChime(now: Date | null): UseWorkChimeReturn {
     playedKeysRef.current = [...playedKeysRef.current, due.playKey].slice(-50);
     setActiveChime(due);
 
-    if (settings.soundEnabled && isAudioEnabled) {
-      void playWorkChime(due.kind, { volume: settings.volume }).then((didPlay) => {
-        if (!didPlay) setIsAudioEnabled(false);
-      });
+    // 発火時は React の isAudioEnabled フラグ（古い値の可能性あり）ではなく、
+    // AudioContext の生きた状態 isWorkChimeAudioReady() で判定する。
+    // これにより iOS の interrupted 自動復帰後も確実に鳴り、未アンロック時は
+    // 余計な AudioContext 生成やコンソール警告を避けられる。結果でフラグを自己修復する。
+    const audioReady = isWorkChimeAudioReady();
+    if (settings.soundEnabled && audioReady) {
+      void playWorkChime(due.kind, { volume: settings.volume }).then(setIsAudioEnabled);
+    } else if (!audioReady) {
+      // 鳴らせない状態なので有効フラグを下げ、「有効化」ボタンを出して
+      // 次のユーザー操作で復帰できるようにする。
+      setIsAudioEnabled(false);
     }
 
     if (timerRef.current) clearTimeout(timerRef.current);
@@ -131,16 +138,18 @@ export function useWorkChime(now: Date | null): UseWorkChimeReturn {
       setActiveChime(null);
       timerRef.current = null;
     }, 5000);
-  }, [isAudioEnabled, now, settings]);
+  }, [now, settings]);
 
+  // フォアグラウンド復帰時、suspended でも即 disable せず resume を試みて自動復旧する。
   useEffect(() => {
     if (typeof window === 'undefined' || typeof document === 'undefined') return;
-    if (!isAudioEnabled) return;
 
     const refreshAudioState = () => {
-      if (!isWorkChimeAudioReady()) {
-        setIsAudioEnabled(false);
+      if (isWorkChimeAudioReady()) {
+        setIsAudioEnabled(true);
+        return;
       }
+      void resumeWorkChimeAudio().then(setIsAudioEnabled);
     };
 
     window.addEventListener('focus', refreshAudioState);
@@ -152,7 +161,32 @@ export function useWorkChime(now: Date | null): UseWorkChimeReturn {
       window.removeEventListener('pageshow', refreshAudioState);
       document.removeEventListener('visibilitychange', refreshAudioState);
     };
-  }, [isAudioEnabled]);
+  }, []);
+
+  // 画面上の任意のユーザー操作でオーディオを自動的に有効化する。
+  // ボタンを押し直さなくても、タップ／クリック／キー操作だけで suspended から復帰できる。
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+
+    const handleGesture = () => {
+      if (isWorkChimeAudioReady()) {
+        setIsAudioEnabled(true);
+        return;
+      }
+      void unlockWorkChimeAudio().then(setIsAudioEnabled);
+    };
+
+    const options: AddEventListenerOptions = { passive: true };
+    document.addEventListener('pointerdown', handleGesture, options);
+    document.addEventListener('keydown', handleGesture, options);
+    document.addEventListener('touchend', handleGesture, options);
+
+    return () => {
+      document.removeEventListener('pointerdown', handleGesture);
+      document.removeEventListener('keydown', handleGesture);
+      document.removeEventListener('touchend', handleGesture);
+    };
+  }, []);
 
   useEffect(() => {
     return () => {

--- a/lib/workChimeAudio.test.ts
+++ b/lib/workChimeAudio.test.ts
@@ -100,6 +100,20 @@ describe('workChimeAudio', () => {
     expect(mock.ctx.createOscillator).toHaveBeenCalled();
   });
 
+  it('iOSのinterrupted状態でも再開してからチャイムをスケジュールする', async () => {
+    const resume = vi.fn(() => Promise.resolve());
+    // iOS 独自の 'interrupted' 状態（型上は存在しないためキャスト）。
+    const mock = createAudioContextMock({
+      state: 'interrupted' as AudioContextState,
+      resume,
+    });
+
+    await playWorkChime('break', { volume: 0.8, audioContext: mock.ctx });
+
+    expect(resume).toHaveBeenCalledTimes(1);
+    expect(mock.ctx.createOscillator).toHaveBeenCalled();
+  });
+
   it('音声有効化時にAudioContextを作成して無音チャイムで初期化する', async () => {
     const resume = vi.fn(() => Promise.resolve());
     const mock = createAudioContextMock({ state: 'suspended', resume });

--- a/lib/workChimeAudio.ts
+++ b/lib/workChimeAudio.ts
@@ -28,6 +28,19 @@ function clampVolume(value: number): number {
   return Math.max(0, Math.min(1, value));
 }
 
+// iOS/iPadOS は標準外の 'interrupted' 状態を持つ（画面スリープ・自動ロック・他アプリの音声・
+// コントロールセンター等で遷移する）。'suspended' と同様に resume が必要だが、'interrupted' は
+// ユーザー操作なしでも resume できる点が異なる。state は型上 'interrupted' を含まないため緩く扱う。
+type AudioContextStateLike = AudioContextState | 'interrupted' | undefined;
+
+function getContextState(ctx: AudioContextLike): AudioContextStateLike {
+  return ctx.state as AudioContextStateLike;
+}
+
+function needsResume(state: AudioContextStateLike): boolean {
+  return state === 'suspended' || state === 'interrupted';
+}
+
 let workChimeAudioContext: AudioContextLike | null = null;
 
 function createAudioContext(): AudioContextLike | null {
@@ -36,7 +49,19 @@ function createAudioContext(): AudioContextLike | null {
   const AudioContextConstructor = window.AudioContext || window.webkitAudioContext;
   if (!AudioContextConstructor) return null;
 
-  return new AudioContextConstructor();
+  const ctx = new AudioContextConstructor();
+
+  // iOS: 'interrupted' へ遷移したら（画面スリープ・他アプリの音声等）ユーザー操作なしで
+  // resume を試みて自動復帰する。'suspended' はジェスチャが必要なためここでは何もしない。
+  if (typeof ctx.addEventListener === 'function') {
+    ctx.addEventListener('statechange', () => {
+      if (getContextState(ctx) === 'interrupted') {
+        void ctx.resume?.().catch(() => {});
+      }
+    });
+  }
+
+  return ctx;
 }
 
 function getAudioContext(): AudioContextLike | null {
@@ -47,8 +72,9 @@ function getAudioContext(): AudioContextLike | null {
 }
 
 async function resumeAudioContext(ctx: AudioContextLike): Promise<boolean> {
-  if (ctx.state === 'closed') return false;
-  if (ctx.state !== 'suspended') return true;
+  const state = getContextState(ctx);
+  if (state === 'closed') return false;
+  if (!needsResume(state)) return true;
   if (!ctx.resume) return false;
 
   try {
@@ -132,7 +158,13 @@ async function scheduleWorkChime(ctx: AudioContextLike, kind: WorkChimeKind, vol
 
 export function isWorkChimeAudioReady(): boolean {
   if (!workChimeAudioContext) return false;
-  return workChimeAudioContext.state !== 'suspended' && workChimeAudioContext.state !== 'closed';
+  const state = getContextState(workChimeAudioContext);
+  return state !== 'suspended' && state !== 'closed' && state !== 'interrupted';
+}
+
+export async function resumeWorkChimeAudio(): Promise<boolean> {
+  if (!workChimeAudioContext) return false;
+  return resumeAudioContext(workChimeAudioContext);
 }
 
 export async function unlockWorkChimeAudio(): Promise<boolean> {


### PR DESCRIPTION
## 背景・原因

時計のチャイムが「鳴らない時がある／開き直す・有効化を押し直すと直る」問題を、**iPad の PWA 前提**で調査・特定しました。

チャイムは Web Audio API（`AudioContext`）の合成音で鳴らしています。iPadOS（WebKit）には以下の挙動があり、これが原因でした。

1. **背面化・画面スリープ・自動ロックで `AudioContext` が `suspended` / iOS 独自の `interrupted` 状態になる**（WebKit Bug [237878](https://bugs.webkit.org/show_bug.cgi?id=237878) / [198277](https://bugs.webkit.org/show_bug.cgi?id=198277)）。音声再生中でもプロセスごと停止されるため、背面では鳴らせない。
2. **フォアグラウンド復帰時に自動 resume されない**。さらに `suspended` の `resume()` は**ユーザー操作の呼び出しスタック内**でしか成功しない（`focus`/`visibilitychange` は不可）。
3. 従来コード（`hooks/useWorkChime.ts`）は復帰時に `setIsAudioEnabled(false)` にするだけで resume を試みず、チャイム発火を `isAudioEnabled` で握りつぶしていた。→「有効化ボタンの押し直し／開き直し」という**新しいユーザー操作**で初めて resume が走り復旧していた。
4. iOS 独自の `interrupted` 状態が未対応で、`resumeAudioContext` が ready とみなして resume せず**無音**になっていた。

## 修正内容

### `lib/workChimeAudio.ts`
- iOS 独自の `'interrupted'` 状態を `suspended` と同様に resume 対象として扱う
- `AudioContext` 生成時に `statechange` を監視し、`interrupted` へ遷移したら**ユーザー操作なしで自動 resume**（interrupted はジェスチャ不要）
- 既存コンテキストを再開する `resumeWorkChimeAudio()` を追加

### `hooks/useWorkChime.ts`
- フォーカス/可視復帰時に無効化ではなく **resume を試みて自動復旧**
- 画面上の**任意のユーザー操作**（pointerdown / keydown / touchend）で自動的にオーディオを有効化（ボタンを探す必要なし）
- チャイム発火判定を stale な React フラグではなく `isWorkChimeAudioReady()` の**生きた状態**で行い、`interrupted` 自動復帰後も確実に鳴らす

## 既知の制約

iPadOS では PWA が**完全に背面・ロック中**の間は、Web Audio で鳴らすことはできません（OS がプロセスを停止するため）。フォアグラウンド復帰時・操作時の復旧不全を解消するもので、報告された「開き直すと直る」ケース（＝フォアグラウンドでの不全）を解決します。完全な背面通知が必要な場合は Web Push（iOS 16.4+ PWA）の別途実装が必要です。

## テスト

- `lib/workChimeAudio.test.ts`：`interrupted` 状態でも resume してスケジュールすることを追加検証
- `hooks/useWorkChime.test.tsx`：復帰時の resume 成功/失敗、ユーザー操作での自動有効化、未準備時は鳴らさず通知のみ、を検証
- `npx vitest run lib/workChimeAudio.test.ts hooks/useWorkChime.test.tsx` → 17 passed
- `npm run typecheck` → エラーなし

## 手動検証（推奨）

1. iPad の PWA で `/clock` を開きチャイムを有効化
2. 別アプリ切替 or 自動ロック → 復帰 → ボタンを押し直さず、画面を一度タップするだけで有効状態が維持され、チャイム時刻に鳴ること
3. テストチャイムで復帰後も鳴ること

https://claude.ai/code/session_01MaAB2f7PRfkYXz3gRzAbxF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MaAB2f7PRfkYXz3gRzAbxF)_