### PR TITLE
生産記録のUX改善（数字・UIのちらつき対策＋モーダル整形）

### DIFF
--- a/app/production-record/page.test.tsx
+++ b/app/production-record/page.test.tsx
@@ -244,6 +244,8 @@ function setupWithData() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // 月リストキャッシュ(localStorage)がテスト間で残ると空状態テストを汚染するためクリア
+  localStorage.clear();
   mocks.months = [];
   mocks.hookState.monthDoc = null;
   mocks.hookState.handpickEntries = [];
@@ -352,6 +354,8 @@ describe('ProductionRecordPage データ表示と集計', () => {
 
   it('月合計サマリーとCSVプレビューを表示する', () => {
     render(<ProductionRecordPage />);
+    // 月合計は普段隠れており、下部バーのタップでモーダルとして開く
+    fireEvent.click(screen.getByRole('button', { name: /月合計・CSV出力/ }));
 
     expect(screen.getByRole('heading', { name: '月合計サマリー' })).toBeInTheDocument();
     // 配合ラベル
@@ -365,7 +369,9 @@ describe('ProductionRecordPage データ表示と集計', () => {
 
   it('「設定を編集」で月設定モーダルを既存値入り（initial=monthDoc）で開く', () => {
     render(<ProductionRecordPage />);
-    fireEvent.click(screen.getByRole('button', { name: '設定を編集' }));
+    // 設定編集は「月の設定」メニュー内に集約された
+    fireEvent.click(screen.getByRole('button', { name: '月の設定' }));
+    fireEvent.click(screen.getByRole('button', { name: /設定を編集/ }));
 
     expect(screen.getByTestId('month-modal')).toBeInTheDocument();
     // 編集モードでは選択中の月とその設定が初期値として渡る
@@ -375,9 +381,12 @@ describe('ProductionRecordPage データ表示と集計', () => {
 
   it('新規作成時は月設定モーダルが空（initial=null）で開く', async () => {
     render(<ProductionRecordPage />);
+    // 新規作成は「月の設定」メニュー内の「新しい月を作る」に移動した
+    fireEvent.click(screen.getByRole('button', { name: '月の設定' }));
+    const createSection = screen.getByText('新しい月を作る').parentElement as HTMLElement;
     // 既存月(2026-05)と重複しない月を指定する（重複月は作成がブロックされるため、当月の日付に依存させない）
-    fireEvent.change(screen.getByLabelText('新規作成'), { target: { value: '2026-07' } });
-    fireEvent.click(screen.getByRole('button', { name: '対象月を作成' }));
+    fireEvent.change(within(createSection).getByLabelText('対象月'), { target: { value: '2026-07' } });
+    fireEvent.click(within(createSection).getByRole('button', { name: '作成' }));
 
     expect(await screen.findByTestId('month-modal')).toBeInTheDocument();
     expect(mocks.monthProps?.initial).toBeNull();
@@ -475,6 +484,8 @@ describe('ProductionRecordPage CSV出力', () => {
     window.URL.revokeObjectURL = revokeObjectURL;
 
     render(<ProductionRecordPage />);
+    // CSV出力ボタンは月合計モーダル内にあるため、先に下部バーから開く
+    fireEvent.click(screen.getByRole('button', { name: /月合計・CSV出力/ }));
 
     // 生成された <a> を捕捉する（最後の1つが CSV ダウンロード用）
     const realCreateElement = document.createElement.bind(document);
@@ -506,8 +517,11 @@ describe('ProductionRecordPage 月切替ローディング中のガード', () =
     setupWithData();
   });
 
-  it('読み込み中は入力3ボタンを無効化する（前月設定での誤入力を防ぐ）', () => {
-    mocks.hookState.isLoading = true;
+  // 入力可否は「設定済みの月があるか」(monthDoc) で判定する。
+  // 月切替時は useProductionRecord が monthDoc を新しい月のキャッシュ(無ければnull)へ
+  // 描画中に差し替えるため、前月設定での誤入力は monthDoc 判定だけで防げる。
+  it('対象月の設定が無い（monthDoc=null）ときは入力3ボタンを無効化する', () => {
+    mocks.hookState.monthDoc = null;
     render(<ProductionRecordPage />);
 
     expect(screen.getByRole('button', { name: '欠点豆を入力' })).toBeDisabled();
@@ -515,8 +529,8 @@ describe('ProductionRecordPage 月切替ローディング中のガード', () =
     expect(screen.getByRole('button', { name: 'パッケージを入力' })).toBeDisabled();
   });
 
-  it('読み込み完了後は入力3ボタンを有効化する', () => {
-    mocks.hookState.isLoading = false;
+  it('対象月の設定があれば、読み込み中でも入力3ボタンを有効化する（キャッシュ即表示でちらつかせない）', () => {
+    mocks.hookState.isLoading = true;
     render(<ProductionRecordPage />);
 
     expect(screen.getByRole('button', { name: '欠点豆を入力' })).toBeEnabled();
@@ -540,9 +554,11 @@ describe('ProductionRecordPage 重複月の作成防止', () => {
 
   it('既存月を指定して「対象月を作成」を押すと、作成せず既存である旨を通知する', () => {
     render(<ProductionRecordPage />);
-    // 新規作成欄に既存月(2026-05)を指定する
-    fireEvent.change(screen.getByLabelText('新規作成'), { target: { value: '2026-05' } });
-    fireEvent.click(screen.getByRole('button', { name: '対象月を作成' }));
+    // 新規作成は「月の設定」メニュー内へ。既存月(2026-05)を指定する
+    fireEvent.click(screen.getByRole('button', { name: '月の設定' }));
+    const createSection = screen.getByText('新しい月を作る').parentElement as HTMLElement;
+    fireEvent.change(within(createSection).getByLabelText('対象月'), { target: { value: '2026-05' } });
+    fireEvent.click(within(createSection).getByRole('button', { name: '作成' }));
 
     // 月設定モーダルは開かず（無警告の上書きを防ぐ）、既存月である旨を通知する
     expect(screen.queryByTestId('month-modal')).not.toBeInTheDocument();
@@ -553,8 +569,11 @@ describe('ProductionRecordPage 重複月の作成防止', () => {
     // months には 2026-05 のみ。2026-01 はセレクタ外だが Firestore には存在する想定
     mocks.productionRecordMonthExists.mockResolvedValue(true);
     render(<ProductionRecordPage />);
-    fireEvent.change(screen.getByLabelText('新規作成'), { target: { value: '2026-01' } });
-    fireEvent.click(screen.getByRole('button', { name: '対象月を作成' }));
+    // 新規作成は「月の設定」メニュー内へ。recentMonths窓外の2026-01を指定する
+    fireEvent.click(screen.getByRole('button', { name: '月の設定' }));
+    const createSection = screen.getByText('新しい月を作る').parentElement as HTMLElement;
+    fireEvent.change(within(createSection).getByLabelText('対象月'), { target: { value: '2026-01' } });
+    fireEvent.click(within(createSection).getByRole('button', { name: '作成' }));
 
     await waitFor(() => {
       expect(mocks.showToast).toHaveBeenCalledWith(expect.stringContaining('既に存在'), 'error');

--- a/app/production-record/page.tsx
+++ b/app/production-record/page.tsx
@@ -627,26 +627,43 @@ export default function ProductionRecordPage() {
           onClose={() => setIsMonthMenuOpen(false)}
           contentClassName="rounded-2xl max-w-sm w-full bg-overlay border border-edge shadow-xl"
         >
-          <div className="space-y-4 p-5">
+          {/* ヘッダー：他モーダルと揃えてタイトル＋閉じる(×) */}
+          <div className="flex items-center justify-between border-b border-edge p-5">
             <h2 className="text-lg font-bold text-ink">月の設定</h2>
+            <IconButton onClick={() => setIsMonthMenuOpen(false)} rounded aria-label="閉じる">
+              <HiX className="h-5 w-5" />
+            </IconButton>
+          </div>
 
-            {/* 現在選択中の月の設定（配合・粉量）を編集。月が選ばれていないときは出さない。 */}
+          <div className="space-y-5 p-5">
+            {/* 現在選択中の月の設定（配合・粉量）を編集。月が選ばれていないときは出さない。
+                濃色ブロックではなく、アイコン＋2行ラベル＋右矢印の軽いメニュー行にする。 */}
             {selectedMonth && monthDoc && (
-              <Button
+              // eslint-disable-next-line local/no-raw-button -- アイコン＋2行ラベル＋右シェブロンのメニュー行のため Button では表現できない
+              <button
                 type="button"
-                variant="secondary"
-                className="w-full justify-start"
                 onClick={() => {
                   setIsMonthMenuOpen(false);
                   handleEditMonth();
                 }}
+                className="flex w-full items-center gap-3 rounded-xl border border-edge bg-surface px-4 py-3 text-left transition-colors hover:bg-ground"
               >
-                この月（{formatProductionMonthLabel(selectedMonth)}）の設定を編集
-              </Button>
+                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-field text-ink-sub">
+                  <MdSettings className="h-5 w-5" />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block text-sm font-semibold text-ink">この月の設定を編集</span>
+                  <span className="block truncate text-xs text-ink-muted">
+                    {formatProductionMonthLabel(selectedMonth)}・配合や1袋粉量
+                  </span>
+                </span>
+                <HiChevronRight className="h-5 w-5 shrink-0 text-ink-muted" />
+              </button>
             )}
 
-            {/* 新しい月生産単位を作る。何月分かは作業日とは別に選ぶ（spec第5章）。 */}
-            <div className="space-y-2 border-t border-edge pt-4">
+            {/* 新しい月生産単位を作る。何月分かは作業日とは別に選ぶ（spec第5章）。
+                編集行があるときだけ上に区切り線を引いて、別操作だと分かるようにする。 */}
+            <div className={selectedMonth && monthDoc ? 'space-y-2 border-t border-edge pt-5' : 'space-y-2'}>
               <p className="text-sm font-semibold text-ink">新しい月を作る</p>
               <p className="text-xs text-ink-muted">「何月分」として作るかを選びます（作業日とは別です）。</p>
               <div className="flex items-end gap-2">

--- a/app/production-record/page.tsx
+++ b/app/production-record/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
-import { HiDownload } from 'react-icons/hi';
-import { MdFactory } from 'react-icons/md';
+import { HiChevronRight, HiDownload, HiOutlineDocumentText, HiX } from 'react-icons/hi';
+import { MdFactory, MdSettings, MdSummarize } from 'react-icons/md';
 import LoginPage from '@/app/login/page';
 import { Loading } from '@/components/Loading';
 import { useToastContext } from '@/components/Toast';
@@ -10,9 +10,10 @@ import { HandpickEntryModal } from '@/components/production-record/HandpickEntry
 import { MonthSettingsModal } from '@/components/production-record/MonthSettingsModal';
 import { PackageEntryModal } from '@/components/production-record/PackageEntryModal';
 import { RoastEntryModal } from '@/components/production-record/RoastEntryModal';
-import { Badge, Button, Card, EmptyState, FloatingNav, Input, Select } from '@/components/ui';
+import { Badge, Button, Card, EmptyState, FloatingNav, IconButton, Input, Modal, Select } from '@/components/ui';
 import { useProductionRecord } from '@/hooks/useProductionRecord';
 import { useAuth } from '@/lib/auth';
+import { readMonthListCache, writeMonthListCache } from '@/lib/productionRecordCache';
 import {
   productionRecordMonthExists,
   saveHandpickEntry,
@@ -82,6 +83,23 @@ export default function ProductionRecordPage() {
   const [isRoastOpen, setIsRoastOpen] = useState(false);
   const [editingPackage, setEditingPackage] = useState<PackageEntry | null>(null);
   const [isPackageOpen, setIsPackageOpen] = useState(false);
+  // 月の設定メニュー（新規作成・設定編集をまとめた小さなメニュー）の開閉
+  const [isMonthMenuOpen, setIsMonthMenuOpen] = useState(false);
+  // 月合計サマリー（本社提出用）モーダルの開閉
+  const [isSummaryOpen, setIsSummaryOpen] = useState(false);
+
+  // user が確定した最初の描画で、月リストをキャッシュから同期的に差し込む。
+  // useEffect だと一度「空状態」が描画されてしまうため、描画の途中で入れて
+  // 空状態↔グリッドの入替・対象月セレクトのポップインを防ぐ（フックと同じ公式パターン）。
+  const [hydratedUserId, setHydratedUserId] = useState<string | null>(null);
+  if (user && user.uid !== hydratedUserId) {
+    setHydratedUserId(user.uid);
+    const cachedMonths = readMonthListCache(user.uid);
+    if (cachedMonths && cachedMonths.length > 0) {
+      setRecentMonths(cachedMonths);
+      setSelectedMonth((prev) => prev || cachedMonths[0].month);
+    }
+  }
 
   // 月docと3種entriesを購読
   const { monthDoc, handpickEntries, roastEntries, packageEntries, isLoading } = useProductionRecord(
@@ -100,6 +118,8 @@ export default function ProductionRecordPage() {
       user.uid,
       (months) => {
         setRecentMonths(months);
+        // 次回オープン時に即描画するため、最新の月リストをキャッシュに保存
+        writeMonthListCache(user.uid, months);
         // 初回のみ：最新月があればそれを選択する（以降はユーザー選択を尊重）
         if (!hasInitialized) {
           hasInitialized = true;
@@ -177,9 +197,9 @@ export default function ProductionRecordPage() {
   const csvPreview = useMemo(() => (summary ? buildProductionRecordCsv(summary) : ''), [summary]);
 
   // 各列の最新2件（createdAt降順は購読側で保証済み）
-  const recentHandpick = handpickEntries.slice(0, 2);
-  const recentRoast = roastEntries.slice(0, 2);
-  const recentPackage = packageEntries.slice(0, 2);
+  const recentHandpick = handpickEntries.slice(0, 3);
+  const recentRoast = roastEntries.slice(0, 3);
+  const recentPackage = packageEntries.slice(0, 3);
 
   // 月設定の保存（モーダル側が成功時に onClose を呼ぶ）
   const handleSaveMonth = async (input: ProductionRecordMonthInput) => {
@@ -296,47 +316,27 @@ export default function ProductionRecordPage() {
               <p className="mt-1 text-sm text-ink-sub">対象月を作成して記録を始めます。</p>
             )}
           </div>
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+          {/* 毎日触る「対象月の切替」は表に。月1回の管理操作（作成・設定編集）は「月の設定」へ集約する。 */}
+          <div className="flex items-end gap-2">
             {monthOptions.length > 0 && (
-              <div className="flex items-end gap-2">
-                <Select
-                  label="対象月"
-                  options={monthOptions}
-                  value={selectedMonth}
-                  onChange={(event) => setSelectedMonth(event.target.value)}
-                  className="sm:w-[160px] !min-h-[42px] !py-2 !text-base"
-                />
-                {selectedMonth && monthDoc && !isLoading && (
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="secondary"
-                    onClick={handleEditMonth}
-                    className="!min-h-[42px] whitespace-nowrap !py-2 !text-base"
-                  >
-                    設定を編集
-                  </Button>
-                )}
-              </div>
-            )}
-            <div className="flex items-end gap-2">
-              <Input
-                type="month"
-                label="新規作成"
-                value={newMonthInput}
-                onChange={(event) => setNewMonthInput(event.target.value || getCurrentMonth())}
+              <Select
+                label="対象月"
+                options={monthOptions}
+                value={selectedMonth}
+                onChange={(event) => setSelectedMonth(event.target.value)}
                 className="sm:w-[160px] !min-h-[42px] !py-2 !text-base"
               />
-              <Button
-                type="button"
-                size="sm"
-                variant="primary"
-                onClick={handleCreateMonth}
-                className="!min-h-[42px] whitespace-nowrap !py-2 !text-base"
-              >
-                対象月を作成
-              </Button>
-            </div>
+            )}
+            <Button
+              type="button"
+              size="sm"
+              variant="secondary"
+              onClick={() => setIsMonthMenuOpen(true)}
+              className="!min-h-[42px] whitespace-nowrap !py-2 !text-base"
+            >
+              <MdSettings className="h-5 w-5" />
+              月の設定
+            </Button>
           </div>
         </header>
 
@@ -356,8 +356,9 @@ export default function ProductionRecordPage() {
           </Card>
         ) : (
           <>
-            {/* 本体3列：iPad横向き相当（md以上）で3列表示。スマホでは隠す */}
-            <main className="hidden gap-4 md:grid lg:grid-cols-3">
+            {/* 本体3列：iPad横向き相当（md以上）で3列表示。スマホでは隠す。
+                flex-1 + lg:grid-rows-1 で残りの高さいっぱいにカードを縦に伸ばす。 */}
+            <main className="hidden min-h-0 flex-1 gap-4 md:grid lg:grid-cols-3 lg:grid-rows-1">
               {/* 1列目：生豆ハンドピック */}
               <Card className="flex flex-col gap-4 p-4 sm:p-5">
                 <div className="flex items-center justify-between gap-3">
@@ -372,11 +373,13 @@ export default function ProductionRecordPage() {
                   <ColumnStat label="欠点率" value={formatPercent(handpickDefectRate)} />
                 </div>
 
+                {/* 無効条件に isLoading を入れない：monthDoc はキャッシュから即入るので、
+                    読み込み中のグレー→有効のちらつきを避ける。入力可否は「設定済みの月があるか」(monthDoc) で判定する。 */}
                 <Button
                   type="button"
                   size="sm"
                   variant="primary"
-                  disabled={!selectedMonth || !monthDoc || isLoading}
+                  disabled={!selectedMonth || !monthDoc}
                   onClick={() => {
                     setEditingHandpick(null);
                     setIsHandpickOpen(true);
@@ -387,7 +390,7 @@ export default function ProductionRecordPage() {
 
                 <div className="space-y-2">
                   {recentHandpick.length === 0 ? (
-                    <p className="text-sm text-ink-muted">まだ記録がありません。</p>
+                    <RecentEmptyHint />
                   ) : (
                     recentHandpick.map((entry) => (
                       // eslint-disable-next-line local/no-raw-button -- 複数行のカード型タップ行のため Button では表現できない
@@ -432,7 +435,7 @@ export default function ProductionRecordPage() {
                   type="button"
                   size="sm"
                   variant="primary"
-                  disabled={!selectedMonth || !monthDoc || isLoading}
+                  disabled={!selectedMonth || !monthDoc}
                   onClick={() => {
                     setEditingRoast(null);
                     setIsRoastOpen(true);
@@ -443,7 +446,7 @@ export default function ProductionRecordPage() {
 
                 <div className="space-y-2">
                   {recentRoast.length === 0 ? (
-                    <p className="text-sm text-ink-muted">まだ記録がありません。</p>
+                    <RecentEmptyHint />
                   ) : (
                     recentRoast.map((entry) => (
                       // eslint-disable-next-line local/no-raw-button -- 複数行のカード型タップ行のため Button では表現できない
@@ -496,7 +499,7 @@ export default function ProductionRecordPage() {
                   type="button"
                   size="sm"
                   variant="primary"
-                  disabled={!selectedMonth || !monthDoc || isLoading}
+                  disabled={!selectedMonth || !monthDoc}
                   onClick={() => {
                     setEditingPackage(null);
                     setIsPackageOpen(true);
@@ -507,7 +510,7 @@ export default function ProductionRecordPage() {
 
                 <div className="space-y-2">
                   {recentPackage.length === 0 ? (
-                    <p className="text-sm text-ink-muted">まだ記録がありません。</p>
+                    <RecentEmptyHint />
                   ) : (
                     recentPackage.map((entry) => (
                       // eslint-disable-next-line local/no-raw-button -- 複数行のカード型タップ行のため Button では表現できない
@@ -542,67 +545,27 @@ export default function ProductionRecordPage() {
               />
             </Card>
 
-            {/* 下部：月合計サマリー + CSV */}
-            <Card className="space-y-4 p-4 sm:p-5">
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-                <div>
-                  <h2 className="text-lg font-semibold text-ink">月合計サマリー</h2>
-                  <p className="mt-1 text-sm text-ink-muted">本社報告用の月合計です。</p>
-                </div>
-                <Button
-                  type="button"
-                  size="sm"
-                  onClick={handleExportCsv}
-                  disabled={!summary || isLoading}
-                  className="w-full sm:w-auto"
-                >
-                  <HiDownload className="h-5 w-5" />
-                  CSV出力
-                </Button>
-              </div>
-
-              {!summary ? (
-                <div className="flex min-h-[120px] items-center justify-center text-sm text-ink-muted">
-                  {isLoading ? '読み込み中...' : '対象月の設定がありません。'}
-                </div>
-              ) : (
-                <>
-                  {/* 配合は数値ではないため独立した行にし、数値タイルの大きさを揃える */}
-                  <div className="rounded-xl border border-edge bg-surface p-4">
-                    <div className="text-xs font-semibold text-ink-muted">配合</div>
-                    <p className="mt-1 text-lg font-bold text-ink">{summary.blendLabel}</p>
-                  </div>
-                  <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
-                    <SummaryTile label="生豆重量" value={formatKg(summary.greenBeanTotalGram)} unit="kg" />
-                    <SummaryTile label="欠点豆重量" value={summary.defectBeanTotalGram} unit="g" />
-                    <SummaryTile label="欠点率" value={formatPercent(summary.defectRate)} />
-                    <SummaryTile label="焙煎後重量" value={formatKg(summary.roastAfterTotalGram)} unit="kg" />
-                    <SummaryTile label="焙煎ロス率" value={formatPercent(summary.moistureLossRate)} />
-                    <SummaryTile label="30kg理論袋数" value={summary.thirtyKgTheoryPacks} unit="袋" />
-                    <SummaryTile
-                      label="月良品数"
-                      value={summary.monthlyGoodCount}
-                      unit="個"
-                      valueClassName="text-info"
-                    />
-                    <SummaryTile
-                      label="月不良品数"
-                      value={summary.monthlyDefectiveCount}
-                      unit="個"
-                      valueClassName="text-danger"
-                    />
-                    <SummaryTile label="月生産個数" value={summary.monthlyProducedCount} unit="個" />
-                    <SummaryTile label="不良率" value={formatPercent(summary.packageLossRate)} />
-                  </div>
-
-                  <div>
-                    <h3 className="mb-2 text-sm font-semibold text-ink-muted">CSVプレビュー</h3>
-                    <pre className="overflow-x-auto rounded-lg border border-edge bg-field p-3 text-xs text-ink-sub">
-                      {csvPreview}
-                    </pre>
-                  </div>
-                </>
-              )}
+            {/* 下部：月合計バー（本社提出用・毎日は使わないため普段は隠し、タップでモーダル表示） */}
+            <Card className="p-1.5 sm:p-2">
+              {/* eslint-disable-next-line local/no-raw-button -- バー全体をタップしてモーダルを開く行のため Button では表現できない */}
+              <button
+                type="button"
+                onClick={() => setIsSummaryOpen(true)}
+                className="flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left transition-colors hover:bg-ground"
+              >
+                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-field text-ink-sub">
+                  <MdSummarize className="h-5 w-5" />
+                </span>
+                <span className="flex flex-wrap items-baseline gap-x-2">
+                  <span className="text-base font-semibold text-ink">月合計・CSV出力</span>
+                  <span className="text-xs font-normal text-ink-muted">本社提出用の月合計（月末にまとめて）</span>
+                </span>
+                {/* 「押すと開ける」ことを示す視覚的な手がかり */}
+                <span className="ml-auto flex shrink-0 items-center gap-0.5 text-sm font-medium text-ink-muted">
+                  開く
+                  <HiChevronRight className="h-5 w-5" />
+                </span>
+              </button>
             </Card>
           </>
         )}
@@ -656,6 +619,140 @@ export default function ProductionRecordPage() {
           onSave={handleSavePackage}
         />
       )}
+
+      {/* 月の設定メニュー：月1回の管理操作（設定編集・新規作成）をまとめた小さなメニュー */}
+      {isMonthMenuOpen && (
+        <Modal
+          show={true}
+          onClose={() => setIsMonthMenuOpen(false)}
+          contentClassName="rounded-2xl max-w-sm w-full bg-overlay border border-edge shadow-xl"
+        >
+          <div className="space-y-4 p-5">
+            <h2 className="text-lg font-bold text-ink">月の設定</h2>
+
+            {/* 現在選択中の月の設定（配合・粉量）を編集。月が選ばれていないときは出さない。 */}
+            {selectedMonth && monthDoc && (
+              <Button
+                type="button"
+                variant="secondary"
+                className="w-full justify-start"
+                onClick={() => {
+                  setIsMonthMenuOpen(false);
+                  handleEditMonth();
+                }}
+              >
+                この月（{formatProductionMonthLabel(selectedMonth)}）の設定を編集
+              </Button>
+            )}
+
+            {/* 新しい月生産単位を作る。何月分かは作業日とは別に選ぶ（spec第5章）。 */}
+            <div className="space-y-2 border-t border-edge pt-4">
+              <p className="text-sm font-semibold text-ink">新しい月を作る</p>
+              <p className="text-xs text-ink-muted">「何月分」として作るかを選びます（作業日とは別です）。</p>
+              <div className="flex items-end gap-2">
+                <Input
+                  type="month"
+                  label="対象月"
+                  value={newMonthInput}
+                  onChange={(event) => setNewMonthInput(event.target.value || getCurrentMonth())}
+                  className="flex-1 !min-h-[42px] !py-2 !text-base"
+                />
+                <Button
+                  type="button"
+                  variant="primary"
+                  className="!min-h-[42px] whitespace-nowrap"
+                  onClick={() => {
+                    setIsMonthMenuOpen(false);
+                    handleCreateMonth();
+                  }}
+                >
+                  作成
+                </Button>
+              </div>
+            </div>
+          </div>
+        </Modal>
+      )}
+
+      {/* 月合計サマリー（本社提出用）モーダル：普段は隠し、バーのタップで開く */}
+      {isSummaryOpen && (
+        <Modal
+          show={true}
+          onClose={() => setIsSummaryOpen(false)}
+          contentClassName="rounded-2xl max-w-3xl w-full overflow-hidden bg-overlay border border-edge shadow-xl"
+        >
+          <div className="sticky top-0 z-20 flex items-center justify-between border-b border-edge bg-surface p-5">
+            <div>
+              <h2 className="text-xl font-semibold text-ink">月合計サマリー</h2>
+              <p className="mt-0.5 text-sm text-ink-muted">本社提出用の月合計です。</p>
+            </div>
+            <IconButton onClick={() => setIsSummaryOpen(false)} rounded aria-label="閉じる">
+              <HiX className="h-6 w-6" />
+            </IconButton>
+          </div>
+
+          <div className="space-y-4 p-5">
+            {!summary ? (
+              <div className="flex min-h-[120px] items-center justify-center text-sm text-ink-muted">
+                {isLoading ? '読み込み中...' : '対象月の設定がありません。'}
+              </div>
+            ) : (
+              <>
+                {/* 配合は数値ではないため独立した行にし、数値タイルの大きさを揃える */}
+                <div className="rounded-xl border border-edge bg-surface p-4">
+                  <div className="text-xs font-semibold text-ink-muted">配合</div>
+                  <p className="mt-1 text-lg font-bold text-ink">{summary.blendLabel}</p>
+                </div>
+                <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+                  <SummaryTile label="生豆重量" value={formatKg(summary.greenBeanTotalGram)} unit="kg" />
+                  <SummaryTile label="欠点豆重量" value={summary.defectBeanTotalGram} unit="g" />
+                  <SummaryTile label="欠点率" value={formatPercent(summary.defectRate)} />
+                  <SummaryTile label="焙煎後重量" value={formatKg(summary.roastAfterTotalGram)} unit="kg" />
+                  <SummaryTile label="焙煎ロス率" value={formatPercent(summary.moistureLossRate)} />
+                  <SummaryTile label="30kg理論袋数" value={summary.thirtyKgTheoryPacks} unit="袋" />
+                  <SummaryTile label="月良品数" value={summary.monthlyGoodCount} unit="個" valueClassName="text-info" />
+                  <SummaryTile
+                    label="月不良品数"
+                    value={summary.monthlyDefectiveCount}
+                    unit="個"
+                    valueClassName="text-danger"
+                  />
+                  <SummaryTile label="月生産個数" value={summary.monthlyProducedCount} unit="個" />
+                  <SummaryTile label="不良率" value={formatPercent(summary.packageLossRate)} />
+                </div>
+
+                <div>
+                  <h3 className="mb-2 text-sm font-semibold text-ink-muted">CSVプレビュー</h3>
+                  <pre className="overflow-x-auto rounded-lg border border-edge bg-field p-3 text-xs text-ink-sub">
+                    {csvPreview}
+                  </pre>
+                </div>
+
+                {/* このモーダルの主目的＝CSV出力。最下部に主要アクションとして右寄せ配置 */}
+                <div className="flex justify-end border-t border-edge pt-4">
+                  <Button type="button" onClick={handleExportCsv} disabled={isLoading}>
+                    <HiDownload className="h-5 w-5" />
+                    CSV出力
+                  </Button>
+                </div>
+              </>
+            )}
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+}
+
+/**
+ * 直近の記録プレビュー欄が空のときの控えめなヒント。
+ * すぐ上に入力ボタンがあるため、ボタンより目立たないよう全体を ink-muted（薄色）で統一する。
+ */
+function RecentEmptyHint() {
+  return (
+    <div className="flex flex-col items-center gap-1.5 py-6 text-center text-ink-muted">
+      <HiOutlineDocumentText className="h-6 w-6" aria-hidden />
+      <p className="max-w-[180px] text-xs leading-relaxed">入力すると、最近の記録がここに表示されます</p>
     </div>
   );
 }

--- a/components/production-record/MonthSettingsModal.tsx
+++ b/components/production-record/MonthSettingsModal.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { useEffect, useId, useRef, useState } from 'react';
-import { HiX } from 'react-icons/hi';
+import { HiPlus, HiX } from 'react-icons/hi';
 
-import { Modal, IconButton, Button, NumberInput, Input } from '@/components/ui';
+import { Modal, IconButton, Button, NumberInput } from '@/components/ui';
 import { DEFAULT_POWDER_PER_PACK_GRAM, MAX_BLEND_ITEMS, formatKg, validateBlendItems } from '@/lib/productionRecords';
 import type { BlendItem, ProductionRecordMonth, ProductionRecordMonthInput } from '@/types';
 
@@ -148,34 +148,30 @@ export function MonthSettingsModal({
       </div>
 
       <div className="p-5 space-y-5">
-        {/* 月の基本設定：短い数値なので幅を絞って横並び（フル幅に伸ばさない） */}
-        <div className="flex flex-wrap gap-4">
-          <div className="w-40">
-            <NumberInput
-              label="生豆総量"
-              suffix="kg"
-              suffixInside
-              align="left"
-              min={0}
-              step="0.01"
-              placeholder="0"
-              value={greenBeanTotal}
-              onChange={(e) => setGreenBeanTotal(e.target.value)}
-            />
-          </div>
-          <div className="w-40">
-            <NumberInput
-              label="1袋粉量"
-              suffix="g"
-              suffixInside
-              align="left"
-              min={0}
-              step="0.1"
-              placeholder="0"
-              value={powderPerPack}
-              onChange={(e) => setPowderPerPack(e.target.value)}
-            />
-          </div>
+        {/* 月の基本設定：2カラムで均等に並べ、下の配合表と左右端を揃える */}
+        <div className="grid grid-cols-2 gap-4">
+          <NumberInput
+            label="生豆総量"
+            suffix="kg"
+            suffixInside
+            align="left"
+            min={0}
+            step="0.01"
+            placeholder="0"
+            value={greenBeanTotal}
+            onChange={(e) => setGreenBeanTotal(e.target.value)}
+          />
+          <NumberInput
+            label="1袋粉量"
+            suffix="g"
+            suffixInside
+            align="left"
+            min={0}
+            step="0.1"
+            placeholder="0"
+            value={powderPerPack}
+            onChange={(e) => setPowderPerPack(e.target.value)}
+          />
         </div>
 
         <div className="space-y-3">
@@ -183,53 +179,71 @@ export function MonthSettingsModal({
             <p className="text-sm font-semibold text-ink">配合</p>
             <p className="text-xs text-ink-muted">最大{MAX_BLEND_ITEMS}件・合計100%</p>
           </div>
-          {/* 配合は1行1件のコンパクトな表（列見出し＋区切り線・塗り無し）でスクロールを避ける */}
+          {/* 配合：セル一体のスプレッドシート型。入力欄をセルいっぱいに広げ、
+              ヘッダーと中身を同じセル余白(px-3)で揃える。枠は標準入力ではなくセル側で描く。 */}
           <div className="overflow-hidden rounded-xl border border-edge">
-            <div className="grid grid-cols-[1fr_100px_92px_auto] items-center gap-2 border-b border-edge px-3 py-2 text-[11px] font-medium text-ink-muted">
-              <span>豆名</span>
-              <span>比率</span>
-              <span>必要量</span>
-              <span className="sr-only">削除</span>
+            {/* ヘッダー行：4列をそのままデータ行と共有して位置を一致させる */}
+            <div className="grid grid-cols-[1fr_92px_104px_44px] divide-x divide-edge border-b border-edge bg-surface text-[11px] font-medium text-ink-muted">
+              <div className="px-3 py-2">豆名</div>
+              <div className="px-3 py-2">比率</div>
+              <div className="px-3 py-2">必要量</div>
+              <div className="px-3 py-2 sr-only">削除</div>
             </div>
             <div className="divide-y divide-edge">
               {blendDrafts.map((item, index) => {
                 const ratio = parseFloat(item.ratioPercent) || 0;
                 const requiredKg = (greenBeanTotalGram * (ratio / 100)) / 1000;
+                // セルいっぱいの枠なし入力。フォーカスは枠ではなく塗り＋内側リングで示す。
+                const cellInput =
+                  'min-h-[44px] w-full bg-transparent px-3 py-2 text-base text-ink placeholder:text-ink-muted focus:bg-field focus:outline-none focus:ring-2 focus:ring-inset focus:ring-spot-subtle';
                 return (
-                  <div key={item.id} className="grid grid-cols-[1fr_100px_92px_auto] items-center gap-2 px-3 py-2">
-                    <Input
+                  <div key={item.id} className="grid grid-cols-[1fr_92px_104px_44px] divide-x divide-edge">
+                    {/* 豆名 */}
+                    <input
                       aria-label={`豆 ${index + 1}`}
                       placeholder="豆名"
-                      className="!py-2 !shadow-none"
+                      className={cellInput}
                       value={item.beanName}
                       onChange={(e) => handleBlendChange(index, 'beanName', e.target.value)}
                     />
-                    <NumberInput
-                      aria-label="比率"
-                      suffix="%"
-                      suffixInside
-                      align="left"
-                      min={0}
-                      placeholder="0"
-                      value={item.ratioPercent}
-                      onChange={(e) => handleBlendChange(index, 'ratioPercent', e.target.value)}
-                    />
-                    <div className="text-sm font-bold tabular-nums text-ink">
+                    {/* 比率：% はセル内右端に固定 */}
+                    <div className="relative">
+                      <input
+                        aria-label="比率"
+                        type="number"
+                        min={0}
+                        placeholder="0"
+                        className={`${cellInput} pr-7`}
+                        value={item.ratioPercent}
+                        onChange={(e) => handleBlendChange(index, 'ratioPercent', e.target.value)}
+                      />
+                      <span className="pointer-events-none absolute inset-y-0 right-2 flex items-center text-xs font-medium text-ink-sub">
+                        %
+                      </span>
+                    </div>
+                    {/* 必要量：派生表示（読み取り専用）。0のときは薄色で静かに */}
+                    <div
+                      className={`flex min-h-[44px] items-center px-3 py-2 text-sm font-bold tabular-nums ${
+                        requiredKg > 0 ? 'text-ink' : 'text-ink-muted'
+                      }`}
+                    >
                       {requiredKg.toFixed(2)}
                       <span className="ml-0.5 text-xs font-medium text-ink-sub">kg</span>
                     </div>
-                    {blendDrafts.length > 1 ? (
-                      <IconButton
-                        type="button"
-                        rounded
-                        aria-label={`豆 ${index + 1} を削除`}
-                        onClick={() => handleRemoveBlend(index)}
-                      >
-                        <HiX className="h-5 w-5" />
-                      </IconButton>
-                    ) : (
-                      <span className="w-11" />
-                    )}
+                    {/* 削除：1行だけのときは消せないよう空セル */}
+                    <div className="flex items-center justify-center">
+                      {blendDrafts.length > 1 && (
+                        // eslint-disable-next-line local/no-raw-button -- セル内に収める小型の削除ボタンのため Button では表現できない
+                        <button
+                          type="button"
+                          aria-label={`豆 ${index + 1} を削除`}
+                          onClick={() => handleRemoveBlend(index)}
+                          className="flex h-8 w-8 items-center justify-center rounded-md text-ink-muted transition-colors hover:bg-ground hover:text-ink"
+                        >
+                          <HiX className="h-4 w-4" />
+                        </button>
+                      )}
+                    </div>
                   </div>
                 );
               })}
@@ -243,6 +257,7 @@ export function MonthSettingsModal({
               onClick={handleAddBlend}
               disabled={blendDrafts.length >= MAX_BLEND_ITEMS}
             >
+              <HiPlus className="h-4 w-4" />
               豆を追加
             </Button>
             <span

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -45,8 +45,8 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     const isPasswordField = type === 'password' && showPasswordToggle;
     const inputType = isPasswordField && showPassword ? 'text' : type;
 
-    const baseStyles =
-      'w-full rounded-lg border-2 px-4 py-3.5 text-lg transition-all duration-200 shadow-sm min-h-[44px]';
+    // 入力部品の統一寸法（Select / NumberInput と揃える）。py-3・影なしのフラット。
+    const baseStyles = 'w-full rounded-lg border-2 px-4 py-3 text-lg transition-all duration-200 min-h-[44px]';
 
     const themeStyles =
       'bg-field border-edge text-ink placeholder:text-ink-muted hover:border-edge-strong focus:border-spot focus:bg-field focus:outline-none focus:ring-2 focus:ring-spot-subtle';

--- a/components/ui/NumberInput.tsx
+++ b/components/ui/NumberInput.tsx
@@ -52,7 +52,8 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
     const hasInsideSuffix = Boolean(suffix && suffixInside);
 
     const alignStyles = align === 'left' ? 'text-left' : align === 'right' ? 'text-right' : 'text-center';
-    const baseStyles = `rounded-lg border-2 px-4 py-2 text-lg transition-all duration-200 min-h-[44px] ${alignStyles}`;
+    // 入力部品の統一寸法（Input / Select と揃える）。py-3・影なしのフラット。
+    const baseStyles = `rounded-lg border-2 px-4 py-3 text-lg transition-all duration-200 min-h-[44px] ${alignStyles}`;
 
     const themeStyles =
       'bg-field border-edge text-ink placeholder:text-ink-muted hover:border-edge-strong focus:border-spot focus:bg-field focus:outline-none focus:ring-2 focus:ring-spot-subtle';

--- a/e2e/production-record.spec.ts
+++ b/e2e/production-record.spec.ts
@@ -18,7 +18,8 @@ async function createMonth(
   // 月の作成は「月の設定」メニューに集約されている（Layout A）
   await page.getByRole('button', { name: '月の設定' }).click();
   await page.getByLabel('対象月').fill(month);
-  await page.getByRole('button', { name: '作成' }).click();
+  // 空状態の「対象月を作成」と部分一致するため exact でメニューの「作成」に限定
+  await page.getByRole('button', { name: '作成', exact: true }).click();
 
   const modal = page.getByRole('heading', { name: /月設定/ });
   await expect(modal).toBeVisible();

--- a/e2e/production-record.spec.ts
+++ b/e2e/production-record.spec.ts
@@ -89,16 +89,17 @@ test.describe('生産記録 E2E（実Firestoreエミュレータ）', () => {
     await expect(packageCard.getByText('190')).toBeVisible({ timeout: 15_000 });
     await expect(packageCard.getByText('205')).toBeVisible();
 
-    // 月合計サマリーとCSVプレビュー
+    // 月合計サマリーは下部バーから開く（Layout A）
+    await page.getByRole('button', { name: /月合計・CSV出力/ }).click();
     await expect(page.getByRole('heading', { name: '月合計サマリー' })).toBeVisible();
     const pre = page.locator('pre');
     await expect(pre).toContainText('2026年8月分');
     await expect(pre).toContainText('モカ 100%');
 
-    // CSV出力でダウンロードが発火する
+    // CSV出力でダウンロードが発火する（「月合計・CSV出力」と部分一致するため exact）
     const [download] = await Promise.all([
       page.waitForEvent('download'),
-      page.getByRole('button', { name: 'CSV出力' }).click(),
+      page.getByRole('button', { name: 'CSV出力', exact: true }).click(),
     ]);
     expect(download.suggestedFilename()).toBe('production-record-2026-08.csv');
   });

--- a/e2e/production-record.spec.ts
+++ b/e2e/production-record.spec.ts
@@ -10,9 +10,16 @@ function column(page: Page, heading: string): Locator {
   return page.locator('div.rounded-2xl').filter({ has: page.getByRole('heading', { name: heading }) });
 }
 
-// 月設定モーダルで対象月を作成する（配合は1件・100%）
-async function createMonth(page: Page, { greenKg, beanName }: { greenKg: string; beanName: string }) {
-  await page.getByRole('button', { name: '対象月を作成' }).first().click();
+// 「月の設定」メニューから対象月を指定して作成し、月設定モーダルで配合まで保存する（配合は1件・100%）
+async function createMonth(
+  page: Page,
+  { month, greenKg, beanName }: { month: string; greenKg: string; beanName: string }
+) {
+  // 月の作成は「月の設定」メニューに集約されている（Layout A）
+  await page.getByRole('button', { name: '月の設定' }).click();
+  await page.getByLabel('対象月').fill(month);
+  await page.getByRole('button', { name: '作成' }).click();
+
   const modal = page.getByRole('heading', { name: /月設定/ });
   await expect(modal).toBeVisible();
 
@@ -39,8 +46,7 @@ test.describe('生産記録 E2E（実Firestoreエミュレータ）', () => {
     await expect(page.getByText('生産記録がまだありません')).toBeVisible({ timeout: 15_000 });
 
     // 月設定（生豆30kg / 配合モカ100%）
-    await page.getByLabel('新規作成').fill('2026-08');
-    await createMonth(page, { greenKg: '30', beanName: 'モカ' });
+    await createMonth(page, { month: '2026-08', greenKg: '30', beanName: 'モカ' });
 
     // 3列表示に切り替わる
     await expect(page.getByRole('heading', { name: '生豆ハンドピック' })).toBeVisible({ timeout: 15_000 });
@@ -98,8 +104,7 @@ test.describe('生産記録 E2E（実Firestoreエミュレータ）', () => {
 
   test('同じ日付・区分・豆名のハンドピックは重複せず上書き（upsert）される', async ({ page }) => {
     await page.goto('/production-record');
-    await page.getByLabel('新規作成').fill('2026-09');
-    await createMonth(page, { greenKg: '30', beanName: 'モカ' });
+    await createMonth(page, { month: '2026-09', greenKg: '30', beanName: 'モカ' });
     await expect(page.getByRole('heading', { name: '生豆ハンドピック' })).toBeVisible({ timeout: 15_000 });
 
     const handpickCard = column(page, '生豆ハンドピック');

--- a/hooks/useProductionRecord.test.ts
+++ b/hooks/useProductionRecord.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useProductionRecord } from './useProductionRecord';
+import { readProductionRecordCache, writeProductionRecordCache } from '@/lib/productionRecordCache';
 import type { ProductionRecordMonth, HandpickEntry, RoastEntry, PackageEntry } from '@/types';
 
 // Firestore層の購読関数をモックする（firebase/firestoreは直接モックしない）
@@ -97,6 +98,7 @@ describe('useProductionRecord', () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.clearAllMocks();
+    localStorage.clear();
   });
 
   it('userId が undefined のときは購読せず空の初期値を返す', async () => {
@@ -278,5 +280,51 @@ describe('useProductionRecord', () => {
       expect.any(Function)
     );
     expect(second.unsubMonth).not.toHaveBeenCalled();
+  });
+
+  it('購読データを受け取るとキャッシュへ保存する', async () => {
+    setupSubscriptions({
+      monthDoc: MONTH_DOC,
+      handpickEntries: [HANDPICK_ENTRY],
+      roastEntries: [ROAST_ENTRY],
+      packageEntries: [PACKAGE_ENTRY],
+    });
+
+    renderHook(() => useProductionRecord(USER_ID, MONTH));
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(readProductionRecordCache(USER_ID, MONTH)).toEqual({
+      monthDoc: MONTH_DOC,
+      handpickEntries: [HANDPICK_ENTRY],
+      roastEntries: [ROAST_ENTRY],
+      packageEntries: [PACKAGE_ENTRY],
+    });
+  });
+
+  it('Firestore応答前でもキャッシュ値を即返す（0/空のちらつき防止）', async () => {
+    // 事前にキャッシュを仕込む
+    writeProductionRecordCache(USER_ID, MONTH, {
+      monthDoc: MONTH_DOC,
+      handpickEntries: [HANDPICK_ENTRY],
+      roastEntries: [ROAST_ENTRY],
+      packageEntries: [PACKAGE_ENTRY],
+    });
+
+    // 購読は張るが callback はまだ返さない（=Firestore応答前の状態を再現）
+    mockSubscribeProductionRecordMonth.mockImplementation(() => vi.fn());
+    mockSubscribeHandpickEntries.mockImplementation(() => vi.fn());
+    mockSubscribeRoastEntries.mockImplementation(() => vi.fn());
+    mockSubscribePackageEntries.mockImplementation(() => vi.fn());
+
+    const { result } = renderHook(() => useProductionRecord(USER_ID, MONTH));
+
+    // タイマーを進めず（=応答前）に、キャッシュ由来の値が出ていること
+    expect(result.current.monthDoc).toEqual(MONTH_DOC);
+    expect(result.current.handpickEntries).toEqual([HANDPICK_ENTRY]);
+    expect(result.current.roastEntries).toEqual([ROAST_ENTRY]);
+    expect(result.current.packageEntries).toEqual([PACKAGE_ENTRY]);
   });
 });

--- a/hooks/useProductionRecord.ts
+++ b/hooks/useProductionRecord.ts
@@ -7,6 +7,7 @@ import {
   subscribeRoastEntries,
   subscribePackageEntries,
 } from '@/lib/firestore';
+import { readProductionRecordCache, writeProductionRecordCache } from '@/lib/productionRecordCache';
 import type { ProductionRecordMonth, HandpickEntry, RoastEntry, PackageEntry } from '@/types';
 
 /**
@@ -32,6 +33,20 @@ export function useProductionRecord(
   const [roastEntries, setRoastEntries] = useState<RoastEntry[]>([]);
   const [packageEntries, setPackageEntries] = useState<PackageEntry[]>([]);
   const [isLoading, setIsLoading] = useState(() => Boolean(userId && month));
+
+  // 対象が切り替わった瞬間に、描画の途中でキャッシュ値へ state を差し替える。
+  // useEffect より一歩早く（=0/空が一瞬も見えない形で）前回値を入れるための公式パターン。
+  // hydratedKey と現在の鍵が食い違う最初の描画でだけ走り、以降は走らない。
+  const currentKey = userId && month ? `${userId}:${month}` : null;
+  const [hydratedKey, setHydratedKey] = useState<string | null>(null);
+  if (currentKey !== hydratedKey) {
+    setHydratedKey(currentKey);
+    const cached = currentKey ? readProductionRecordCache(userId, month) : null;
+    setMonthDoc(cached?.monthDoc ?? null);
+    setHandpickEntries(cached?.handpickEntries ?? []);
+    setRoastEntries(cached?.roastEntries ?? []);
+    setPackageEntries(cached?.packageEntries ?? []);
+  }
 
   useEffect(() => {
     if (!userId || !month) {
@@ -63,13 +78,33 @@ export function useProductionRecord(
       }
     };
 
+    // 次回オープン時に即描画するためのキャッシュ書き込み用。
+    // state setter は非同期なので、最新値は別途ローカル変数で持ち回る。
+    // 起点は前回キャッシュ（部分的な更新で良い値を空で潰さないため）。
+    const cached = readProductionRecordCache(userId, month);
+    let latestMonthDoc: ProductionRecordMonth | null = cached?.monthDoc ?? null;
+    let latestHandpick: HandpickEntry[] = cached?.handpickEntries ?? [];
+    let latestRoast: RoastEntry[] = cached?.roastEntries ?? [];
+    let latestPackage: PackageEntry[] = cached?.packageEntries ?? [];
+
+    const persist = () => {
+      writeProductionRecordCache(userId, month, {
+        monthDoc: latestMonthDoc,
+        handpickEntries: latestHandpick,
+        roastEntries: latestRoast,
+        packageEntries: latestPackage,
+      });
+    };
+
     const unsubscribeMonth = subscribeProductionRecordMonth(
       userId,
       month,
       (m) => {
         setMonthDoc(m);
+        latestMonthDoc = m;
         readyMonth = true;
         updateLoading();
+        persist();
       },
       (error) => {
         console.error('Failed to subscribe production record month:', error);
@@ -83,8 +118,10 @@ export function useProductionRecord(
       month,
       (entries) => {
         setHandpickEntries(entries);
+        latestHandpick = entries;
         readyHandpick = true;
         updateLoading();
+        persist();
       },
       (error) => {
         console.error('Failed to subscribe handpick entries:', error);
@@ -98,8 +135,10 @@ export function useProductionRecord(
       month,
       (entries) => {
         setRoastEntries(entries);
+        latestRoast = entries;
         readyRoast = true;
         updateLoading();
+        persist();
       },
       (error) => {
         console.error('Failed to subscribe roast entries:', error);
@@ -113,8 +152,10 @@ export function useProductionRecord(
       month,
       (entries) => {
         setPackageEntries(entries);
+        latestPackage = entries;
         readyPackage = true;
         updateLoading();
+        persist();
       },
       (error) => {
         console.error('Failed to subscribe package entries:', error);

--- a/lib/productionRecordCache.test.ts
+++ b/lib/productionRecordCache.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  readProductionRecordCache,
+  writeProductionRecordCache,
+  readMonthListCache,
+  writeMonthListCache,
+} from './productionRecordCache';
+import type { ProductionRecordCacheData } from './productionRecordCache';
+import type { ProductionRecordMonth } from '@/types';
+
+const USER_ID = 'user-1';
+const MONTH = '2026-08';
+
+const SAMPLE: ProductionRecordCacheData = {
+  monthDoc: {
+    month: '2026-08',
+    greenBeanTotalGram: 30000,
+    powderPerPackGram: 8.5,
+    blendItems: [{ beanName: 'ブラジル', ratioPercent: 100 }],
+  },
+  handpickEntries: [
+    {
+      id: 'h1',
+      workDate: '2026-08-01',
+      beanName: 'ブラジル',
+      segment: 'first',
+      greenBeanWeightGram: 10000,
+      defectBeanWeightGram: 300,
+    },
+  ],
+  roastEntries: [{ id: 'r1', workDate: '2026-08-01', beforeRoastWeightGram: 10000, afterRoastWeightGram: 8500 }],
+  packageEntries: [
+    {
+      id: 'p1',
+      workDate: '2026-08-01',
+      teamA: { goodCount: 100, defectiveCount: 2 },
+      teamB: { goodCount: 120, defectiveCount: 3 },
+    },
+  ],
+};
+
+describe('productionRecordCache', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('書き込んだ値をそのまま読み戻せる', () => {
+    writeProductionRecordCache(USER_ID, MONTH, SAMPLE);
+    expect(readProductionRecordCache(USER_ID, MONTH)).toEqual(SAMPLE);
+  });
+
+  it('未保存なら null を返す', () => {
+    expect(readProductionRecordCache(USER_ID, MONTH)).toBeNull();
+  });
+
+  it('userId が違えば読み出せない（アカウント分離）', () => {
+    writeProductionRecordCache(USER_ID, MONTH, SAMPLE);
+    expect(readProductionRecordCache('other-user', MONTH)).toBeNull();
+  });
+
+  it('month が違えば読み出せない', () => {
+    writeProductionRecordCache(USER_ID, MONTH, SAMPLE);
+    expect(readProductionRecordCache(USER_ID, '2026-09')).toBeNull();
+  });
+
+  it('userId / month が未指定なら読み書きしない', () => {
+    writeProductionRecordCache(undefined, MONTH, SAMPLE);
+    writeProductionRecordCache(USER_ID, undefined, SAMPLE);
+    expect(readProductionRecordCache(undefined, MONTH)).toBeNull();
+    expect(readProductionRecordCache(USER_ID, undefined)).toBeNull();
+  });
+
+  it('壊れたJSONが入っていても null を返す（描画を落とさない）', () => {
+    localStorage.setItem(`roastplus_prodrec_cache:v1:${USER_ID}:${MONTH}`, '{壊れた');
+    expect(readProductionRecordCache(USER_ID, MONTH)).toBeNull();
+  });
+});
+
+describe('productionRecordCache 月リスト', () => {
+  const MONTHS: ProductionRecordMonth[] = [
+    { month: '2026-08', greenBeanTotalGram: 30000, powderPerPackGram: 8.5, blendItems: [] },
+    { month: '2026-07', greenBeanTotalGram: 28000, powderPerPackGram: 8.5, blendItems: [] },
+  ];
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('書き込んだ月リストをそのまま読み戻せる', () => {
+    writeMonthListCache(USER_ID, MONTHS);
+    expect(readMonthListCache(USER_ID)).toEqual(MONTHS);
+  });
+
+  it('未保存なら null を返す', () => {
+    expect(readMonthListCache(USER_ID)).toBeNull();
+  });
+
+  it('userId が違えば読み出せない（アカウント分離）', () => {
+    writeMonthListCache(USER_ID, MONTHS);
+    expect(readMonthListCache('other-user')).toBeNull();
+  });
+
+  it('userId が未指定なら読み書きしない', () => {
+    writeMonthListCache(undefined, MONTHS);
+    expect(readMonthListCache(undefined)).toBeNull();
+  });
+
+  it('壊れたJSONが入っていても null を返す', () => {
+    localStorage.setItem(`roastplus_prodrec_months:v1:${USER_ID}`, '[壊れた');
+    expect(readMonthListCache(USER_ID)).toBeNull();
+  });
+});

--- a/lib/productionRecordCache.ts
+++ b/lib/productionRecordCache.ts
@@ -1,0 +1,126 @@
+'use client';
+
+import type { ProductionRecordMonth, HandpickEntry, RoastEntry, PackageEntry } from '@/types';
+
+/**
+ * 生産記録の「数字のちらつき」防止用ローカルキャッシュ。
+ *
+ * Firestoreのデータは非同期で届くため、ページを開いた最初の描画では必ず空(0)になる。
+ * 前回見た値を localStorage に保存しておき、描画の瞬間に同期的に読み出して
+ * 0 ではなく前回値で描画を始めることで、0→実数値のジャンプを消す。
+ *
+ * - 認証や本番アクセス制御には使わない（あくまで表示の初期値ヒント）。
+ * - 鍵に userId を含めるため、別アカウントの値は読み出されない。
+ * - データ形が変わったら CACHE_VERSION を上げれば古いキャッシュは無視される。
+ */
+
+export interface ProductionRecordCacheData {
+  monthDoc: ProductionRecordMonth | null;
+  handpickEntries: HandpickEntry[];
+  roastEntries: RoastEntry[];
+  packageEntries: PackageEntry[];
+}
+
+const CACHE_VERSION = 'v1';
+const KEY_PREFIX = 'roastplus_prodrec_cache';
+
+function buildKey(userId: string, month: string): string {
+  return `${KEY_PREFIX}:${CACHE_VERSION}:${userId}:${month}`;
+}
+
+/**
+ * キャッシュを同期的に読み出す。条件未達・未保存・壊れたJSONはすべて null を返し、
+ * 呼び出し側は「キャッシュ無し（=従来どおり空から開始）」として扱えばよい。
+ */
+export function readProductionRecordCache(
+  userId: string | undefined,
+  month: string | undefined
+): ProductionRecordCacheData | null {
+  if (typeof window === 'undefined' || !userId || !month) {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(buildKey(userId, month));
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw) as Partial<ProductionRecordCacheData> | null;
+    if (!parsed || typeof parsed !== 'object') {
+      return null;
+    }
+
+    // 配列フィールドは型を最低限ガードしておく（壊れた値で描画が落ちないように）
+    return {
+      monthDoc: parsed.monthDoc ?? null,
+      handpickEntries: Array.isArray(parsed.handpickEntries) ? parsed.handpickEntries : [],
+      roastEntries: Array.isArray(parsed.roastEntries) ? parsed.roastEntries : [],
+      packageEntries: Array.isArray(parsed.packageEntries) ? parsed.packageEntries : [],
+    };
+  } catch {
+    // JSON破損やストレージ無効時はキャッシュ無し扱い
+    return null;
+  }
+}
+
+/**
+ * 最新値をキャッシュに保存する。容量超過などの失敗は握りつぶす
+ * （キャッシュは無くても本体は動くため）。
+ */
+export function writeProductionRecordCache(
+  userId: string | undefined,
+  month: string | undefined,
+  data: ProductionRecordCacheData
+): void {
+  if (typeof window === 'undefined' || !userId || !month) {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(buildKey(userId, month), JSON.stringify(data));
+  } catch {
+    // QuotaExceeded などは無視
+  }
+}
+
+const MONTH_LIST_KEY_PREFIX = 'roastplus_prodrec_months';
+
+function buildMonthListKey(userId: string): string {
+  return `${MONTH_LIST_KEY_PREFIX}:${CACHE_VERSION}:${userId}`;
+}
+
+/**
+ * 月リスト（対象月の一覧）のキャッシュ。
+ * これを描画の瞬間に入れることで、空状態↔グリッドの入替や
+ * 対象月セレクトのポップインを防ぐ。
+ */
+export function readMonthListCache(userId: string | undefined): ProductionRecordMonth[] | null {
+  if (typeof window === 'undefined' || !userId) {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(buildMonthListKey(userId));
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed) ? (parsed as ProductionRecordMonth[]) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeMonthListCache(userId: string | undefined, months: ProductionRecordMonth[]): void {
+  if (typeof window === 'undefined' || !userId) {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(buildMonthListKey(userId), JSON.stringify(months));
+  } catch {
+    // QuotaExceeded などは無視
+  }
+}


### PR DESCRIPTION
## 概要

生産記録機能のUX改善。ホームから開いたときの「数字が0→実数値に飛ぶ」「空状態↔グリッドが入れ替わる」「入力ボタンが点滅する」といったちらつきを解消し、あわせて各モーダルの見た目を整えました。

## 変更内容

### 1. ちらつき対策（localStorage キャッシュ）
- `lib/productionRecordCache.ts`：描画の瞬間に同期的に読める前回値の保存先（userIdで鍵分離・バージョン付き・破損/容量超過に耐性）
- `useProductionRecord`：月切替の瞬間に描画中キャッシュ値へ差し替え＋購読ごとに保存 → 数字の0ジャンプを解消
- 月リストもキャッシュして描画中に差し込み → 空状態↔グリッドの入替・対象月セレクトのポップインを解消
- 入力ボタンの無効化から `isLoading` を除去（`monthDoc` 判定に統一。月切替時の差し替えで誤入力は防止）

### 2. Layout A 再構成
- 月1回の管理操作（作成・設定編集）を「月の設定」メニューとサマリーモーダルへ集約し、毎日の入力を画面の主役に
- 直近3件表示・空欄ヒント

### 3. UI 整形
- 入力部品（Input/NumberInput）の寸法を統一（`py-3`・影なしのフラット）
- 「月の設定」メニュー：閉じる(×)付きヘッダー、設定編集を軽いメニュー行に
- 月設定モーダルの配合エディタを**スプレッドシート型**に刷新（列見出しと入力の位置ずれを根本解消）＋上段を均等2カラム化

## 検証
- 全体テスト **1075件パス**（新規テスト追加：キャッシュ単体・フック結合・ボタン挙動）
- tsc / prettier / eslint すべてクリア

## 補足
- 月削除機能は今回の対象外
- 実機での現場確認（IT不慣れな新人さん向け）は研修終了後を想定

🤖 Generated with [Claude Code](https://claude.com/claude-code)