### PR TITLE
[codex] ログイン画面のロゴ背景色を調整

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -90,9 +90,9 @@ function LoginForm() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-page px-4">
       <div className="w-full max-w-md rounded-lg bg-surface p-8 shadow-md border border-edge">
-        <div className="mb-8 flex flex-col items-center bg-[#1a1412] py-6 rounded-xl shadow-inner">
-          <h1 className="text-4xl font-bold text-white tracking-tight font-[var(--font-playfair)]">
-            Roast<span className="text-amber-500">Plus</span>
+        <div className="mb-8 flex flex-col items-center rounded-xl bg-[#3a261d] py-6 shadow-inner">
+          <h1 className="text-4xl font-bold tracking-tight text-header-text font-[var(--font-playfair)]">
+            Roast<span className="text-header-accent">Plus</span>
           </h1>
         </div>
 


### PR DESCRIPTION
## 概要

ログイン画面上部の RoastPlus ロゴ帯の背景色を、ほぼ黒に近い色から落ち着いた単色のコーヒーブラウンに調整しました。

## 変更したファイル

- `app/login/page.tsx`
  - ロゴ帯の背景色を `#3a261d` に変更
  - ロゴ文字色をテーマの `text-header-text` / `text-header-accent` に合わせる形へ整理

## なぜこの修正が必要か

ログイン画面のロゴ帯が暗く見えすぎて、RoastPlusらしいコーヒー色として見えにくかったためです。ユーザー確認の結果、グラデーションではなく単色の落ち着いたブラウンにしました。

## 確認したこと

- `npm run lint` 成功
- ログイン画面の認証処理、フォーム送信処理、Firebase関連処理には触れていません

## 残っているリスク

- Codex in-app browser の自動操作接続がこの環境で起動失敗したため、最終的な自動スクリーンショット確認は未実施です
- ユーザーのブラウザ上では `#3a261d` の見た目を確認済み