### PR TITLE
refactor: マジックナンバーと重複定数をDRY原則に沿って整理

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,7 +17,7 @@ import { getUserData } from '@/lib/firestore';
 import { needsConsent } from '@/lib/consent';
 import type { HomeFeatureKey } from '@/lib/homeFeatures';
 import dynamic from 'next/dynamic';
-import { SPLASH_DISPLAY_TIME } from '@/components/SplashScreen';
+import { SPLASH_DISPLAY_TIME } from '@/lib/constants';
 
 const Snowfall = dynamic(() => import('@/components/Snowfall').then((mod) => ({ default: mod.Snowfall })), {
   ssr: false,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,6 +17,7 @@ import { getUserData } from '@/lib/firestore';
 import { needsConsent } from '@/lib/consent';
 import type { HomeFeatureKey } from '@/lib/homeFeatures';
 import dynamic from 'next/dynamic';
+import { SPLASH_DISPLAY_TIME } from '@/components/SplashScreen';
 
 const Snowfall = dynamic(() => import('@/components/Snowfall').then((mod) => ({ default: mod.Snowfall })), {
   ssr: false,
@@ -45,8 +46,6 @@ const CHRISTMAS_ICONS: Record<string, IconType> = {
   'drip-guide': GiCandyCanes,
   settings: IoSettings,
 };
-
-const SPLASH_DISPLAY_TIME = 2800; // スプラッシュ画面の表示時間（SplashScreen.tsx と同値）
 
 const ACTIONS: Action[] = [
   {

--- a/components/SplashScreen.tsx
+++ b/components/SplashScreen.tsx
@@ -2,8 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { splashPatterns } from '@/components/splash/patterns';
-
-export const SPLASH_DISPLAY_TIME = 2800;
+import { SPLASH_DISPLAY_TIME } from '@/lib/constants';
 const SPLASH_SHOWN_KEY = 'roastplus_splash_shown';
 const REPLAY_SPLASH_EVENT = 'replay-splash';
 

--- a/components/SplashScreen.tsx
+++ b/components/SplashScreen.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { splashPatterns } from '@/components/splash/patterns';
 
-const SPLASH_DISPLAY_TIME = 2800;
+export const SPLASH_DISPLAY_TIME = 2800;
 const SPLASH_SHOWN_KEY = 'roastplus_splash_shown';
 const REPLAY_SPLASH_EVENT = 'replay-splash';
 

--- a/components/home/ActionCard.tsx
+++ b/components/home/ActionCard.tsx
@@ -16,10 +16,12 @@ interface ActionCardProps {
   index: number;
 }
 
+const CARD_ANIMATION_DELAY_MS = 60;
+
 export function ActionCard({ title, label, description, href, icon: Icon, badge, index }: ActionCardProps) {
   const router = useRouter();
   const cardStyle = {
-    animationDelay: `${index * 60}ms`,
+    animationDelay: `${index * CARD_ANIMATION_DELAY_MS}ms`,
   } as CSSProperties;
 
   return (

--- a/components/home/HomeHeader.tsx
+++ b/components/home/HomeHeader.tsx
@@ -5,6 +5,9 @@ import { HiClock } from 'react-icons/hi';
 import { useChristmasMode } from '@/hooks/useChristmasMode';
 import { IconButton } from '@/components/ui';
 
+const LOGO_TEXT_BASE =
+  'text-2xl md:text-3xl font-[var(--font-inter)] font-extrabold tracking-[-0.04em] leading-none';
+
 export function HomeHeader() {
   const router = useRouter();
   const { isChristmasMode } = useChristmasMode();
@@ -31,24 +34,14 @@ export function HomeHeader() {
           )}
           {isChristmasMode ? (
             <div className="flex items-baseline">
-              <span className="text-2xl md:text-3xl font-[var(--font-inter)] font-extrabold tracking-[-0.04em] text-[#e23636] leading-none">
-                R
-              </span>
-              <span className="text-2xl md:text-3xl font-[var(--font-inter)] font-extrabold tracking-[-0.04em] text-header-text leading-none">
-                oast
-              </span>
-              <span className="text-2xl md:text-3xl font-[var(--font-inter)] font-extrabold tracking-[-0.04em] text-header-accent leading-none">
-                Plus
-              </span>
+              <span className={`${LOGO_TEXT_BASE} text-[#e23636]`}>R</span>
+              <span className={`${LOGO_TEXT_BASE} text-header-text`}>oast</span>
+              <span className={`${LOGO_TEXT_BASE} text-header-accent`}>Plus</span>
             </div>
           ) : (
             <div className="flex items-baseline">
-              <span className="text-2xl md:text-3xl font-[var(--font-inter)] font-extrabold tracking-[-0.04em] text-header-text leading-none">
-                Roast
-              </span>
-              <span className="text-2xl md:text-3xl font-[var(--font-inter)] font-extrabold tracking-[-0.04em] text-header-accent leading-none">
-                Plus
-              </span>
+              <span className={`${LOGO_TEXT_BASE} text-header-text`}>Roast</span>
+              <span className={`${LOGO_TEXT_BASE} text-header-accent`}>Plus</span>
             </div>
           )}
         </div>

--- a/components/home/HomeHeader.tsx
+++ b/components/home/HomeHeader.tsx
@@ -5,8 +5,7 @@ import { HiClock } from 'react-icons/hi';
 import { useChristmasMode } from '@/hooks/useChristmasMode';
 import { IconButton } from '@/components/ui';
 
-const LOGO_TEXT_BASE =
-  'text-2xl md:text-3xl font-[var(--font-inter)] font-extrabold tracking-[-0.04em] leading-none';
+const LOGO_TEXT_BASE = 'text-2xl md:text-3xl font-[var(--font-inter)] font-extrabold tracking-[-0.04em] leading-none';
 
 export function HomeHeader() {
   const router = useRouter();

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,3 +1,5 @@
+export const SPLASH_DISPLAY_TIME = 2800;
+
 export const ROAST_LEVELS = ['浅煎り', '中煎り', '中深煎り', '深煎り'] as const;
 
 export type RoastLevel = (typeof ROAST_LEVELS)[number];


### PR DESCRIPTION
## 概要

IKさんが自分で手を動かして行ったリファクタリング学習セッションの記録PR。
動作の変更なし。コードの読みやすさのみを改善。

## 変更内容

- **ActionCard.tsx** — アニメーション遅延 `60` を `CARD_ANIMATION_DELAY_MS` に命名（マジックナンバーの排除）
- **SplashScreen.tsx / page.tsx** — `SPLASH_DISPLAY_TIME = 2800` が2ファイルに重複していたのを `export/import` で一元管理
- **HomeHeader.tsx** — ロゴ `<span>` ×5に繰り返していた長いクラス名を `LOGO_TEXT_BASE` 定数にまとめた

## 学んだ概念

| # | リファクタリング | 概念 |
|---|---|---|
| ① | 数字に名前をつける | マジックナンバーの排除 |
| ② | 重複定数を一元管理 | Single Source of Truth / export・import |
| ③ | クラス名の重複をまとめる | DRY原則 |

## 確認事項

- [ ] 動作変更なし（定数の移動・命名のみ）
- [ ] Lint・ビルドエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)