### PR TITLE
fix(assignment): 未割り当てメンバーがシャッフルで再配置される不具合を修正

### DIFF
--- a/app/assignment/lib/shuffle.test.ts
+++ b/app/assignment/lib/shuffle.test.ts
@@ -510,3 +510,44 @@ describe('calculateAssignment - メンバー完全配置保証（#330）', () =>
     });
   });
 });
+
+describe('calculateAssignment - 未割り当てメンバーの除外', () => {
+  it('未割り当て（どのスロットにも配置されていない）メンバーは、シャッフルしても再配置されない', () => {
+    // 3班×2タスク=6スロット、メンバーm1..m6（全員active）
+    const { teams, taskLabels, members } = createThreeTeamData();
+
+    // m6 を「未割り当て」にした状態を表す currentAssignments。
+    // 5スロットに m1..m5 を配置し、1スロット(task1-teamC)を未割り当て(null)にする。
+    // m6 はどのスロットにも入っていない（＝担当表に表示されていない）。
+    const currentAssignments: Assignment[] = [
+      { teamId: 'teamA', taskLabelId: 'task1', memberId: 'm1', assignedDate: '2026-03-12' },
+      { teamId: 'teamB', taskLabelId: 'task1', memberId: 'm2', assignedDate: '2026-03-12' },
+      { teamId: 'teamC', taskLabelId: 'task1', memberId: null, assignedDate: '2026-03-12' },
+      { teamId: 'teamA', taskLabelId: 'task2', memberId: 'm3', assignedDate: '2026-03-12' },
+      { teamId: 'teamB', taskLabelId: 'task2', memberId: 'm4', assignedDate: '2026-03-12' },
+      { teamId: 'teamC', taskLabelId: 'task2', memberId: 'm5', assignedDate: '2026-03-12' },
+    ];
+
+    // このバグは確率的（eligibleがスロットより多いとランダムに選ばれる）なので複数回試す。
+    // 一度でも未割り当ての m6 が配置されたら失敗。
+    for (let i = 0; i < 30; i++) {
+      const result = calculateAssignment(
+        teams,
+        taskLabels,
+        members,
+        [],
+        '2026-03-12',
+        currentAssignments,
+        undefined,
+        true // crossTeamShuffle: 班制約を外し、空きスロットに誰でも入り得る状況にする
+      );
+      const placedIds = result.filter((a) => a.memberId !== null).map((a) => a.memberId);
+      // 未割り当ての m6 は再配置されない
+      expect(placedIds).not.toContain('m6');
+      // 配置されるのは、元々配置済みだった m1..m5 のみ
+      for (const id of placedIds) {
+        expect(['m1', 'm2', 'm3', 'm4', 'm5']).toContain(id);
+      }
+    }
+  });
+});

--- a/app/assignment/lib/shuffle.ts
+++ b/app/assignment/lib/shuffle.ts
@@ -148,8 +148,18 @@ export const calculateAssignment = (
   crossTeamShuffle?: boolean,
   priority?: 'pair' | 'row'
 ): Assignment[] => {
-  // 1. 対象メンバーの抽出（アクティブなメンバーのみ）
-  const eligibleMembers = members.filter((m) => m.active !== false);
+  // 1. 対象メンバーの抽出
+  //   現在スロットに配置されているメンバーだけをシャッフル対象にする。
+  //   （未割り当て＝どのスロットにも入っていないメンバーは再配置しない）
+  //   配置情報が無い場合（初期状態の空テーブル等）は従来通り全アクティブメンバーを
+  //   対象にする（空テーブルからの自動配置を維持。なお「全員を未割り当てにしてから
+  //   シャッフル」すると、この分岐で全員が再配置されるが、これは意図的な挙動）。
+  const placedMemberIds = new Set(
+    (currentAssignments ?? []).filter((asg) => asg.memberId !== null).map((asg) => asg.memberId as string)
+  );
+  const activeMembers = members.filter((m) => m.active !== false);
+  const eligibleMembers =
+    placedMemberIds.size > 0 ? activeMembers.filter((m) => placedMemberIds.has(m.id)) : activeMembers;
 
   // 2. 固定枠（memberId === null）の特定
   const lockedSlots = new Map<string, boolean>();


### PR DESCRIPTION
## 概要

担当表で、メンバーを長押し →「未割り当てにする」で外したのに、**シャッフルすると別のスロットに再配置されて居座る**不具合を修正します。

## 原因

- 「未割り当てにする」は対象スロットの `memberId` を `null` にするだけで、メンバーの `active` は変えない（`TableModals.tsx`）。
- シャッフルは `shuffle.ts` で `eligibleMembers = members.filter((m) => m.active !== false)` ＝ **active な全員**を対象にしていた。
- そのため未割り当てメンバーが対象に残り、空きスロットへ再配置されていた（空にしたスロット自体はロックされ空のままだが、本人は別スロットに入る）。

## 修正

シャッフル対象を「**現在スロットに配置されているメンバーだけ**」に限定（ユーザーの「担当表に表示されているメンバー＝シャッフル対象」という仕様に一致）。

- 配置情報が無い場合（初期状態の空テーブル・既存テスト）は従来通り全アクティブメンバーにフォールバックし、**後方互換**を維持。
- コア変更は `shuffle.ts` の1か所のみ。結果生成部は `eligibleMembers` 由来の解＋ロック枠のみで構築されることを確認済み。

## テスト

- このバグは**確率的**（eligibleがスロットより多いとランダムに選ばれる）なため、**30回ループ**の回帰テストを追加。修正前は red、修正後は green。
- 既存の担当表テスト42件すべて緑。

## 検証

- [x] `shuffle.test.ts`（新規ループ＋既存）緑
- [x] 担当表ディレクトリ全テスト（42件）緑
- [x] lint / format:check / docs:check 通過
- [x] 実機（chrome-devtools, iPad運用想定）で再現確認：未割り当てメンバーがシャッフル後も復活せず、配置済みメンバーは正常にシャッフルされることを3回連続で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)