### PR TITLE
fix(sync): Firestore購読エラーをUIに通知し自動再購読する (#496)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import localFont from 'next/font/local';
 import { OfflineBanner } from '@/components/OfflineBanner';
 import { ServiceWorkerRegistration } from '@/components/ServiceWorkerRegistration';
 import { SplashScreenWrapper } from '@/components/SplashScreenWrapper';
+import { SyncErrorBanner } from '@/components/SyncErrorBanner';
 import { ThemeProvider } from '@/components/ThemeProvider';
 import { ToastProvider } from '@/components/Toast';
 
@@ -69,6 +70,7 @@ export default function RootLayout({
         <ThemeProvider>
           <ToastProvider>
             <OfflineBanner />
+            <SyncErrorBanner />
             {children}
           </ToastProvider>
         </ThemeProvider>

--- a/components/SyncErrorBanner.test.tsx
+++ b/components/SyncErrorBanner.test.tsx
@@ -1,0 +1,71 @@
+// Firestore購読エラー通知バナーのテスト（issue #496）
+
+import { render, screen, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SyncErrorBanner } from './SyncErrorBanner';
+import { reportSyncError, clearSyncError } from '@/lib/syncStatus';
+
+const onlineStatusMock = vi.hoisted(() => ({
+  isOnline: true,
+}));
+
+vi.mock('@/hooks/useOnlineStatus', () => ({
+  useOnlineStatus: () => onlineStatusMock.isOnline,
+}));
+
+describe('SyncErrorBanner', () => {
+  beforeEach(() => {
+    onlineStatusMock.isOnline = true;
+    clearSyncError();
+  });
+
+  it('同期エラーがないときは何も表示しない', () => {
+    const { container } = render(<SyncErrorBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('unavailable エラー時に「同期できていません」を表示する', () => {
+    render(<SyncErrorBanner />);
+
+    act(() => {
+      reportSyncError('unavailable');
+    });
+
+    expect(screen.getByRole('status')).toHaveTextContent('データを同期できていません');
+  });
+
+  it('permission-denied エラー時はアクセス権限のメッセージを表示する', () => {
+    render(<SyncErrorBanner />);
+
+    act(() => {
+      reportSyncError('permission-denied');
+    });
+
+    expect(screen.getByRole('status')).toHaveTextContent('アクセス権限');
+  });
+
+  it('エラー回復（clearSyncError）でバナーが消える', () => {
+    render(<SyncErrorBanner />);
+
+    act(() => {
+      reportSyncError('unavailable');
+    });
+    expect(screen.getByRole('status')).toBeInTheDocument();
+
+    act(() => {
+      clearSyncError();
+    });
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('オフライン時は表示しない（OfflineBanner に譲る）', () => {
+    onlineStatusMock.isOnline = false;
+    render(<SyncErrorBanner />);
+
+    act(() => {
+      reportSyncError('unavailable');
+    });
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+});

--- a/components/SyncErrorBanner.tsx
+++ b/components/SyncErrorBanner.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+import { subscribeSyncError, getSyncError, type SyncErrorType } from '@/lib/syncStatus';
+import { useOnlineStatus } from '@/hooks/useOnlineStatus';
+
+// SSR/ビルド時はエラーなし扱い（バナー非表示）にする
+function getServerSnapshot(): SyncErrorType | null {
+  return null;
+}
+
+const MESSAGES: Record<SyncErrorType, string> = {
+  'permission-denied': 'データへのアクセス権限がありません。再ログインをお試しください',
+  unavailable: 'データを同期できていません。表示中の内容は最新でない可能性があります',
+  unknown: 'データを同期できていません。表示中の内容は最新でない可能性があります',
+};
+
+export function SyncErrorBanner() {
+  const syncError = useSyncExternalStore(subscribeSyncError, getSyncError, getServerSnapshot);
+  const isOnline = useOnlineStatus();
+
+  // オフライン時は OfflineBanner が表示されるため二重に警告しない
+  if (!syncError || !isOnline) {
+    return null;
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed top-0 inset-x-0 z-40 pointer-events-none bg-danger text-white text-center text-sm font-medium py-1.5 px-4"
+    >
+      {MESSAGES[syncError]}
+    </div>
+  );
+}

--- a/lib/firestore/userData/crud.test.ts
+++ b/lib/firestore/userData/crud.test.ts
@@ -1,0 +1,186 @@
+// subscribeUserData の購読エラー通知・自動再購読のテスト（issue #496）
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { subscribeUserData } from './crud';
+import { getSyncError, clearSyncError } from '@/lib/syncStatus';
+
+const firestoreMocks = vi.hoisted(() => ({
+  onSnapshot: vi.fn(),
+}));
+
+vi.mock('firebase/firestore', () => ({
+  setDoc: vi.fn(),
+  getDoc: vi.fn(),
+  onSnapshot: firestoreMocks.onSnapshot,
+}));
+
+vi.mock('../common', () => ({
+  getUserDocRef: vi.fn(() => ({ path: 'users/test-user' })),
+  removeUndefinedFields: vi.fn((data: unknown) => data),
+  normalizeAppData: vi.fn((data: unknown) => data),
+  defaultData: { todaySchedules: [] },
+}));
+
+vi.mock('@/lib/e2eMode', () => ({
+  isE2EMode: () => false,
+  loadE2EAppData: vi.fn(),
+  saveE2EAppData: vi.fn(),
+}));
+
+vi.mock('./write-queue', () => ({
+  writeQueues: new Map(),
+  SAVE_USER_DATA_DEBOUNCE_MS: 0,
+  executeWrite: vi.fn(),
+}));
+
+type SnapshotHandler = (snapshot: { exists: () => boolean; data: () => unknown }) => void;
+type ErrorHandler = (error: { code?: string }) => void;
+
+// onSnapshot に渡されたハンドラを捕捉するヘルパー
+function captureHandlers() {
+  const captured: { onNext: SnapshotHandler[]; onError: ErrorHandler[]; unsubscribes: ReturnType<typeof vi.fn>[] } = {
+    onNext: [],
+    onError: [],
+    unsubscribes: [],
+  };
+  firestoreMocks.onSnapshot.mockImplementation((_ref: unknown, onNext: SnapshotHandler, onError: ErrorHandler) => {
+    captured.onNext.push(onNext);
+    captured.onError.push(onError);
+    const unsubscribe = vi.fn();
+    captured.unsubscribes.push(unsubscribe);
+    return unsubscribe;
+  });
+  return captured;
+}
+
+describe('subscribeUserData の購読エラー処理', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    firestoreMocks.onSnapshot.mockReset();
+    clearSyncError();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('購読エラー時に callback を呼ばず、同期エラーが報告される', () => {
+    const captured = captureHandlers();
+    const callback = vi.fn();
+    subscribeUserData('test-user', callback);
+
+    captured.onError[0]({ code: 'internal' });
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(getSyncError()).toBe('unknown');
+  });
+
+  it('permission-denied エラーは種別 permission-denied として報告される', () => {
+    const captured = captureHandlers();
+    subscribeUserData('test-user', vi.fn());
+
+    captured.onError[0]({ code: 'permission-denied' });
+
+    expect(getSyncError()).toBe('permission-denied');
+  });
+
+  it('unavailable エラーは種別 unavailable として報告される', () => {
+    const captured = captureHandlers();
+    subscribeUserData('test-user', vi.fn());
+
+    captured.onError[0]({ code: 'unavailable' });
+
+    expect(getSyncError()).toBe('unavailable');
+  });
+
+  it('エラー後にスナップショットを受信できたら同期エラーが解除される', () => {
+    const captured = captureHandlers();
+    const callback = vi.fn();
+    subscribeUserData('test-user', callback);
+
+    captured.onError[0]({ code: 'unavailable' });
+    expect(getSyncError()).toBe('unavailable');
+
+    // バックオフ経過後に再購読され、その購読でスナップショット成功
+    vi.advanceTimersByTime(1000);
+    expect(captured.onNext.length).toBeGreaterThanOrEqual(2);
+    captured.onNext[1]({ exists: () => true, data: () => ({ todaySchedules: [] }) });
+
+    expect(getSyncError()).toBeNull();
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('購読エラー後、バックオフ付きで自動的に再購読される', () => {
+    const captured = captureHandlers();
+    subscribeUserData('test-user', vi.fn());
+    expect(firestoreMocks.onSnapshot).toHaveBeenCalledTimes(1);
+
+    // 1回目のエラー → 1秒後に再購読
+    captured.onError[0]({ code: 'unavailable' });
+    vi.advanceTimersByTime(999);
+    expect(firestoreMocks.onSnapshot).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(1);
+    expect(firestoreMocks.onSnapshot).toHaveBeenCalledTimes(2);
+
+    // 2回目のエラー → 2秒後に再購読（指数バックオフ）
+    captured.onError[1]({ code: 'unavailable' });
+    vi.advanceTimersByTime(1999);
+    expect(firestoreMocks.onSnapshot).toHaveBeenCalledTimes(2);
+    vi.advanceTimersByTime(1);
+    expect(firestoreMocks.onSnapshot).toHaveBeenCalledTimes(3);
+  });
+
+  it('unsubscribe 後は再購読されず、進行中のリトライもキャンセルされる', () => {
+    const captured = captureHandlers();
+    const unsubscribe = subscribeUserData('test-user', vi.fn());
+
+    captured.onError[0]({ code: 'unavailable' });
+    unsubscribe();
+
+    vi.advanceTimersByTime(60_000);
+    expect(firestoreMocks.onSnapshot).toHaveBeenCalledTimes(1);
+    expect(captured.unsubscribes[0]).toHaveBeenCalled();
+  });
+
+  it('unsubscribe 時に同期エラーが解除される（ログアウト後の古いバナー防止）', () => {
+    const captured = captureHandlers();
+    const unsubscribe = subscribeUserData('test-user', vi.fn());
+
+    captured.onError[0]({ code: 'unavailable' });
+    expect(getSyncError()).toBe('unavailable');
+
+    unsubscribe();
+
+    expect(getSyncError()).toBeNull();
+  });
+
+  it('同一購読でエラーが連続しても、リトライタイマーは1つだけ保持される', () => {
+    const captured = captureHandlers();
+    subscribeUserData('test-user', vi.fn());
+
+    // 同じ購読世代でエラーが2回発火（前のタイマーは破棄されるべき）
+    captured.onError[0]({ code: 'unavailable' });
+    captured.onError[0]({ code: 'unavailable' });
+
+    vi.advanceTimersByTime(60_000);
+    // 再購読は1回だけ（初回購読1 + 再購読1 = 2）
+    expect(firestoreMocks.onSnapshot).toHaveBeenCalledTimes(2);
+  });
+
+  it('スナップショット成功でバックオフがリセットされる', () => {
+    const captured = captureHandlers();
+    subscribeUserData('test-user', vi.fn());
+
+    // エラー → 再購読 → 成功 → 再びエラー
+    captured.onError[0]({ code: 'unavailable' });
+    vi.advanceTimersByTime(1000);
+    captured.onNext[1]({ exists: () => true, data: () => ({ todaySchedules: [] }) });
+    captured.onError[1]({ code: 'unavailable' });
+
+    // リセットされていれば再購読まで1秒（2秒ではない）
+    vi.advanceTimersByTime(1000);
+    expect(firestoreMocks.onSnapshot).toHaveBeenCalledTimes(3);
+  });
+});

--- a/lib/firestore/userData/crud.ts
+++ b/lib/firestore/userData/crud.ts
@@ -3,6 +3,7 @@
 import { setDoc, getDoc, onSnapshot } from 'firebase/firestore';
 import { getUserDocRef, removeUndefinedFields, normalizeAppData, defaultData } from '../common';
 import { isE2EMode, loadE2EAppData, saveE2EAppData } from '@/lib/e2eMode';
+import { reportSyncError, clearSyncError, type SyncErrorType } from '@/lib/syncStatus';
 import type { AppData } from '@/types';
 import { writeQueues, SAVE_USER_DATA_DEBOUNCE_MS, executeWrite, type SaveUserDataOptions } from './write-queue';
 
@@ -111,6 +112,20 @@ function mergeSaveUserDataOptions(
   };
 }
 
+// onSnapshot はエラーで購読が恒久停止するため、指数バックオフで再購読する
+const RESUBSCRIBE_BASE_DELAY_MS = 1000;
+const RESUBSCRIBE_MAX_DELAY_MS = 30_000;
+
+function toSyncErrorType(error: { code?: string }): SyncErrorType {
+  if (error.code === 'permission-denied') {
+    return 'permission-denied';
+  }
+  if (error.code === 'unavailable') {
+    return 'unavailable';
+  }
+  return 'unknown';
+}
+
 export function subscribeUserData(userId: string, callback: (data: AppData) => void): () => void {
   if (isE2EMode()) {
     queueMicrotask(() => callback(loadE2EAppData(defaultData)));
@@ -119,18 +134,55 @@ export function subscribeUserData(userId: string, callback: (data: AppData) => v
 
   const userDocRef = getUserDocRef(userId);
 
-  return onSnapshot(
-    userDocRef,
-    (snapshot) => {
-      if (snapshot.exists()) {
-        callback(normalizeAppData(snapshot.data()));
-      } else {
-        callback(defaultData);
+  let stopped = false;
+  let retryCount = 0;
+  let retryTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  let unsubscribeSnapshot: () => void = () => {};
+
+  const start = () => {
+    unsubscribeSnapshot = onSnapshot(
+      userDocRef,
+      (snapshot) => {
+        retryCount = 0;
+        clearSyncError();
+        if (snapshot.exists()) {
+          callback(normalizeAppData(snapshot.data()));
+        } else {
+          callback(defaultData);
+        }
+      },
+      (error) => {
+        console.error('Error in Firestore subscription:', error);
+        // エラー時はcallbackを呼ばない（既存データを保持する）
+        // ただし「同期できていない」ことをUIへ通知する（issue #496）
+        reportSyncError(toSyncErrorType(error));
+
+        // 同一世代でエラーが連続した場合は前のタイマーを破棄し、二重再購読を防ぐ
+        if (retryTimeoutId) {
+          clearTimeout(retryTimeoutId);
+        }
+        const delay = Math.min(RESUBSCRIBE_MAX_DELAY_MS, RESUBSCRIBE_BASE_DELAY_MS * 2 ** retryCount);
+        retryCount += 1;
+        retryTimeoutId = setTimeout(() => {
+          retryTimeoutId = null;
+          if (!stopped) {
+            start();
+          }
+        }, delay);
       }
-    },
-    (error) => {
-      console.error('Error in Firestore subscription:', error);
-      // エラー時はcallbackを呼ばない（既存データを保持する）
+    );
+  };
+
+  start();
+
+  return () => {
+    stopped = true;
+    if (retryTimeoutId) {
+      clearTimeout(retryTimeoutId);
+      retryTimeoutId = null;
     }
-  );
+    unsubscribeSnapshot();
+    // 購読が無くなった後にバナーが残り続けないようにする（ログアウト時など）
+    clearSyncError();
+  };
 }

--- a/lib/syncStatus.test.ts
+++ b/lib/syncStatus.test.ts
@@ -1,0 +1,62 @@
+// Firestore購読エラーの同期状態ストアのテスト（issue #496）
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getSyncError, reportSyncError, clearSyncError, subscribeSyncError } from './syncStatus';
+
+describe('syncStatus', () => {
+  beforeEach(() => {
+    clearSyncError();
+  });
+
+  it('初期状態ではエラーがない（null）', () => {
+    expect(getSyncError()).toBeNull();
+  });
+
+  it('reportSyncError で報告したエラー種別を取得できる', () => {
+    reportSyncError('permission-denied');
+    expect(getSyncError()).toBe('permission-denied');
+  });
+
+  it('reportSyncError で購読中のリスナーが呼ばれる', () => {
+    const listener = vi.fn();
+    subscribeSyncError(listener);
+
+    reportSyncError('unavailable');
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('clearSyncError でエラーが消えてリスナーが呼ばれる', () => {
+    const listener = vi.fn();
+    reportSyncError('unknown');
+    subscribeSyncError(listener);
+
+    clearSyncError();
+
+    expect(getSyncError()).toBeNull();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('状態が変化しないときはリスナーを呼ばない（不要な再レンダー防止）', () => {
+    const listener = vi.fn();
+    subscribeSyncError(listener);
+
+    clearSyncError(); // すでに null → 変化なし
+    expect(listener).not.toHaveBeenCalled();
+
+    reportSyncError('unavailable');
+    listener.mockClear();
+    reportSyncError('unavailable'); // 同じ値 → 変化なし
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('unsubscribe したリスナーは呼ばれない', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeSyncError(listener);
+
+    unsubscribe();
+    reportSyncError('permission-denied');
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/lib/syncStatus.ts
+++ b/lib/syncStatus.ts
@@ -1,0 +1,39 @@
+// Firestore購読エラーの同期状態ストア（issue #496）
+// React非依存のミニストア。useSyncExternalStore から購読して
+// 「データを同期できていません」バナーの表示制御に使う。
+
+export type SyncErrorType = 'permission-denied' | 'unavailable' | 'unknown';
+
+let currentError: SyncErrorType | null = null;
+const listeners = new Set<() => void>();
+
+function notify(): void {
+  listeners.forEach((listener) => listener());
+}
+
+export function getSyncError(): SyncErrorType | null {
+  return currentError;
+}
+
+export function reportSyncError(type: SyncErrorType): void {
+  if (currentError === type) {
+    return;
+  }
+  currentError = type;
+  notify();
+}
+
+export function clearSyncError(): void {
+  if (currentError === null) {
+    return;
+  }
+  currentError = null;
+  notify();
+}
+
+export function subscribeSyncError(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}


### PR DESCRIPTION
## 概要

Closes #496

`subscribeUserData` の onSnapshot エラーハンドラが `console.error` のみで callback を呼ばないため、権限切れ・Firestore障害時もUIは古いデータを表示し続け、利用者が「保存・同期できているつもり」になる問題を修正します。

## 変更内容

- **`lib/syncStatus.ts`（新規）**: 同期エラー状態のミニストア（report / clear / subscribe）。React非依存で `useSyncExternalStore` に直結できる形
- **`lib/firestore/userData/crud.ts`**: `subscribeUserData` のエラーハンドラでエラー種別（permission-denied / unavailable / unknown）をストアへ報告。onSnapshot はエラーで購読が恒久停止するため、指数バックオフ（1s→2s→…最大30s）で自動再購読し、成功スナップショット受信でエラー解除・バックオフリセット
- **`components/SyncErrorBanner.tsx`（新規）**: 「データを同期できていません」バナー。permission-denied 時は再ログイン案内に切替。オフライン時は OfflineBanner に譲って非表示
- **`app/layout.tsx`**: バナーをグローバル設置

## 設計上の判断

- 「エラー時は callback を呼ばず既存データを保持する」既存方針はそのまま維持し、「最新でない可能性がある」ことだけをバナーで通知
- unsubscribe 時に同期エラーを解除（ログアウト後に古いバナーが残るのを防止）
- エラー連続時は前のリトライタイマーを破棄し、二重購読を防止

## 完了条件の充足

- [x] 購読エラー発生時にユーザーが視覚的に気づける（バナー表示・iPad幅で目視確認済み）
- [x] エラー回復（再接続）時に通知が消える（自動再購読＋成功時クリア）
- [x] テストで購読エラー時の通知挙動を検証（20件追加・全1130件パス）

## 検証

- `npm run test:run` 1130件パス
- `npm run build` / `npm run lint` / `npm run format:check` クリーン
- chrome-devtools（iPad幅 1024x768）で unavailable / permission-denied / 回復消滅の3パターンを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)