### PR TITLE
fix: iPadで日付・時刻ピッカーが横に伸びる問題を修正

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -752,3 +752,18 @@ input[type='datetime-local']::-webkit-calendar-picker-indicator {
   height: 1.1rem;
   cursor: pointer;
 }
+
+/* iOS/iPadのネイティブ日付・時刻入力(date/month/time/datetime-local)は、共通Inputの
+   w-full(width:100%)を受けると、短い値に対して親フォーム幅いっぱいまで横に伸び、
+   iPadの広い画面で不自然に間延びして見える。最大幅で頭打ちにして、値に見合った
+   コンパクトな幅に収める。
+   - 単独配置(w-fullのみ)のフィールド: 上限で止まり左寄せの落ち着いた幅になる。
+   - grid/flexのセル内(日付範囲・時刻レンジ等): セル幅が上限より狭いため従来どおり
+     セルいっぱいに追従し、整列は崩れない。
+   属性セレクタ(0,1,1)はTailwindの .w-full(0,1,0) より詳細度が高く確実に上書きできる。 */
+input[type='date'],
+input[type='month'],
+input[type='time'],
+input[type='datetime-local'] {
+  max-width: 16rem;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -753,17 +753,34 @@ input[type='datetime-local']::-webkit-calendar-picker-indicator {
   cursor: pointer;
 }
 
-/* iOS/iPadのネイティブ日付・時刻入力(date/month/time/datetime-local)は、共通Inputの
-   w-full(width:100%)を受けると、短い値に対して親フォーム幅いっぱいまで横に伸び、
-   iPadの広い画面で不自然に間延びして見える。最大幅で頭打ちにして、値に見合った
-   コンパクトな幅に収める。
-   - 単独配置(w-fullのみ)のフィールド: 上限で止まり左寄せの落ち着いた幅になる。
-   - grid/flexのセル内(日付範囲・時刻レンジ等): セル幅が上限より狭いため従来どおり
-     セルいっぱいに追従し、整列は崩れない。
+/* ネイティブ日付・時刻入力(date/month/time/datetime-local)は、共通Inputのw-full
+   (width:100%)を受けると短い値に対して親フォーム幅いっぱいまで広がり、iPadの広い
+   画面で不自然に間延びして見える。最大幅で頭打ちにして、値に見合ったコンパクトな幅に
+   収める。grid/flexのセル内はセル幅が上限より狭いため従来どおりセルに追従する。
    属性セレクタ(0,1,1)はTailwindの .w-full(0,1,0) より詳細度が高く確実に上書きできる。 */
 input[type='date'],
 input[type='month'],
 input[type='time'],
 input[type='datetime-local'] {
   max-width: 16rem;
+}
+
+/* iOS/iPadのSafari限定の不具合対策。
+   これらの入力はネイティブ既定スタイルにより「値テキスト分の固有最小幅」を持ち、
+   max-widthやw-fullで枠を狭めても中身が枠を無視して右へはみ出す。その結果、
+   画面外への突き抜けや、隣接ボタン(対象月の「作成」など)との重なりが起きていた。
+   -webkit-appearance:none で固有スタイルを外し、普通のテキスト枠として枠内に収める
+   (タップでネイティブピッカーが開く挙動は維持)。min-width:0 で flex 内での縮小も許可。
+   デスクトップのカレンダーアイコンを保つため、適用はiOS Safariに限定する
+   (-webkit-touch-callout はiOS SafariでのみサポートされるためUA判定に使える)。 */
+@supports (-webkit-touch-callout: none) {
+  input[type='date'],
+  input[type='month'],
+  input[type='time'],
+  input[type='datetime-local'] {
+    -webkit-appearance: none;
+    appearance: none;
+    min-width: 0;
+    overflow: hidden;
+  }
 }


### PR DESCRIPTION
## 背景

iPad の PWA で、`date` / `month` / `time` などのネイティブピッカー（iOS 専用UI）が、短い値（例: `2026/06/09`、`2026年6月`）に対してフォーム幅いっぱいまで横に伸び、不自然に間延びして見える問題があった。アプリ全体・どのページでも発生していた。

## 原因

これらの入力は共通の `Input` コンポーネント（および一部の直書き input）経由で `w-full`（`width: 100%`）を受けている。iPad の広いフォーム幅では、短い日付・時刻値に対して入力欄が必要以上に横長になっていた。

## 対応

`app/globals.css` で、ネイティブ日付・時刻入力に `max-width: 16rem` を設定し、値に見合ったコンパクトな幅で頭打ちにした。

```css
input[type='date'],
input[type='month'],
input[type='time'],
input[type='datetime-local'] {
  max-width: 16rem;
}
```

- **単独配置（`w-full` のみ）のフィールド**（試飲日・対象月など）: 上限で止まり、左寄せの落ち着いた幅になる。
- **grid / flex のセル内**（日付範囲フィルタ・勤怠チャイムの時刻レンジなど）: セル幅が上限より狭いため従来どおりセルいっぱいに追従し、整列は崩れない。
- 属性セレクタ（詳細度 0,1,1）は Tailwind の `.w-full`（0,1,0）より詳細度が高いため、確実に上書きできる。

## 検証

- CSS のみの変更。属性セレクタの詳細度により `w-full` を上書きできることを確認。
- ⚠️ 本リモート環境では chrome-devtools MCP が利用できず、iPad 幅でのライブ目視確認は未実施。マージ前に実機/エミュレータでの確認を推奨。

https://claude.ai/code/session_01ETQXf4w9NXdax5K9iYxEDK

---
_Generated by [Claude Code](https://claude.ai/code/session_01ETQXf4w9NXdax5K9iYxEDK)_