### PR TITLE
docs: README・法的文書を実態に合わせて更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,16 @@ AGENTS.md の「Skill活用方針」は Codex 向けのため、Claude Code で�
 | 完了前の確認 | `superpowers:verification-before-completion` |
 | PR前のレビュー | `superpowers:requesting-code-review` |
 
+## 機能追加・削除時のルール
+
+`app/` 配下のページ（`page.tsx`）を追加・削除したときは、必ず以下の3ファイルも合わせて更新する：
+
+1. `data/legal/privacy-policy.ts` — 収集する業務データの一覧を更新し、`PRIVACY_POLICY_LAST_UPDATED` の日付と `lib/consent.ts` の `PRIVACY_POLICY_VERSION` をインクリメント
+2. `data/legal/terms.ts` — 第2条のサービス機能一覧を更新し、`TERMS_LAST_UPDATED` の日付と `lib/consent.ts` の `TERMS_VERSION` をインクリメント
+3. `lib/consent.test.ts` — バージョン定数のテスト期待値を更新
+
+バージョンのインクリメントルール：機能の追加・削除はマイナーバージョン（x.**Y**.0）を上げる。
+
 ## Claude 固有ツール
 
 - **Serena MCP**：コードファイルの読み書きは Serena MCP を優先する（グローバル設定準拠）

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # RoastPlus
 
-**コーヒー焙煎現場向け PWA**
+**ドリップパックコーヒー製造現場向け PWA**
 
-> iPad で現場に置いて使える、作業の見取り図に寄せた業務支援ツール
+> iPad で現場に置いて使う業務支援ツール
 
 <p>
   <img src="https://img.shields.io/badge/Next.js-16-black?logo=next.js" alt="Next.js" />
@@ -17,16 +17,16 @@
 
 ## このアプリの立ち位置
 
-RoastPlus は、焙煎・試験・抽出業務の現場で、**実際に使われること**を前提に作った社内ツールです。  
-開発当初は 8 名体制でしたが、現在は 5 名での運用を前提に、使う機能を絞って運用性を上げています。
+RoastPlus は、ドリップパックコーヒーの製造現場で、**実際に使われること**を前提に作った社内ツールです。  
+少人数でも迷わず使えることを目指して、使う機能を絞って運用性を上げています。
 
-目的は「機能を増やすこと」ではなく、現場の人数が少ないときでも:
+目的は**属人化の解消**です。障碍のあるスタッフが働く現場のため、担当者が変わっても誰でも:
 
 - 迷わず見える
 - 誤操作しにくい
 - 作業区切りがその場で分かる
 
-を満たすことです。
+を実現できることを優先しています。
 
 ---
 
@@ -46,26 +46,15 @@ RoastPlus は、焙煎・試験・抽出業務の現場で、**実際に使わ�
 ### 既存機能（運用で必要に応じて使う）
 
 - 担当表
-- 焙煎タイマー・記録
+- スケジュール
 - 試飲感想の記録
+- 欠点豆図鑑
+- 生産記録
 - ドリップガイド
-- 欠点豆の情報共有
-- コーヒー豆図鑑・クイズ
 
 ### 運用方針
 
-使われない機能は「将来追加」より先に、まず既存機能の表示とフローをシンプル化して運用側のストレスを下げる方針です。
-
----
-
-## 主要な画面
-
-- `/clock`  
-  作業効率を直接支える中核画面。区切り時刻の管理と通知がメインです。
-- `/`  
-  メインダッシュボード。各機能への導線。
-- `settings/home`, `settings/theme`, `settings`  
-  テーマや表示、時計機能の設定。
+新機能より、今ある機能を使いやすくすることを優先する。
 
 ---
 
@@ -96,35 +85,13 @@ iPad 実機確認がある場合は同一ネットワークからアクセスし
 ### よく使うコマンド
 
 ```bash
-npm run dev        # 開発サーバ起動（音声ファイル一覧を生成してからNext.js起動）
+npm run dev        # 開発サーバ起動
 npm run typecheck  # TypeScript型チェック
 npm run lint       # ESLint
 npm run test:run   # Vitestを1回実行
 npm run test:rules # Firestore Rulesテスト
 npm run build      # 本番ビルド（productionではstatic exportでout/を生成）
 npm run test:e2e   # Playwright E2E
-```
-
-### E2Eテストのローカル実行
-
-`npm run test:e2e` は E2E 専用に `http://localhost:3100` を使います。
-通常は `scripts/run-e2e.ts` が開発サーバーを起動してから Playwright を実行します。
-
-既に E2E 用サーバーが `3100` で動いている場合、ローカルではそれを再利用します。
-CI では意図しないサーバーを使わないよう、既存サーバーがある場合は失敗させます。
-
-Windows で `3100` の利用状況を確認する場合:
-
-```powershell
-Get-NetTCPConnection -LocalPort 3100 -ErrorAction SilentlyContinue
-```
-
-別ポートで実行したい場合:
-
-```powershell
-$env:E2E_PORT = '3101'
-npm run test:e2e
-Remove-Item Env:E2E_PORT
 ```
 
 ---
@@ -147,17 +114,11 @@ Remove-Item Env:E2E_PORT
 
 ## ビルドと配信
 
+本番URL: https://roastplus-72fa6.web.app
+
 本番ビルドは Next.js の static export です。`next.config.ts` では production 時のみ `output: 'export'` が有効になり、Firebase Hosting は `firebase.json` の設定どおり `out/` を配信します。
 
 `public/` 配下は本番でそのまま配信される公開素材置き場です。秘密情報、テスト用ファイル、デバッグ用ファイルは置かないでください。
-
----
-
-## 実運用での現状
-
-- 利用者: 5 名（現場運用）
-- 主軸利用機能: 時計・作業チャイム
-- 方向性: 使われる導線を優先し、画面・操作を最適化
 
 ---
 
@@ -165,8 +126,3 @@ Remove-Item Env:E2E_PORT
 
 - [バックアップ運用手順](docs/steering/BACKUP_OPERATIONS.md) — Firestore / Storage の手動バックアップ・復元手順
 
----
-
-## ライセンス
-
-社内運用向けの実用コードとして管理し、利用範囲や導入方針はリポジトリ内の運用ルールに従って判断してください。

--- a/data/legal/privacy-policy.ts
+++ b/data/legal/privacy-policy.ts
@@ -26,15 +26,10 @@ export const PRIVACY_POLICY_SECTIONS: PrivacyPolicySection[] = [
       '【業務データ】',
       '・担当表（メンバー名、タスク割り当てなど）',
       '・スケジュール（日時、作業内容など）',
+      '・生産記録（ハンドピック重量、焙煎重量、パッケージ数など）',
       '・試飲感想記録（評価スコア、感想コメント、豆名など）',
-      '・ローストタイマー（焙煎時間、豆名、焙煎レベルなど）',
       '・欠点豆図鑑（欠点豆の名前、特徴など）',
-      '・作業進捗（タスク名、進捗状況、完了日時など）',
       '・ドリップガイド（レシピ名、抽出手順など）',
-      '',
-      '【学習データ】',
-      '・クイズ回答履歴',
-      '・獲得XP・レベル情報',
       '',
       '【画像データ】',
       '・欠点豆の画像（Firebase Storageに保存）',
@@ -48,7 +43,6 @@ export const PRIVACY_POLICY_SECTIONS: PrivacyPolicySection[] = [
       '・問い合わせフォームに入力した名前、メールアドレス、お問い合わせ種別、本文',
       '',
       '【デバイス情報】',
-      '・デバイスID（焙煎タイマーの同期用）',
       '・操作タイムスタンプ',
     ],
   },
@@ -165,4 +159,4 @@ export const PRIVACY_POLICY_SECTIONS: PrivacyPolicySection[] = [
   },
 ];
 
-export const PRIVACY_POLICY_LAST_UPDATED = '2026年5月23日';
+export const PRIVACY_POLICY_LAST_UPDATED = '2026年6月5日';

--- a/data/legal/terms.ts
+++ b/data/legal/terms.ts
@@ -17,7 +17,7 @@ export const TERMS_SECTIONS: TermsSection[] = [
     title: '第2条（サービスの概要）',
     content: [
       '本サービスは、コーヒー加工業務の支援を目的としたアプリケーションです。',
-      '主な機能として、担当表、スケジュール、試飲感想記録、ローストタイマー、コーヒー豆図鑑、作業進捗、ドリップガイド、コーヒークイズなどを提供します。',
+      '主な機能として、担当表、スケジュール、生産記録、試飲感想記録、ドリップガイド、欠点豆図鑑などを提供します。',
     ],
   },
   {
@@ -100,4 +100,4 @@ export const TERMS_SECTIONS: TermsSection[] = [
   },
 ];
 
-export const TERMS_LAST_UPDATED = '2025年1月24日';
+export const TERMS_LAST_UPDATED = '2026年6月5日';

--- a/lib/consent.test.ts
+++ b/lib/consent.test.ts
@@ -5,11 +5,11 @@ import type { UserConsent } from '@/types';
 describe('consent', () => {
   describe('定数', () => {
     it('TERMS_VERSIONが定義されている', () => {
-      expect(TERMS_VERSION).toBe('1.0.0');
+      expect(TERMS_VERSION).toBe('1.1.0');
     });
 
     it('PRIVACY_POLICY_VERSIONが定義されている', () => {
-      expect(PRIVACY_POLICY_VERSION).toBe('1.1.0');
+      expect(PRIVACY_POLICY_VERSION).toBe('1.2.0');
     });
   });
 

--- a/lib/consent.ts
+++ b/lib/consent.ts
@@ -1,8 +1,8 @@
 import { UserConsent } from '@/types';
 
 // バージョン定義
-export const TERMS_VERSION = '1.0.0';
-export const PRIVACY_POLICY_VERSION = '1.1.0';
+export const TERMS_VERSION = '1.1.0';
+export const PRIVACY_POLICY_VERSION = '1.2.0';
 
 // 同意が必要かどうかをチェック
 export function needsConsent(userConsent: UserConsent | undefined): boolean {


### PR DESCRIPTION
## 変更内容

### README.md
- 業種名を「コーヒードリップパック製造現場向け」に統一
- 削除済み機能（焙煎タイマー・クイズ）をリストから除去、生産記録・スケジュールを追加
- 動的情報（人数・運用状況）を削除
- 「作業の見取り図に寄せた」など意味が伝わりにくい表現を修正
- 本番URL追加、E2Eテスト詳細説明・ライセンスセクション削除
- `npm run dev` コメントを package.json の実態に合わせて修正

### 法的文書
- `privacy-policy.ts`: 削除済み機能を除去・生産記録を追加、v1.1.0 → v1.2.0
- `terms.ts`: 第2条の機能一覧を現状に更新、v1.0.0 → v1.1.0
- `consent.ts` / `consent.test.ts`: バージョン定数と期待値を更新

### CLAUDE.md
- 機能追加・削除時に法的文書3ファイルを自動で更新するルールを追加

## 確認済み
- コミット前フック（lint・secrets scan）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)