### PR TITLE
時計チャイムを iPad で十分な音量にしつつ音割れを防ぐ

### DIFF
--- a/lib/workChimeAudio.test.ts
+++ b/lib/workChimeAudio.test.ts
@@ -31,6 +31,8 @@ function createAudioContextMock(options: Partial<Pick<AudioContext, 'state' | 'r
     return oscillator;
   });
 
+  const compressorConnections: unknown[] = [];
+
   const createGain = vi.fn(
     () =>
       ({
@@ -42,11 +44,25 @@ function createAudioContextMock(options: Partial<Pick<AudioContext, 'state' | 'r
       }) as unknown as GainNode
   );
 
+  const createDynamicsCompressor = vi.fn(() => {
+    const compressor = {
+      threshold: { setValueAtTime: vi.fn() },
+      knee: { setValueAtTime: vi.fn() },
+      ratio: { setValueAtTime: vi.fn() },
+      attack: { setValueAtTime: vi.fn() },
+      release: { setValueAtTime: vi.fn() },
+      connect: vi.fn((target: unknown) => compressorConnections.push(target)),
+    } as unknown as DynamicsCompressorNode;
+
+    return compressor;
+  });
+
   const ctx: AudioContextMock = {
     currentTime: 10,
     destination,
     createOscillator,
     createGain,
+    createDynamicsCompressor,
     ...options,
   };
 
@@ -54,6 +70,8 @@ function createAudioContextMock(options: Partial<Pick<AudioContext, 'state' | 'r
     ctx,
     events,
     gainValues,
+    destination,
+    compressorConnections,
   };
 }
 
@@ -88,6 +106,26 @@ describe('workChimeAudio', () => {
 
     expect(low.gainValues).toContain(0);
     expect(high.gainValues.some((value) => value > 1)).toBe(false);
+  });
+
+  it('出力リミッターを最終段に挟んでdestinationへ接続する', async () => {
+    const mock = createAudioContextMock();
+
+    await playWorkChime('break', { volume: 0.8, audioContext: mock.ctx });
+
+    expect(mock.ctx.createDynamicsCompressor).toHaveBeenCalledTimes(1);
+    // リミッターが destination に接続される（master → limiter → destination の最終段）。
+    expect(mock.compressorConnections).toContain(mock.destination);
+  });
+
+  it('createDynamicsCompressor非対応環境でもチャイムをスケジュールする', async () => {
+    const mock = createAudioContextMock();
+    // 旧環境を想定し compressor 非対応にする。
+    (mock.ctx as { createDynamicsCompressor?: unknown }).createDynamicsCompressor = undefined;
+
+    await playWorkChime('break', { volume: 0.8, audioContext: mock.ctx });
+
+    expect(mock.ctx.createOscillator).toHaveBeenCalledTimes(6);
   });
 
   it('停止中のAudioContextを再開してからチャイムをスケジュールする', async () => {

--- a/lib/workChimeAudio.ts
+++ b/lib/workChimeAudio.ts
@@ -7,7 +7,21 @@ declare global {
 }
 
 type AudioContextLike = Pick<AudioContext, 'currentTime' | 'destination' | 'createOscillator' | 'createGain'> &
-  Partial<Pick<AudioContext, 'state' | 'resume'>>;
+  Partial<Pick<AudioContext, 'state' | 'resume' | 'createDynamicsCompressor'>>;
+
+// iPad のスピーカーは中低域が弱く、純音ベースのチャイムは知覚的に小さい。詳細設定の音量(master)を
+// 100% にしても合成音側の gain が控えめでヘッドルームが余っているため、合成音側だけを底上げする
+// ブースト係数。master(=ユーザー音量) には掛けず、最終段のリミッターで音割れを防ぐ。
+// 物足りない/歪む場合はこの値とリミッター閾値(LIMITER_THRESHOLD_DB)を実機で詰める。
+const CHIME_GAIN_SCALE = 1.6;
+
+// 最終段リミッター（DynamicsCompressor）設定。合成音をどれだけ大きくしても出力ピークを抑え、
+// 原理的に音割れ（クリップ）を防ぐ安全網。
+const LIMITER_THRESHOLD_DB = -3;
+const LIMITER_KNEE_DB = 0;
+const LIMITER_RATIO = 20;
+const LIMITER_ATTACK_SEC = 0.003;
+const LIMITER_RELEASE_SEC = 0.25;
 
 interface PlayWorkChimeOptions {
   volume: number;
@@ -140,19 +154,33 @@ async function scheduleWorkChime(ctx: AudioContextLike, kind: WorkChimeKind, vol
 
   const master = ctx.createGain();
   master.gain.setValueAtTime(volume, ctx.currentTime);
-  master.connect(ctx.destination);
+
+  // 最終段に出力リミッターを挟む。合成音側を増幅してもピークが threshold で抑えられるため、
+  // 音量を上げても音割れしない。createDynamicsCompressor 非対応環境では従来どおり直結する。
+  const limiter = ctx.createDynamicsCompressor?.();
+  if (limiter) {
+    limiter.threshold.setValueAtTime(LIMITER_THRESHOLD_DB, ctx.currentTime);
+    limiter.knee.setValueAtTime(LIMITER_KNEE_DB, ctx.currentTime);
+    limiter.ratio.setValueAtTime(LIMITER_RATIO, ctx.currentTime);
+    limiter.attack.setValueAtTime(LIMITER_ATTACK_SEC, ctx.currentTime);
+    limiter.release.setValueAtTime(LIMITER_RELEASE_SEC, ctx.currentTime);
+    master.connect(limiter);
+    limiter.connect(ctx.destination);
+  } else {
+    master.connect(ctx.destination);
+  }
 
   const now = ctx.currentTime + 0.05;
 
   if (kind === 'break') {
-    bell(ctx, master, now, 784, 0.18, 0.34);
-    bell(ctx, master, now + 0.26, 659, 0.28, 0.3);
+    bell(ctx, master, now, 784, 0.18, 0.34 * CHIME_GAIN_SCALE);
+    bell(ctx, master, now + 0.26, 659, 0.28, 0.3 * CHIME_GAIN_SCALE);
     return true;
   }
 
-  bell(ctx, master, now, 659, 0.14, 0.3);
-  bell(ctx, master, now + 0.21, 784, 0.14, 0.32);
-  bell(ctx, master, now + 0.42, 988, 0.22, 0.28);
+  bell(ctx, master, now, 659, 0.14, 0.3 * CHIME_GAIN_SCALE);
+  bell(ctx, master, now + 0.21, 784, 0.14, 0.32 * CHIME_GAIN_SCALE);
+  bell(ctx, master, now + 0.42, 988, 0.22, 0.28 * CHIME_GAIN_SCALE);
   return true;
 }
 


### PR DESCRIPTION
## 背景・目的

時計のチャイムを iPad で使うと、本体音量をかなり上げないと聞こえず、アプリ詳細設定の音量を 100% にしても物足りなかった。一方で業務 PWA のため「うるさすぎて音割れ（クリップ）する」のは絶対に避けたい。

調査の結果、チャイムは音源ファイルではなく `lib/workChimeAudio.ts` で Web Audio API によりリアルタイム合成されており、各トーンの基準 gain が控えめ（最大でも約 0.34）で、クリップ上限 1.0 に対し**約3倍のヘッドルームが余っている**ことが原因と判明。「100%」が実出力の上限になっていなかった。

## 変更内容

**リミッター＋増幅**の方針で、音割れを原理的に防ぎつつ音量を底上げ：

- 出力の最終段に **DynamicsCompressorNode（リミッター）** を追加。合成音を大きくしても出力ピークが threshold で抑えられ、音割れを防ぐ安全網にする。
- 合成音側を `CHIME_GAIN_SCALE = 1.6`（やや大きめ・様子見の控えめ値）で底上げ。
- `master.gain`（＝詳細設定の音量 0〜1.0 = ユーザー設定 0〜100%）の意味は**変更しない**。増幅は合成音側にのみ適用。
- `CHIME_GAIN_SCALE` とリミッター各パラメータを定数化し、実機で調整しやすくした。
- `createDynamicsCompressor` 非対応環境では従来どおり `master → destination` 直結にフォールバック。

UI・設定値（localStorage の `volume`）・設定画面は変更なし。

## テスト

- `lib/workChimeAudio.test.ts` のモック AudioContext に `createDynamicsCompressor` を追加。
- リミッターが destination に接続されること、非対応環境でのフォールバックを検証するテストを追加。
- 既存の「音量は0から1に丸める」テストは `master.gain` 据え置きのためそのまま pass。

### 検証結果
- ✅ ユニットテスト 8件 pass
- ✅ `npm run typecheck` エラーなし
- ✅ `npm run lint` 問題なし
- ⏳ 実機（iPad）での聴感確認（音量・歪みの有無）は要確認。物足りなければ `CHIME_GAIN_SCALE` を上げ、歪むようなら下げる/リミッター閾値を下げて調整可能。

https://claude.ai/code/session_01Po5hBGbzVNYJwMBa6fUEdj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Po5hBGbzVNYJwMBa6fUEdj)_