### PR TITLE
fix(sync): write-queue保存失敗をUIに通知しcatch漏れ経路を解消する (#497)

### DIFF
--- a/components/SyncErrorBanner.test.tsx
+++ b/components/SyncErrorBanner.test.tsx
@@ -1,9 +1,9 @@
-// Firestore購読エラー通知バナーのテスト（issue #496）
+// Firestore購読エラー（issue #496）・保存エラー（issue #497）通知バナーのテスト
 
 import { render, screen, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SyncErrorBanner } from './SyncErrorBanner';
-import { reportSyncError, clearSyncError } from '@/lib/syncStatus';
+import { reportSyncError, clearSyncError, reportSaveError, clearSaveError } from '@/lib/syncStatus';
 
 const onlineStatusMock = vi.hoisted(() => ({
   isOnline: true,
@@ -17,6 +17,7 @@ describe('SyncErrorBanner', () => {
   beforeEach(() => {
     onlineStatusMock.isOnline = true;
     clearSyncError();
+    clearSaveError();
   });
 
   it('同期エラーがないときは何も表示しない', () => {
@@ -67,5 +68,51 @@ describe('SyncErrorBanner', () => {
     });
 
     expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('保存エラー時に「保存できませんでした」を表示する（issue #497）', () => {
+    render(<SyncErrorBanner />);
+
+    act(() => {
+      reportSaveError('unknown');
+    });
+
+    expect(screen.getByRole('status')).toHaveTextContent('保存できませんでした');
+  });
+
+  it('保存エラーが permission-denied のときは再ログイン案内を表示する', () => {
+    render(<SyncErrorBanner />);
+
+    act(() => {
+      reportSaveError('permission-denied');
+    });
+
+    expect(screen.getByRole('status')).toHaveTextContent('再ログイン');
+  });
+
+  it('保存エラーは購読エラーより優先して表示する（データ未保存の方が深刻）', () => {
+    render(<SyncErrorBanner />);
+
+    act(() => {
+      reportSyncError('unavailable');
+      reportSaveError('unknown');
+    });
+
+    expect(screen.getByRole('status')).toHaveTextContent('保存できませんでした');
+  });
+
+  it('保存エラーの解除（clearSaveError）で購読エラーの表示に戻る', () => {
+    render(<SyncErrorBanner />);
+
+    act(() => {
+      reportSyncError('unavailable');
+      reportSaveError('unknown');
+    });
+
+    act(() => {
+      clearSaveError();
+    });
+
+    expect(screen.getByRole('status')).toHaveTextContent('データを同期できていません');
   });
 });

--- a/components/SyncErrorBanner.tsx
+++ b/components/SyncErrorBanner.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useSyncExternalStore } from 'react';
-import { subscribeSyncError, getSyncError, type SyncErrorType } from '@/lib/syncStatus';
+import { subscribeSyncError, getSyncError, getSaveError, type SyncErrorType } from '@/lib/syncStatus';
 import { useOnlineStatus } from '@/hooks/useOnlineStatus';
 
 // SSR/ビルド時はエラーなし扱い（バナー非表示）にする
@@ -9,20 +9,32 @@ function getServerSnapshot(): SyncErrorType | null {
   return null;
 }
 
-const MESSAGES: Record<SyncErrorType, string> = {
+// 購読エラー（同期できていない＝表示が古いかもしれない）のメッセージ
+const SYNC_MESSAGES: Record<SyncErrorType, string> = {
   'permission-denied': 'データへのアクセス権限がありません。再ログインをお試しください',
   unavailable: 'データを同期できていません。表示中の内容は最新でない可能性があります',
   unknown: 'データを同期できていません。表示中の内容は最新でない可能性があります',
 };
 
+// 保存エラー（直前の変更が保存されていない）のメッセージ（issue #497）
+const SAVE_MESSAGES: Record<SyncErrorType, string> = {
+  'permission-denied': 'データを保存できませんでした。アクセス権限がありません。再ログインをお試しください',
+  unavailable: 'データを保存できませんでした。直前の変更は反映されていません。もう一度お試しください',
+  unknown: 'データを保存できませんでした。直前の変更は反映されていません。もう一度お試しください',
+};
+
 export function SyncErrorBanner() {
   const syncError = useSyncExternalStore(subscribeSyncError, getSyncError, getServerSnapshot);
+  const saveError = useSyncExternalStore(subscribeSyncError, getSaveError, getServerSnapshot);
   const isOnline = useOnlineStatus();
 
   // オフライン時は OfflineBanner が表示されるため二重に警告しない
-  if (!syncError || !isOnline) {
+  if ((!syncError && !saveError) || !isOnline) {
     return null;
   }
+
+  // 保存エラー（データ未保存）の方が深刻なため優先して表示する
+  const message = saveError ? SAVE_MESSAGES[saveError] : SYNC_MESSAGES[syncError!];
 
   return (
     <div
@@ -30,7 +42,7 @@ export function SyncErrorBanner() {
       aria-live="polite"
       className="fixed top-0 inset-x-0 z-40 pointer-events-none bg-danger text-white text-center text-sm font-medium py-1.5 px-4"
     >
-      {MESSAGES[syncError]}
+      {message}
     </div>
   );
 }

--- a/hooks/useAppData.ts
+++ b/hooks/useAppData.ts
@@ -277,6 +277,8 @@ export function useAppData() {
           updatedFields: mutatedKeys,
         });
       } catch (error) {
+        // ユーザーへの通知は write-queue の reportSaveError が行うため（issue #497）、
+        // ここでは「失敗した変更を破棄してサーバーの状態へ巻き戻す」ことに専念する
         saveError = error;
         console.error('Failed to save data:', error);
         lockedKeysRef.current.clear();

--- a/lib/firestore/userData/crud.ts
+++ b/lib/firestore/userData/crud.ts
@@ -3,7 +3,7 @@
 import { setDoc, getDoc, onSnapshot } from 'firebase/firestore';
 import { getUserDocRef, removeUndefinedFields, normalizeAppData, defaultData } from '../common';
 import { isE2EMode, loadE2EAppData, saveE2EAppData } from '@/lib/e2eMode';
-import { reportSyncError, clearSyncError, type SyncErrorType } from '@/lib/syncStatus';
+import { reportSyncError, clearSyncError, toSyncErrorType } from '@/lib/syncStatus';
 import type { AppData } from '@/types';
 import { writeQueues, SAVE_USER_DATA_DEBOUNCE_MS, executeWrite, type SaveUserDataOptions } from './write-queue';
 
@@ -83,7 +83,13 @@ export async function saveUserData(userId: string, data: AppData, options: SaveU
       queue.pendingData = null;
       queue.pendingOptions = null;
       queue.timeoutId = null;
-      await executeWrite(userId, dataToWrite, optionsToWrite);
+      try {
+        await executeWrite(userId, dataToWrite, optionsToWrite);
+      } catch {
+        // 失敗は saveUserData が返す promise の reject と、write-queue 内の
+        // reportSaveError によるユーザー通知（issue #497）で伝達済み。
+        // ここで catch しないと未処理 Promise rejection になる
+      }
     }
   }, SAVE_USER_DATA_DEBOUNCE_MS);
 
@@ -115,16 +121,6 @@ function mergeSaveUserDataOptions(
 // onSnapshot はエラーで購読が恒久停止するため、指数バックオフで再購読する
 const RESUBSCRIBE_BASE_DELAY_MS = 1000;
 const RESUBSCRIBE_MAX_DELAY_MS = 30_000;
-
-function toSyncErrorType(error: { code?: string }): SyncErrorType {
-  if (error.code === 'permission-denied') {
-    return 'permission-denied';
-  }
-  if (error.code === 'unavailable') {
-    return 'unavailable';
-  }
-  return 'unknown';
-}
 
 export function subscribeUserData(userId: string, callback: (data: AppData) => void): () => void {
   if (isE2EMode()) {

--- a/lib/firestore/userData/write-queue.ts
+++ b/lib/firestore/userData/write-queue.ts
@@ -3,6 +3,7 @@
 
 import { deleteField, writeBatch, type FieldValue, type WriteBatch } from 'firebase/firestore';
 import { getDb, getUserDocRef, removeUndefinedFields } from '../common';
+import { reportSaveError, clearSaveError, toSyncErrorType } from '@/lib/syncStatus';
 import type { AppData } from '@/types';
 
 // デバウンス待機時間（ミリ秒）
@@ -256,6 +257,8 @@ export async function executeWrite(
       await performWrite(userId, data, options);
       queue.isWriting = false;
       queue.retryCount = 0;
+      // 保存が成功したので「保存できていない」バナーを解除する（issue #497）
+      clearSaveError();
 
       if (currentPromise) {
         currentPromise.resolve();
@@ -300,6 +303,9 @@ export async function executeWrite(
 
       queue.isWriting = false;
       console.error('Failed to save data to Firestore:', error);
+      // 全書き込みが必ず通るここで通知することで、呼び出し側の catch 漏れでも
+      // ユーザーへの通知が漏れないようにする（issue #497）
+      reportSaveError(toSyncErrorType(errorInfo));
 
       if (currentPromise) {
         currentPromise.reject(error);

--- a/lib/firestore/write-queue.test.ts
+++ b/lib/firestore/write-queue.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { getSaveError, clearSaveError } from '@/lib/syncStatus';
 import type { AppData } from '@/types';
 
 const firestoreMocks = vi.hoisted(() => {
@@ -114,5 +115,93 @@ describe('saveUserData root write behavior', () => {
 
     expect(rootWritePayloads()).toHaveLength(1);
     expect(rootWritePayloads()[0]).toEqual({ encouragementCount: 9 });
+  });
+});
+
+describe('保存失敗時のユーザー通知（issue #497）', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-11T00:00:00.000Z'));
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    clearSaveError();
+    firestoreMocks.setDoc.mockResolvedValue(undefined);
+    firestoreMocks.batch.commit.mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    const { clearWriteQueueStateForTests } = await import('./userData/write-queue');
+    clearWriteQueueStateForTests();
+    clearSaveError();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  function firestoreError(code: string): Error {
+    return Object.assign(new Error(`mock firestore error: ${code}`), { code });
+  }
+
+  it('保存が最終的に失敗したら saveError を報告し promise を reject する', async () => {
+    const { saveUserData, SAVE_USER_DATA_DEBOUNCE_MS } = await import('./userData');
+
+    firestoreMocks.batch.commit.mockRejectedValue(firestoreError('permission-denied'));
+
+    const savePromise = saveUserData('user-1', appData());
+    const rejection = expect(savePromise).rejects.toMatchObject({ code: 'permission-denied' });
+
+    await flushSaveTimers(SAVE_USER_DATA_DEBOUNCE_MS);
+    await rejection;
+
+    expect(getSaveError()).toBe('permission-denied');
+  });
+
+  it('呼び出し側が await も catch もしない経路でも saveError が報告される', async () => {
+    const { saveUserData, SAVE_USER_DATA_DEBOUNCE_MS } = await import('./userData');
+
+    firestoreMocks.batch.commit.mockRejectedValue(firestoreError('unavailable'));
+
+    // 戻り値を完全に無視する（catch 漏れの再現）。
+    // テストランナーの未処理 rejection 検出を避けるため catch だけ握る
+    void saveUserData('user-1', appData()).catch(() => {});
+
+    await flushSaveTimers(SAVE_USER_DATA_DEBOUNCE_MS);
+
+    expect(getSaveError()).toBe('unavailable');
+  });
+
+  it('リトライ対象エラー（resource-exhausted）も全リトライ失敗後に saveError を報告する', async () => {
+    const { saveUserData, SAVE_USER_DATA_DEBOUNCE_MS } = await import('./userData');
+
+    firestoreMocks.batch.commit.mockRejectedValue(firestoreError('resource-exhausted'));
+
+    const savePromise = saveUserData('user-1', appData());
+    const rejection = expect(savePromise).rejects.toMatchObject({ code: 'resource-exhausted' });
+
+    // デバウンス + 指数バックオフ（1s+2s+4s）を全て消化する
+    await flushSaveTimers(SAVE_USER_DATA_DEBOUNCE_MS);
+    await rejection;
+
+    expect(getSaveError()).toBe('unknown');
+  });
+
+  it('次の保存が成功したら saveError をクリアする', async () => {
+    const { saveUserData, SAVE_USER_DATA_DEBOUNCE_MS } = await import('./userData');
+
+    // 1回目: 失敗
+    firestoreMocks.batch.commit.mockRejectedValue(firestoreError('permission-denied'));
+    const failedSave = saveUserData('user-1', appData());
+    const rejection = expect(failedSave).rejects.toMatchObject({ code: 'permission-denied' });
+    await flushSaveTimers(SAVE_USER_DATA_DEBOUNCE_MS);
+    await rejection;
+    expect(getSaveError()).toBe('permission-denied');
+
+    // 2回目: 成功 → 「保存できていない」状態は解除される
+    firestoreMocks.batch.commit.mockResolvedValue(undefined);
+    const successSave = saveUserData('user-1', appData());
+    await flushSaveTimers(SAVE_USER_DATA_DEBOUNCE_MS);
+    await successSave;
+
+    expect(getSaveError()).toBeNull();
   });
 });

--- a/lib/syncStatus.test.ts
+++ b/lib/syncStatus.test.ts
@@ -1,7 +1,16 @@
-// Firestore購読エラーの同期状態ストアのテスト（issue #496）
+// Firestore購読エラー（issue #496）・保存エラー（issue #497）の同期状態ストアのテスト
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { getSyncError, reportSyncError, clearSyncError, subscribeSyncError } from './syncStatus';
+import {
+  getSyncError,
+  reportSyncError,
+  clearSyncError,
+  subscribeSyncError,
+  getSaveError,
+  reportSaveError,
+  clearSaveError,
+  toSyncErrorType,
+} from './syncStatus';
 
 describe('syncStatus', () => {
   beforeEach(() => {
@@ -58,5 +67,84 @@ describe('syncStatus', () => {
     reportSyncError('permission-denied');
 
     expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+describe('saveError（保存エラーチャンネル・issue #497）', () => {
+  beforeEach(() => {
+    clearSyncError();
+    clearSaveError();
+  });
+
+  it('初期状態では保存エラーがない（null）', () => {
+    expect(getSaveError()).toBeNull();
+  });
+
+  it('reportSaveError で報告したエラー種別を取得できる', () => {
+    reportSaveError('permission-denied');
+    expect(getSaveError()).toBe('permission-denied');
+  });
+
+  it('reportSaveError で購読中のリスナーが呼ばれる（subscribeSyncError を共用）', () => {
+    const listener = vi.fn();
+    subscribeSyncError(listener);
+
+    reportSaveError('unknown');
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('clearSaveError で保存エラーが消えてリスナーが呼ばれる', () => {
+    const listener = vi.fn();
+    reportSaveError('unknown');
+    subscribeSyncError(listener);
+
+    clearSaveError();
+
+    expect(getSaveError()).toBeNull();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('保存エラーと購読エラーは独立して管理される', () => {
+    reportSaveError('unknown');
+    expect(getSyncError()).toBeNull();
+
+    reportSyncError('unavailable');
+    clearSyncError();
+    // 購読エラーをクリアしても保存エラーは残る
+    expect(getSaveError()).toBe('unknown');
+
+    clearSaveError();
+    reportSyncError('unavailable');
+    // 保存エラーをクリアしても購読エラーは残る
+    expect(getSyncError()).toBe('unavailable');
+  });
+
+  it('状態が変化しないときはリスナーを呼ばない（不要な再レンダー防止）', () => {
+    const listener = vi.fn();
+    subscribeSyncError(listener);
+
+    clearSaveError(); // すでに null → 変化なし
+    expect(listener).not.toHaveBeenCalled();
+
+    reportSaveError('unknown');
+    listener.mockClear();
+    reportSaveError('unknown'); // 同じ値 → 変化なし
+    expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+describe('toSyncErrorType（エラーコード分類・購読/保存で共用）', () => {
+  it('permission-denied をそのまま分類する', () => {
+    expect(toSyncErrorType({ code: 'permission-denied' })).toBe('permission-denied');
+  });
+
+  it('unavailable をそのまま分類する', () => {
+    expect(toSyncErrorType({ code: 'unavailable' })).toBe('unavailable');
+  });
+
+  it('未知のコードや code なしは unknown に分類する', () => {
+    expect(toSyncErrorType({ code: 'resource-exhausted' })).toBe('unknown');
+    expect(toSyncErrorType({})).toBe('unknown');
   });
 });

--- a/lib/syncStatus.ts
+++ b/lib/syncStatus.ts
@@ -1,14 +1,28 @@
-// Firestore購読エラーの同期状態ストア（issue #496）
+// Firestore購読エラー（issue #496）・保存エラー（issue #497）の同期状態ストア
 // React非依存のミニストア。useSyncExternalStore から購読して
-// 「データを同期できていません」バナーの表示制御に使う。
+// 「同期できていません」「保存できませんでした」バナーの表示制御に使う。
 
 export type SyncErrorType = 'permission-denied' | 'unavailable' | 'unknown';
 
+// 購読エラー（onSnapshot 失敗）と保存エラー（write-queue 最終失敗）は
+// 原因も回復タイミングも異なるため、独立したチャンネルで管理する
 let currentError: SyncErrorType | null = null;
+let currentSaveError: SyncErrorType | null = null;
 const listeners = new Set<() => void>();
 
 function notify(): void {
   listeners.forEach((listener) => listener());
+}
+
+// Firestore のエラーコードをバナー表示用の種別に分類する（購読・保存で共用）
+export function toSyncErrorType(error: { code?: string }): SyncErrorType {
+  if (error.code === 'permission-denied') {
+    return 'permission-denied';
+  }
+  if (error.code === 'unavailable') {
+    return 'unavailable';
+  }
+  return 'unknown';
 }
 
 export function getSyncError(): SyncErrorType | null {
@@ -28,6 +42,26 @@ export function clearSyncError(): void {
     return;
   }
   currentError = null;
+  notify();
+}
+
+export function getSaveError(): SyncErrorType | null {
+  return currentSaveError;
+}
+
+export function reportSaveError(type: SyncErrorType): void {
+  if (currentSaveError === type) {
+    return;
+  }
+  currentSaveError = type;
+  notify();
+}
+
+export function clearSaveError(): void {
+  if (currentSaveError === null) {
+    return;
+  }
+  currentSaveError = null;
   notify();
 }
 


### PR DESCRIPTION
## 概要

Issue #497 の対応です。書き込みキューの最終リトライ失敗が promise の reject のみで伝達され、呼び出し側が catch していない経路ではユーザーに通知されず、サイレントなデータ未保存につながっていました。

Issue の対応案2「write-queue 側に失敗通知の機構を持たせ、呼び出し側の catch 漏れに依存しない設計」を採用し、#496 で導入した `lib/syncStatus.ts` ストアを拡張しています。

## 変更内容

- **`lib/syncStatus.ts`**: 保存エラーチャンネル（`reportSaveError` / `clearSaveError` / `getSaveError`）を追加。購読エラーとは独立管理（回復条件が異なるため）。エラーコード分類 `toSyncErrorType` を crud.ts から移動して共通化
- **`lib/firestore/userData/write-queue.ts`**: 全書き込みが必ず通る `executeWrite` の最終失敗箇所で `reportSaveError` を呼び、**呼び出し側の catch 漏れでも必ずユーザーへ通知**。次の保存成功で `clearSaveError`
- **`lib/firestore/userData/crud.ts`**: デバウンスタイマー内の `await executeWrite` が catch されておらず未処理 Promise rejection になっていたのを解消（テスト実行時に Unhandled Rejection 4件として実際に検出されたもの）
- **`components/SyncErrorBanner.tsx`**: 保存エラーを購読エラーより優先表示（データ未保存の方が深刻）。`permission-denied` は再ログイン案内
- **`hooks/useAppData.ts`**: コメントのみ。失敗した変更の扱いは「破棄してサーバー状態へ巻き戻し、通知はバナー」と明確化

## 完了条件との対応

| Issue の完了条件 | 対応 |
| --- | --- |
| 保存失敗時に必ずユーザーへ通知される（catch 漏れ経路ゼロ） | write-queue 層で通知するため、呼び出し側の catch 有無に依存しない |
| 失敗した変更の扱いが明確 | キュー内で最大3回リトライ → 最終失敗時は破棄し、useAppData がサーバー状態へ巻き戻し、バナーで「もう一度お試しください」と案内 |
| テストで最終リトライ失敗時の通知挙動を検証 | `lib/firestore/write-queue.test.ts` に4テスト追加（即時失敗・catch漏れ経路・リトライ枯渇・成功時クリア） |

## 検証

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test:run`（103ファイル・1147テスト全パス）
- [x] `npm run format:check`
- [x] chrome-devtools MCP で iPad 幅（1024×768）のバナー表示を目視確認（unknown / permission-denied の両メッセージ）

## 補足（スコープ外の既知エッジケース）

ログアウト時の `flushPendingUserDataWrites` が失敗した場合、バナーは一瞬表示されるもののログアウト後のフルリロードで消えます。ログアウトを中断すべきかは別の設計判断のため、本PRでは扱っていません。

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)