### PR TITLE
fix(clock): iPad PWA復帰後にチャイムが鳴らないゾンビAudioContextを検出・復旧する

### DIFF
--- a/hooks/useWorkChime.test.tsx
+++ b/hooks/useWorkChime.test.tsx
@@ -5,14 +5,16 @@ import { useWorkChime } from './useWorkChime';
 
 const playWorkChimeMock = vi.fn();
 const unlockWorkChimeAudioMock = vi.fn(() => Promise.resolve(true));
-const resumeWorkChimeAudioMock = vi.fn(() => Promise.resolve(true));
+const reviveWorkChimeAudioMock = vi.fn(() => Promise.resolve(true));
+const markWorkChimeAudioSuspectMock = vi.fn();
 const isWorkChimeAudioReadyMock = vi.fn(() => true);
 
 vi.mock('@/lib/workChimeAudio', () => ({
   isWorkChimeAudioReady: () => isWorkChimeAudioReadyMock(),
+  markWorkChimeAudioSuspect: () => markWorkChimeAudioSuspectMock(),
   playWorkChime: (...args: unknown[]) => playWorkChimeMock(...args),
   unlockWorkChimeAudio: () => unlockWorkChimeAudioMock(),
-  resumeWorkChimeAudio: () => resumeWorkChimeAudioMock(),
+  reviveWorkChimeAudio: () => reviveWorkChimeAudioMock(),
 }));
 
 const createLocalStorageMock = () => {
@@ -42,16 +44,23 @@ describe('useWorkChime', () => {
     playWorkChimeMock.mockResolvedValue(true);
     unlockWorkChimeAudioMock.mockReset();
     unlockWorkChimeAudioMock.mockResolvedValue(true);
-    resumeWorkChimeAudioMock.mockReset();
-    resumeWorkChimeAudioMock.mockResolvedValue(true);
+    reviveWorkChimeAudioMock.mockReset();
+    reviveWorkChimeAudioMock.mockResolvedValue(true);
+    markWorkChimeAudioSuspectMock.mockReset();
     isWorkChimeAudioReadyMock.mockReset();
     isWorkChimeAudioReadyMock.mockReturnValue(true);
   });
 
-  it('音の有効化前（AudioContext未準備）は鳴らさず通知だけ表示する', () => {
+  it('音の有効化前（AudioContext未準備）は鳴らさず通知だけ表示する', async () => {
     isWorkChimeAudioReadyMock.mockReturnValue(false);
+    // 未アンロックなので復旧もできない。
+    reviveWorkChimeAudioMock.mockResolvedValue(false);
 
     const { result } = renderHook(() => useWorkChime(localDate(10, 45)));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
 
     expect(playWorkChimeMock).not.toHaveBeenCalled();
     expect(result.current.activeChime?.message).toBe('休憩時間です');
@@ -107,14 +116,19 @@ describe('useWorkChime', () => {
     expect(playWorkChimeMock).toHaveBeenCalledTimes(1);
   });
 
-  it('PWA復帰などで区切り時刻の秒をまたいでも通知を表示する', () => {
+  it('PWA復帰などで区切り時刻の秒をまたいでも通知を表示する', async () => {
     isWorkChimeAudioReadyMock.mockReturnValue(false);
+    reviveWorkChimeAudioMock.mockResolvedValue(false);
 
     const { result, rerender } = renderHook(({ now }) => useWorkChime(now), {
       initialProps: { now: localDate(10, 44, 59) },
     });
 
     rerender({ now: localDate(10, 45, 3) });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
 
     expect(playWorkChimeMock).not.toHaveBeenCalled();
     expect(result.current.activeChime?.label).toBe('休憩開始');
@@ -171,7 +185,7 @@ describe('useWorkChime', () => {
     expect(result.current.activeChime).toBeNull();
   });
 
-  it('復帰時にAudioContextを再開できれば音の有効化を維持する', async () => {
+  it('復帰時にAudioContextを復旧できれば音の有効化を維持する', async () => {
     const { result } = renderHook(() => useWorkChime(localDate(10, 40)));
 
     await act(async () => {
@@ -180,20 +194,20 @@ describe('useWorkChime', () => {
     });
     expect(result.current.isAudioEnabled).toBe(true);
 
-    // iOS で suspended/interrupted になった想定。focus で resume を試みて成功する。
+    // iOS で suspended/interrupted になった想定。focus で復旧を試みて成功する。
     isWorkChimeAudioReadyMock.mockReturnValue(false);
-    resumeWorkChimeAudioMock.mockResolvedValue(true);
+    reviveWorkChimeAudioMock.mockResolvedValue(true);
 
     await act(async () => {
       window.dispatchEvent(new Event('focus'));
       await Promise.resolve();
     });
 
-    expect(resumeWorkChimeAudioMock).toHaveBeenCalled();
+    expect(reviveWorkChimeAudioMock).toHaveBeenCalled();
     expect(result.current.isAudioEnabled).toBe(true);
   });
 
-  it('復帰時にAudioContextを再開できなければ音の有効化を解除する', async () => {
+  it('復帰時にAudioContextを復旧できなければ音の有効化を解除する', async () => {
     const { result } = renderHook(() => useWorkChime(localDate(10, 40)));
 
     await act(async () => {
@@ -202,9 +216,9 @@ describe('useWorkChime', () => {
     });
     expect(result.current.isAudioEnabled).toBe(true);
 
-    // resume が失敗（suspended でユーザー操作が必要）した想定。
+    // 復旧失敗（suspended でユーザー操作が必要、または復帰不能）の想定。
     isWorkChimeAudioReadyMock.mockReturnValue(false);
-    resumeWorkChimeAudioMock.mockResolvedValue(false);
+    reviveWorkChimeAudioMock.mockResolvedValue(false);
 
     await act(async () => {
       window.dispatchEvent(new Event('focus'));
@@ -212,6 +226,62 @@ describe('useWorkChime', () => {
     });
 
     expect(result.current.isAudioEnabled).toBe(false);
+  });
+
+  it('stateがreadyを報告していても復帰時は必ず実測プローブで生存確認する', async () => {
+    renderHook(() => useWorkChime(localDate(10, 40)));
+
+    // iPadOS WebKit のゾンビ状態は state='running'（ready=true）を報告するため、
+    // ready 判定を理由に復旧をスキップしてはいけない（本バグの回帰テスト）。
+    isWorkChimeAudioReadyMock.mockReturnValue(true);
+
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      await Promise.resolve();
+    });
+
+    expect(markWorkChimeAudioSuspectMock).toHaveBeenCalled();
+    expect(reviveWorkChimeAudioMock).toHaveBeenCalled();
+  });
+
+  it('非表示への遷移（visibilityState=hidden）では復旧処理を行わない', async () => {
+    renderHook(() => useWorkChime(localDate(10, 40)));
+
+    const originalVisibilityState = Object.getOwnPropertyDescriptor(Document.prototype, 'visibilityState');
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+
+    try {
+      await act(async () => {
+        document.dispatchEvent(new Event('visibilitychange'));
+        await Promise.resolve();
+      });
+
+      expect(reviveWorkChimeAudioMock).not.toHaveBeenCalled();
+    } finally {
+      delete (document as { visibilityState?: unknown }).visibilityState;
+      if (originalVisibilityState) {
+        Object.defineProperty(Document.prototype, 'visibilityState', originalVisibilityState);
+      }
+    }
+  });
+
+  it('復帰直後の生存確認中にチャイム時刻をまたいだ場合、復旧できたら遅れて鳴らす', async () => {
+    // 復帰直後で ready=false（suspect 中）、復旧は成功する想定。
+    isWorkChimeAudioReadyMock.mockReturnValue(false);
+    reviveWorkChimeAudioMock.mockResolvedValue(true);
+
+    const { rerender } = renderHook(({ now }) => useWorkChime(now), {
+      initialProps: { now: localDate(10, 44, 59) },
+    });
+
+    rerender({ now: localDate(10, 45) });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(reviveWorkChimeAudioMock).toHaveBeenCalled();
+    expect(playWorkChimeMock).toHaveBeenCalledWith('break', { volume: 0.8 });
   });
 
   it('画面上のユーザー操作（pointerdown）でオーディオを自動有効化する', async () => {

--- a/hooks/useWorkChime.ts
+++ b/hooks/useWorkChime.ts
@@ -2,7 +2,13 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { isWorkChimeAudioReady, playWorkChime, resumeWorkChimeAudio, unlockWorkChimeAudio } from '@/lib/workChimeAudio';
+import {
+  isWorkChimeAudioReady,
+  markWorkChimeAudioSuspect,
+  playWorkChime,
+  reviveWorkChimeAudio,
+  unlockWorkChimeAudio,
+} from '@/lib/workChimeAudio';
 import {
   getCurrentWorkChimePeriod,
   getDueWorkChimeSince,
@@ -131,6 +137,15 @@ export function useWorkChime(now: Date | null): UseWorkChimeReturn {
       // 鳴らせない状態なので有効フラグを下げ、「有効化」ボタンを出して
       // 次のユーザー操作で復帰できるようにする。
       setIsAudioEnabled(false);
+      if (settings.soundEnabled) {
+        // 復帰直後の生存確認中にチャイム時刻をまたいだ場合に備え、復旧できたら遅れて鳴らす。
+        void reviveWorkChimeAudio().then((revived) => {
+          setIsAudioEnabled(revived);
+          if (revived) {
+            void playWorkChime(due.kind, { volume: settings.volume });
+          }
+        });
+      }
     }
 
     if (timerRef.current) clearTimeout(timerRef.current);
@@ -140,16 +155,17 @@ export function useWorkChime(now: Date | null): UseWorkChimeReturn {
     }, 5000);
   }, [now, settings]);
 
-  // フォアグラウンド復帰時、suspended でも即 disable せず resume を試みて自動復旧する。
+  // フォアグラウンド復帰時の自動復旧。iPadOS WebKit はバックグラウンド復帰後に
+  // state='running' を報告したまま実際は音が出ない「ゾンビ状態」になることがあるため、
+  // state（isWorkChimeAudioReady）を信頼せず、必ず実測プローブ（revive）で生存確認する。
   useEffect(() => {
     if (typeof window === 'undefined' || typeof document === 'undefined') return;
 
     const refreshAudioState = () => {
-      if (isWorkChimeAudioReady()) {
-        setIsAudioEnabled(true);
-        return;
-      }
-      void resumeWorkChimeAudio().then(setIsAudioEnabled);
+      // 非表示への遷移時は判定できないため何もしない（復帰側のイベントだけ処理する）。
+      if (document.visibilityState === 'hidden') return;
+      markWorkChimeAudioSuspect();
+      void reviveWorkChimeAudio().then(setIsAudioEnabled);
     };
 
     window.addEventListener('focus', refreshAudioState);
@@ -165,6 +181,8 @@ export function useWorkChime(now: Date | null): UseWorkChimeReturn {
 
   // 画面上の任意のユーザー操作でオーディオを自動的に有効化する。
   // ボタンを押し直さなくても、タップ／クリック／キー操作だけで suspended から復帰できる。
+  // ゾンビ疑い中や作り直し直後の context は ready が false になるため、必要な場面では
+  // 必ず unlockWorkChimeAudio() が走る（正常時の毎タップの無駄なノード生成は避ける）。
   useEffect(() => {
     if (typeof document === 'undefined') return;
 

--- a/lib/workChimeAudio.test.ts
+++ b/lib/workChimeAudio.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { playWorkChime, unlockWorkChimeAudio } from './workChimeAudio';
+import { classifyWorkChimeAudioHealth, playWorkChime, probeWorkChimeAudioHealth, unlockWorkChimeAudio } from './workChimeAudio';
 
 type AudioContextMock = NonNullable<Parameters<typeof playWorkChime>[1]['audioContext']>;
 
@@ -176,5 +176,250 @@ describe('workChimeAudio', () => {
       value: originalAudioContext,
       configurable: true,
     });
+  });
+});
+
+describe('classifyWorkChimeAudioHealth', () => {
+  it('runningでcurrentTimeが進んでいればaliveと判定する', () => {
+    expect(
+      classifyWorkChimeAudioHealth({ state: 'running', resumed: true, timeBefore: 10, timeAfter: 10.25 })
+    ).toBe('alive');
+  });
+
+  it('runningなのにcurrentTimeが止まっていればzombieと判定する', () => {
+    expect(
+      classifyWorkChimeAudioHealth({ state: 'running', resumed: true, timeBefore: 10, timeAfter: 10 })
+    ).toBe('zombie');
+  });
+
+  it('resumeに失敗した場合はneeds-gestureと判定する', () => {
+    expect(
+      classifyWorkChimeAudioHealth({ state: 'running', resumed: false, timeBefore: 10, timeAfter: 10.25 })
+    ).toBe('needs-gesture');
+  });
+
+  it('resume後もsuspended/interruptedのままならneeds-gestureと判定する', () => {
+    expect(
+      classifyWorkChimeAudioHealth({ state: 'suspended', resumed: true, timeBefore: 10, timeAfter: 10 })
+    ).toBe('needs-gesture');
+    expect(
+      classifyWorkChimeAudioHealth({
+        state: 'interrupted' as AudioContextState,
+        resumed: true,
+        timeBefore: 10,
+        timeAfter: 10,
+      })
+    ).toBe('needs-gesture');
+  });
+
+  it('closedはunavailableと判定する', () => {
+    expect(
+      classifyWorkChimeAudioHealth({ state: 'closed', resumed: false, timeBefore: 10, timeAfter: 10 })
+    ).toBe('unavailable');
+  });
+
+  it('state非対応環境では検証できないためaliveとして扱う', () => {
+    expect(
+      classifyWorkChimeAudioHealth({ state: undefined, resumed: true, timeBefore: 10, timeAfter: 10 })
+    ).toBe('alive');
+  });
+});
+
+// プローブ・復旧用に、currentTime を可変にし無音キック（createBuffer/createBufferSource）と
+// close を備えたモック。clockAdvancesOnRead は実時間ベースの待機（デフォルト wait）でも
+// alive 判定になるよう、読み取りごとに時計を進める。
+function createProbeAudioContextMock(
+  state: AudioContextState,
+  options: { clockAdvances: boolean; clockAdvancesOnRead?: boolean }
+) {
+  let time = 10;
+  const bufferSourceStart = vi.fn();
+  const close = vi.fn(() => Promise.resolve());
+  const resume = vi.fn(() => Promise.resolve());
+
+  const base = createAudioContextMock();
+
+  const ctx = {
+    ...base.ctx,
+    state,
+    resume,
+    close,
+    sampleRate: 48000,
+    createBuffer: vi.fn(() => ({}) as AudioBuffer),
+    createBufferSource: vi.fn(
+      () =>
+        ({
+          buffer: null,
+          connect: vi.fn(),
+          start: bufferSourceStart,
+        }) as unknown as AudioBufferSourceNode
+    ),
+    get currentTime() {
+      if (options.clockAdvancesOnRead) time += 0.001;
+      return time;
+    },
+  };
+
+  const advance = (seconds: number) => {
+    time += seconds;
+  };
+
+  const wait = vi.fn(async () => {
+    if (options.clockAdvances) advance(0.25);
+  });
+
+  return { ctx, wait, close, resume, bufferSourceStart, advance };
+}
+
+describe('probeWorkChimeAudioHealth', () => {
+  it('待機中にcurrentTimeが進めばaliveを返し、無音キックでcontextを駆動する', async () => {
+    const mock = createProbeAudioContextMock('running', { clockAdvances: true });
+
+    const health = await probeWorkChimeAudioHealth({ audioContext: mock.ctx, wait: mock.wait });
+
+    expect(health).toBe('alive');
+    expect(mock.wait).toHaveBeenCalledWith(250);
+    expect(mock.bufferSourceStart).toHaveBeenCalled();
+  });
+
+  it('runningなのにcurrentTimeが止まっていればzombieを返す', async () => {
+    const mock = createProbeAudioContextMock('running', { clockAdvances: false });
+
+    const health = await probeWorkChimeAudioHealth({ audioContext: mock.ctx, wait: mock.wait });
+
+    expect(health).toBe('zombie');
+  });
+
+  it('createBuffer非対応のcontextでも例外なく判定できる', async () => {
+    const mock = createProbeAudioContextMock('running', { clockAdvances: true });
+    (mock.ctx as { createBuffer?: unknown }).createBuffer = undefined;
+
+    const health = await probeWorkChimeAudioHealth({ audioContext: mock.ctx, wait: mock.wait });
+
+    expect(health).toBe('alive');
+  });
+});
+
+// シングルトン（モジュール内の AudioContext）の状態を伴うテスト。
+// モジュールレジストリをリセットして毎回まっさらな状態から検証する。
+describe('reviveWorkChimeAudio（シングルトン状態）', () => {
+  const originalAudioContext = window.AudioContext;
+
+  afterEach(() => {
+    Object.defineProperty(window, 'AudioContext', {
+      value: originalAudioContext,
+      configurable: true,
+    });
+  });
+
+  async function loadIsolatedModule(contexts: unknown[]) {
+    const constructorMock = vi.fn(function AudioContextMock() {
+      return contexts.shift();
+    });
+    Object.defineProperty(window, 'AudioContext', {
+      value: constructorMock as unknown as typeof AudioContext,
+      configurable: true,
+    });
+    vi.resetModules();
+    const mod = await import('./workChimeAudio');
+    return { mod, constructorMock };
+  }
+
+  it('未アンロック（context未生成）ならfalseを返す', async () => {
+    const { mod, constructorMock } = await loadIsolatedModule([]);
+
+    await expect(mod.reviveWorkChimeAudio()).resolves.toBe(false);
+    expect(constructorMock).not.toHaveBeenCalled();
+  });
+
+  it('ゾンビ検出時はcontextをclose+作り直し、新contextがsuspendedならfalseを返す', async () => {
+    const zombie = createProbeAudioContextMock('running', { clockAdvances: false });
+    const fresh = createProbeAudioContextMock('suspended', { clockAdvances: false });
+    const { mod, constructorMock } = await loadIsolatedModule([zombie.ctx, fresh.ctx]);
+
+    await expect(mod.unlockWorkChimeAudio()).resolves.toBe(true);
+
+    const revived = await mod.reviveWorkChimeAudio({ wait: zombie.wait });
+
+    expect(revived).toBe(false);
+    expect(zombie.close).toHaveBeenCalledTimes(1);
+    expect(constructorMock).toHaveBeenCalledTimes(2);
+    // 新contextはsuspendedのままなのでready判定はfalse（バナー・ジェスチャー経由の復帰につながる）。
+    expect(mod.isWorkChimeAudioReady()).toBe(false);
+  });
+
+  it('suspect中はready判定をfalseに倒し、aliveプローブ成功で復帰する', async () => {
+    const healthy = createProbeAudioContextMock('running', { clockAdvances: true });
+    const { mod } = await loadIsolatedModule([healthy.ctx]);
+
+    await expect(mod.unlockWorkChimeAudio()).resolves.toBe(true);
+    expect(mod.isWorkChimeAudioReady()).toBe(true);
+
+    mod.markWorkChimeAudioSuspect();
+    expect(mod.isWorkChimeAudioReady()).toBe(false);
+
+    await expect(mod.reviveWorkChimeAudio({ wait: healthy.wait })).resolves.toBe(true);
+    expect(mod.isWorkChimeAudioReady()).toBe(true);
+  });
+
+  it('unlockWorkChimeAudioの成功でもsuspectを解除する', async () => {
+    const healthy = createProbeAudioContextMock('running', { clockAdvances: true, clockAdvancesOnRead: true });
+    const { mod } = await loadIsolatedModule([healthy.ctx]);
+
+    await expect(mod.unlockWorkChimeAudio()).resolves.toBe(true);
+    mod.markWorkChimeAudioSuspect();
+    expect(mod.isWorkChimeAudioReady()).toBe(false);
+
+    await expect(mod.unlockWorkChimeAudio()).resolves.toBe(true);
+    expect(mod.isWorkChimeAudioReady()).toBe(true);
+  });
+
+  it('suspect中のアンロックは事後プローブで検証し、ゾンビなら作り直す', async () => {
+    const zombie = createProbeAudioContextMock('running', { clockAdvances: false });
+    const fresh = createProbeAudioContextMock('suspended', { clockAdvances: false });
+    const { mod, constructorMock } = await loadIsolatedModule([zombie.ctx, fresh.ctx]);
+
+    await expect(mod.unlockWorkChimeAudio()).resolves.toBe(true);
+    mod.markWorkChimeAudioSuspect();
+
+    // ゾンビは state='running' を偽申告するため、アンロック自体は「成功」する。
+    await expect(mod.unlockWorkChimeAudio()).resolves.toBe(true);
+
+    // 事後検証プローブ（デフォルト250ms待機）がゾンビを検出して context を作り直す。
+    await vi.waitFor(() => {
+      expect(zombie.close).toHaveBeenCalledTimes(1);
+    });
+    expect(constructorMock).toHaveBeenCalledTimes(2);
+    expect(mod.isWorkChimeAudioReady()).toBe(false);
+  });
+
+  it('同時に複数回呼ばれてもプローブは1回しか実行しない', async () => {
+    const healthy = createProbeAudioContextMock('running', { clockAdvances: true });
+    const { mod } = await loadIsolatedModule([healthy.ctx]);
+
+    await expect(mod.unlockWorkChimeAudio()).resolves.toBe(true);
+
+    let resolveWait: (() => void) | undefined;
+    const wait = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveWait = () => {
+            healthy.advance(0.25);
+            resolve();
+          };
+        })
+    );
+
+    const first = mod.reviveWorkChimeAudio({ wait });
+    const second = mod.reviveWorkChimeAudio({ wait });
+    // プローブが wait に到達するまでマイクロタスクを進めてから解決する。
+    await vi.waitFor(() => {
+      expect(wait).toHaveBeenCalled();
+    });
+    resolveWait?.();
+
+    await expect(first).resolves.toBe(true);
+    await expect(second).resolves.toBe(true);
+    expect(wait).toHaveBeenCalledTimes(1);
   });
 });

--- a/lib/workChimeAudio.test.ts
+++ b/lib/workChimeAudio.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { classifyWorkChimeAudioHealth, playWorkChime, probeWorkChimeAudioHealth, unlockWorkChimeAudio } from './workChimeAudio';
+import {
+  classifyWorkChimeAudioHealth,
+  playWorkChime,
+  probeWorkChimeAudioHealth,
+  unlockWorkChimeAudio,
+} from './workChimeAudio';
 
 type AudioContextMock = NonNullable<Parameters<typeof playWorkChime>[1]['audioContext']>;
 
@@ -181,27 +186,27 @@ describe('workChimeAudio', () => {
 
 describe('classifyWorkChimeAudioHealth', () => {
   it('runningでcurrentTimeが進んでいればaliveと判定する', () => {
-    expect(
-      classifyWorkChimeAudioHealth({ state: 'running', resumed: true, timeBefore: 10, timeAfter: 10.25 })
-    ).toBe('alive');
+    expect(classifyWorkChimeAudioHealth({ state: 'running', resumed: true, timeBefore: 10, timeAfter: 10.25 })).toBe(
+      'alive'
+    );
   });
 
   it('runningなのにcurrentTimeが止まっていればzombieと判定する', () => {
-    expect(
-      classifyWorkChimeAudioHealth({ state: 'running', resumed: true, timeBefore: 10, timeAfter: 10 })
-    ).toBe('zombie');
+    expect(classifyWorkChimeAudioHealth({ state: 'running', resumed: true, timeBefore: 10, timeAfter: 10 })).toBe(
+      'zombie'
+    );
   });
 
   it('resumeに失敗した場合はneeds-gestureと判定する', () => {
-    expect(
-      classifyWorkChimeAudioHealth({ state: 'running', resumed: false, timeBefore: 10, timeAfter: 10.25 })
-    ).toBe('needs-gesture');
+    expect(classifyWorkChimeAudioHealth({ state: 'running', resumed: false, timeBefore: 10, timeAfter: 10.25 })).toBe(
+      'needs-gesture'
+    );
   });
 
   it('resume後もsuspended/interruptedのままならneeds-gestureと判定する', () => {
-    expect(
-      classifyWorkChimeAudioHealth({ state: 'suspended', resumed: true, timeBefore: 10, timeAfter: 10 })
-    ).toBe('needs-gesture');
+    expect(classifyWorkChimeAudioHealth({ state: 'suspended', resumed: true, timeBefore: 10, timeAfter: 10 })).toBe(
+      'needs-gesture'
+    );
     expect(
       classifyWorkChimeAudioHealth({
         state: 'interrupted' as AudioContextState,
@@ -213,15 +218,15 @@ describe('classifyWorkChimeAudioHealth', () => {
   });
 
   it('closedはunavailableと判定する', () => {
-    expect(
-      classifyWorkChimeAudioHealth({ state: 'closed', resumed: false, timeBefore: 10, timeAfter: 10 })
-    ).toBe('unavailable');
+    expect(classifyWorkChimeAudioHealth({ state: 'closed', resumed: false, timeBefore: 10, timeAfter: 10 })).toBe(
+      'unavailable'
+    );
   });
 
   it('state非対応環境では検証できないためaliveとして扱う', () => {
-    expect(
-      classifyWorkChimeAudioHealth({ state: undefined, resumed: true, timeBefore: 10, timeAfter: 10 })
-    ).toBe('alive');
+    expect(classifyWorkChimeAudioHealth({ state: undefined, resumed: true, timeBefore: 10, timeAfter: 10 })).toBe(
+      'alive'
+    );
   });
 });
 

--- a/lib/workChimeAudio.ts
+++ b/lib/workChimeAudio.ts
@@ -7,7 +7,12 @@ declare global {
 }
 
 type AudioContextLike = Pick<AudioContext, 'currentTime' | 'destination' | 'createOscillator' | 'createGain'> &
-  Partial<Pick<AudioContext, 'state' | 'resume' | 'createDynamicsCompressor'>>;
+  Partial<
+    Pick<
+      AudioContext,
+      'state' | 'resume' | 'close' | 'createDynamicsCompressor' | 'createBuffer' | 'createBufferSource' | 'sampleRate'
+    >
+  >;
 
 // iPad のスピーカーは中低域が弱く、純音ベースのチャイムは知覚的に小さい。詳細設定の音量(master)を
 // 100% にしても合成音側の gain が控えめでヘッドルームが余っているため、合成音側だけを底上げする
@@ -56,6 +61,11 @@ function needsResume(state: AudioContextStateLike): boolean {
 }
 
 let workChimeAudioContext: AudioContextLike | null = null;
+
+// iPadOS WebKit はバックグラウンド復帰後、AudioContext が state='running' を報告するのに
+// 実際には音が出ない「ゾンビ状態」になることがある。state を信頼できない間（復帰直後〜
+// プローブ完了まで）はこのフラグで ready 判定を fail-closed に倒す。
+let audioHealthSuspect = false;
 
 function createAudioContext(): AudioContextLike | null {
   if (typeof window === 'undefined') return null;
@@ -184,15 +194,135 @@ async function scheduleWorkChime(ctx: AudioContextLike, kind: WorkChimeKind, vol
   return true;
 }
 
-export function isWorkChimeAudioReady(): boolean {
-  if (!workChimeAudioContext) return false;
-  const state = getContextState(workChimeAudioContext);
-  return state !== 'suspended' && state !== 'closed' && state !== 'interrupted';
+// 1サンプルの無音バッファを再生して context を駆動する。iOS の定番アンロック手法であり、
+// currentTime プローブの前提条件（ノードを最低1つスケジュールして時計を進める）でもある。
+// createBuffer / createBufferSource 非対応環境では何もしない。
+function kickAudioContext(ctx: AudioContextLike): void {
+  if (!ctx.createBuffer || !ctx.createBufferSource) return;
+
+  try {
+    const buffer = ctx.createBuffer(1, 1, ctx.sampleRate ?? 44100);
+    const source = ctx.createBufferSource();
+    source.buffer = buffer;
+    source.connect(ctx.destination);
+    source.start(0);
+  } catch (error) {
+    console.warn('Failed to kick work chime audio context:', error);
+  }
 }
 
-export async function resumeWorkChimeAudio(): Promise<boolean> {
+type WorkChimeAudioHealth = 'alive' | 'needs-gesture' | 'zombie' | 'unavailable';
+
+// resume 試行と currentTime プローブの結果から AudioContext の生死を判定する純粋関数。
+// 'running' を自己申告していても時計が進んでいなければゾンビ（iPadOS WebKit の既知バグ）。
+export function classifyWorkChimeAudioHealth(input: {
+  state: AudioContextStateLike;
+  resumed: boolean;
+  timeBefore: number;
+  timeAfter: number;
+}): WorkChimeAudioHealth {
+  if (input.state === 'closed') return 'unavailable';
+  if (!input.resumed || needsResume(input.state)) return 'needs-gesture';
+  // state 非対応環境では検証できないため申告どおり扱う。
+  if (input.state !== 'running') return 'alive';
+  return input.timeAfter > input.timeBefore ? 'alive' : 'zombie';
+}
+
+const DEFAULT_PROBE_DELAY_MS = 250;
+
+function defaultWait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+interface ProbeWorkChimeAudioOptions {
+  probeDelayMs?: number;
+  wait?: (ms: number) => Promise<void>;
+  audioContext?: AudioContextLike;
+}
+
+// resume → 無音キック → 待機 → currentTime の進行確認、で実際に音が出せる状態かを実測する。
+export async function probeWorkChimeAudioHealth(options: ProbeWorkChimeAudioOptions = {}): Promise<WorkChimeAudioHealth> {
+  const ctx = options.audioContext ?? workChimeAudioContext;
+  if (!ctx) return 'unavailable';
+
+  const resumed = await resumeAudioContext(ctx);
+  kickAudioContext(ctx);
+  const timeBefore = ctx.currentTime;
+  await (options.wait ?? defaultWait)(options.probeDelayMs ?? DEFAULT_PROBE_DELAY_MS);
+  const timeAfter = ctx.currentTime;
+
+  return classifyWorkChimeAudioHealth({ state: getContextState(ctx), resumed, timeBefore, timeAfter });
+}
+
+// ゾンビ化した context を破棄して作り直す。iOS では新 context は suspended で始まるため
+// 戻り値は false になりやすいが、その場合は ready 判定が false になることで既存の
+// ジェスチャーリスナー・有効化バナー経由の再アンロックに自然につながる。
+async function recoverWorkChimeAudio(): Promise<boolean> {
+  const oldCtx = workChimeAudioContext;
+  workChimeAudioContext = null;
+  if (oldCtx?.close) {
+    // ゾンビ context の close() はハング・reject しうるため待たずに投げ捨てる。
+    try {
+      void Promise.resolve(oldCtx.close()).catch(() => {});
+    } catch {
+      // 破棄済み context のため無視する。
+    }
+  }
+
+  const ctx = getAudioContext();
+  if (!ctx) return false;
+
+  const resumed = await resumeAudioContext(ctx);
+  if (!resumed) return false;
+  kickAudioContext(ctx);
+  return !needsResume(getContextState(ctx));
+}
+
+// フォアグラウンド復帰時など、state を信頼できなくなったタイミングで呼ぶ。
+// 次の reviveWorkChimeAudio / unlockWorkChimeAudio が完了するまで ready 判定が false になる。
+export function markWorkChimeAudioSuspect(): void {
+  audioHealthSuspect = true;
+}
+
+let revivePromise: Promise<boolean> | null = null;
+
+// バックグラウンド復帰時の復旧 API。state の自己申告を信頼せず実測プローブで生存確認し、
+// ゾンビなら context を作り直す。focus / pageshow / visibilitychange の同時発火に備えて
+// 実行中の Promise を共有する。
+export async function reviveWorkChimeAudio(options: ProbeWorkChimeAudioOptions = {}): Promise<boolean> {
+  // 実行中なら合流する。recover 中は context が一時的に null になるため、null 判定より先に見る。
+  if (revivePromise) return revivePromise;
+  // 未アンロック（context 未生成）なら復旧対象がない。ready 判定は元々 false。
   if (!workChimeAudioContext) return false;
-  return resumeAudioContext(workChimeAudioContext);
+
+  revivePromise = (async () => {
+    try {
+      const health = await probeWorkChimeAudioHealth(options);
+      // プローブ完了後は判定結果（または作り直した新 context の state）を信頼できる。
+      audioHealthSuspect = false;
+
+      if (health === 'alive') return true;
+      if (health === 'zombie') {
+        console.warn('Work chime audio context is zombie (state=running but clock stalled); recreating.');
+        return recoverWorkChimeAudio();
+      }
+      // 'needs-gesture': state が正しく suspended/interrupted を報告しており、
+      // 既存のジェスチャーリスナー・バナー経由で復帰できる。'unavailable' は復帰不能。
+      return false;
+    } finally {
+      revivePromise = null;
+    }
+  })();
+
+  return revivePromise;
+}
+
+export function isWorkChimeAudioReady(): boolean {
+  if (!workChimeAudioContext) return false;
+  // 復帰直後〜プローブ完了までは state が嘘をついている可能性があるため鳴らせる扱いにしない。
+  if (audioHealthSuspect) return false;
+  const state = getContextState(workChimeAudioContext);
+  return state !== 'suspended' && state !== 'closed' && state !== 'interrupted';
 }
 
 export async function unlockWorkChimeAudio(): Promise<boolean> {
@@ -200,7 +330,21 @@ export async function unlockWorkChimeAudio(): Promise<boolean> {
   if (!ctx) return false;
 
   try {
-    return await scheduleWorkChime(ctx, 'work-start', 0);
+    const unlocked = await scheduleWorkChime(ctx, 'work-start', 0);
+    if (unlocked) {
+      // ユーザージェスチャー起点の確実なアンロックなので、無音バッファでも context を蹴り、
+      // ゾンビ疑いを解除する（設定モーダルの「テスト再生」と同等の復旧力を持たせる）。
+      kickAudioContext(ctx);
+      const wasSuspect = audioHealthSuspect;
+      audioHealthSuspect = false;
+      if (wasSuspect) {
+        // ゾンビは resume / スケジュールの成功すら偽申告するため、疑い中のアンロックは
+        // 事後に実測プローブで検証し、死んでいたら作り直す（結果は ready 判定経由で
+        // 次のチャイム発火・ユーザー操作に反映される）。
+        void reviveWorkChimeAudio();
+      }
+    }
+    return unlocked;
   } catch (error) {
     console.warn('Failed to unlock work chime audio:', error);
     return false;

--- a/lib/workChimeAudio.ts
+++ b/lib/workChimeAudio.ts
@@ -241,7 +241,9 @@ interface ProbeWorkChimeAudioOptions {
 }
 
 // resume → 無音キック → 待機 → currentTime の進行確認、で実際に音が出せる状態かを実測する。
-export async function probeWorkChimeAudioHealth(options: ProbeWorkChimeAudioOptions = {}): Promise<WorkChimeAudioHealth> {
+export async function probeWorkChimeAudioHealth(
+  options: ProbeWorkChimeAudioOptions = {}
+): Promise<WorkChimeAudioHealth> {
   const ctx = options.audioContext ?? workChimeAudioContext;
   if (!ctx) return 'unavailable';
 


### PR DESCRIPTION
## 問題

iPad PWA で「音声を有効にする」をタップ後、別アプリへ移動して戻ると、有効化済みのはずなのにチャイムが鳴らない。設定モーダルの「テスト再生」を押すまで直らない。過去のPR（ac3ded2 / 62dcc08 / 014b41d / 1c3754c / 5b083b7）で対策したはずが解消していなかった。

## 根本原因

iPadOS WebKit の既知バグで、PWA がバックグラウンドから復帰すると AudioContext が **state='running'（正常）を報告するのに実際は音が出ない「ゾンビ状態」** になることがある。

従来コードは state ベースの `isWorkChimeAudioReady()` を信頼していたため、ゾンビ状態では:

1. focus / pageshow / visibilitychange の復帰ハンドラが「正常」と判定して何もしない
2. 画面タップの再アンロック（handleGesture）も早期リターン
3. チャイム発火時も死んだ context に音をスケジュール → 無音
4. 「音を有効化」バナーも表示されない

「テスト再生」だけは状態チェックを飛ばして `unlockWorkChimeAudio()` を強制実行するため、押すと直っていた。

## 対策

state の自己申告を信頼せず、**「無音キック → currentTime プローブ → ゾンビなら context 作り直し」** の実測ベース復旧を導入:

- **`classifyWorkChimeAudioHealth`**（純粋関数）: resume 結果と currentTime の進行から `alive` / `needs-gesture` / `zombie` / `unavailable` を判定
- **`probeWorkChimeAudioHealth`**: resume + 無音バッファ再生（キック）後、250ms 待って context 内部の時計が進んでいるかを実測
- **`reviveWorkChimeAudio`**: 復帰時の復旧API。ゾンビ検出時は context を close + 再生成（新 context は suspended で始まるため、既存のジェスチャーリスナー・有効化バナーが自然に正しく機能する）。復帰イベント3種の同時発火は in-flight Promise 共有で1本化
- **suspect フラグ**: 復帰直後〜プローブ完了（約300ms）の間は ready 判定を fail-closed に倒し、発火・ジェスチャー・バナーの全経路を安全側にする
- **`unlockWorkChimeAudio` 強化**: 無音キックを追加。疑い中のアンロックは事後プローブで検証（ゾンビはアンロックの成功すら偽申告するため）
- **遅延再生**: チャイム発火時に ready=false でも、復旧に成功したら遅れて鳴らす

`app/clock/page.tsx`（バナー表示）は変更不要。UI の見た目は変わらない。

## 検証

- [x] `npm run typecheck` / `npm run lint` / `npm run test:run`（1110件）全パス
- [x] `npm run deadcode`（今回の変更による新規検出なし）
- [ ] **実機 iPad での確認（要レビュアー）**: 音声有効化 → 別アプリへ切替（1分以上）→ 復帰 → **テスト再生を押さずに** チャイムが鳴ること。鳴らない場合でも「音を有効化」バナーが表示され、タップ1回で復帰できること

万一実機で解消しない場合の次の手（無音ループによるキープアライブ）は、デメリット含めて検討済み・不採用として記録してあります。

https://claude.ai/code/session_01UMpJrM2X8JvfXQt9ukfTBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMpJrM2X8JvfXQt9ukfTBr)_