### PR TITLE
[codex] チャイム音有効化UIを改善

### DIFF
--- a/app/clock/page.tsx
+++ b/app/clock/page.tsx
@@ -243,22 +243,47 @@ export default function ClockPage() {
         )}
 
         {shouldShowAudioEnableButton && (
-          <div className="mt-4 flex justify-center">
-            <Button
-              type="button"
-              variant="secondary"
-              size="sm"
-              onClick={enableAudio}
-              className="!min-h-11 border"
+          <div className="mt-4 flex justify-center px-4">
+            <div
+              className="grid w-full max-w-lg grid-cols-[auto_1fr] items-center gap-3 rounded-2xl border p-3 text-left shadow-card sm:grid-cols-[auto_1fr_auto] sm:p-3.5"
               style={{
-                backgroundColor: colors.uiBg,
+                backgroundColor: colors.bg,
                 borderColor: colors.accent,
-                color: colors.text,
               }}
             >
-              <MdVolumeUp className="mr-1.5 h-5 w-5" aria-hidden="true" />
-              チャイム音を有効化
-            </Button>
+              <div
+                className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full"
+                style={{
+                  backgroundColor: `${colors.accent}20`,
+                  color: colors.accent,
+                }}
+                aria-hidden="true"
+              >
+                <MdVolumeUp className="h-5 w-5" />
+              </div>
+              <div>
+                <p className="text-sm font-bold leading-snug" style={{ color: colors.text }}>
+                  チャイム音の準備が必要です
+                </p>
+                <p className="mt-0.5 text-xs font-medium leading-relaxed" style={{ color: colors.uiText }}>
+                  iPadの制限により、初回だけボタン操作で音を有効化します。
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="primary"
+                size="sm"
+                onClick={enableAudio}
+                className="col-span-2 mt-1 w-full !min-h-11 !px-4 sm:col-span-1 sm:mt-0 sm:w-auto"
+                style={{
+                  backgroundColor: colors.accent,
+                  color: '#FFFFFF',
+                }}
+              >
+                <MdVolumeUp className="mr-1.5 h-4 w-4" aria-hidden="true" />
+                音を有効化
+              </Button>
+            </div>
           </div>
         )}
       </div>

--- a/components/clock/ClockSettingsModal.tsx
+++ b/components/clock/ClockSettingsModal.tsx
@@ -254,16 +254,32 @@ export function ClockSettingsModal({
                   </div>
 
                   {workChimeSettings.soundEnabled && (
-                    <div className="flex items-center justify-between py-3 px-1 min-h-[44px]">
-                      <span className="text-sm font-medium" style={{ color: themeColors.text }}>
-                        チャイム音
-                      </span>
+                    <div className="flex items-center justify-between gap-3 py-3 px-1 min-h-[44px]">
+                      <div>
+                        <span className="text-sm font-medium block" style={{ color: themeColors.text }}>
+                          チャイム音
+                        </span>
+                        <span className="text-xs" style={{ color: themeColors.uiText }}>
+                          この端末で音を再生できる状態にします
+                        </span>
+                      </div>
                       {isWorkChimeAudioEnabled ? (
-                        <span className="text-sm font-medium" style={{ color: themeColors.accent }}>
+                        <span className="inline-flex min-h-8 items-center gap-1.5 rounded-full border border-success/20 bg-success-subtle px-3 text-sm font-bold text-success">
+                          <span className="h-2 w-2 rounded-full bg-current" aria-hidden="true" />
                           有効
                         </span>
                       ) : (
-                        <Button type="button" variant="secondary" size="sm" onClick={onEnableWorkChimeAudio}>
+                        <Button
+                          type="button"
+                          variant="primary"
+                          size="sm"
+                          onClick={onEnableWorkChimeAudio}
+                          className="!px-3"
+                          style={{
+                            backgroundColor: themeColors.accent,
+                            color: themeColors.bg,
+                          }}
+                        >
                           <MdVolumeUp className="mr-1.5 h-4 w-4" />
                           音を有効化
                         </Button>


### PR DESCRIPTION
## 概要

時計画面と時計設定モーダルの「チャイム音を有効化」まわりの見た目と文字色を改善しました。

## 変更したファイル

- `app/clock/page.tsx`
  - 時計画面の有効化ボタンを、説明付きの小さな情報パネルに変更
  - 背景は時計画面になじむ白系にし、枠線とオレンジのボタンで操作箇所を強調
- `components/clock/ClockSettingsModal.tsx`
  - チャイム音の説明文を追加
  - 有効状態を緑のバッジで表示

## なぜこの修正が必要か

従来は「チャイム音を有効化」ボタンだけが表示され、なぜ有効化が必要なのか分かりにくい状態でした。iPad / Safari の音声再生制限により初回操作が必要なため、理由と操作を同じ場所で読めるようにしました。

## 確認したこと

- `npm run lint -- app/clock/page.tsx components/clock/ClockSettingsModal.tsx`
- `npm run typecheck`
- `npm run test:run -- components/clock/ClockSettingsModal.test.tsx`
- `http://localhost:3000/clock` で時計画面と設定モーダルの表示を確認

## 残っているリスク

- 画面表示のみの変更で、データ保存・認証・Firestore Rules・Storage Rules への影響はありません。
- テーマごとの見え方は既存の時計テーマ色に依存します。ライトテーマでは確認済みです。

## 意図的に触らなかった範囲

- チャイム音の再生ロジック
- チャイム時刻設定
- localStorage の保存形式
- Firestore / Storage / Cloud Functions