### PR TITLE
fix(firestore): removeUndefinedFieldsのserverTimestampセンチネル破壊を修正する

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -10,9 +10,10 @@ service cloud.firestore {
     // 負値・巨大値・想定外フィールドの書き込みを実行時に拒否する。
     // 上限値はクライアントには無いRules独自の安全弁（正常業務で絶対に到達しない値）。
     //
-    // 注意: createdAt / updatedAt の型は検証しない。既存クライアントは removeUndefinedFields が
-    // serverTimestamp() センチネルを map に変換したまま書き込んでおり（本番データも同形）、
-    // timestamp 型を強制すると全保存が拒否されるため。キーのホワイトリストのみ行う。
+    // 注意: createdAt / updatedAt の型は検証しない（issue #519）。修正前クライアントが
+    // serverTimestamp() センチネルを map に変換したまま書き込んだレガシーdocが本番に残っており、
+    // 古いSWキャッシュの未更新クライアントも当面 map を書き続けるため、timestamp 型を強制すると
+    // 保存が拒否される。全クライアント更新＋レガシーdoc修復の完了後に `is timestamp` を解禁できる。
 
     // 対象月: 'YYYY-MM'（月は01〜12）
     function isYearMonthText(value) {

--- a/lib/firestore/common.test.ts
+++ b/lib/firestore/common.test.ts
@@ -54,6 +54,44 @@ describe('removeUndefinedFields', () => {
     const result = removeUndefinedFields(input);
     expect(result).toEqual({}); // { a: {} } → aは空オブジェクトなので削除
   });
+
+  // issue #519: クラスインスタンス（FieldValueセンチネル・Timestamp・Date等）を
+  // プレーンオブジェクトに再構築すると、Firestore SDK がセンチネルとして認識できなくなる
+  class FieldValueLike {
+    _methodName = 'serverTimestamp';
+  }
+
+  it('serverTimestamp()センチネル相当のクラスインスタンスを同一参照のまま素通しする', () => {
+    const sentinel = new FieldValueLike();
+    const result = removeUndefinedFields({ createdAt: sentinel, a: 1 });
+    expect(result.createdAt).toBe(sentinel);
+    expect(result.a).toBe(1);
+  });
+
+  it('Timestamp相当のクラスインスタンスを同一参照のまま素通しする', () => {
+    class TimestampLike {
+      constructor(
+        public seconds: number,
+        public nanoseconds: number
+      ) {}
+    }
+    const timestamp = new TimestampLike(100, 0);
+    const result = removeUndefinedFields({ updatedAt: timestamp });
+    expect(result.updatedAt).toBe(timestamp);
+  });
+
+  it('Dateインスタンスを削除せず素通しする', () => {
+    const date = new Date('2026-06-11T00:00:00Z');
+    const result = removeUndefinedFields({ at: date });
+    expect(result.at).toBe(date);
+  });
+
+  it('ネストしたプレーンオブジェクト内のクラスインスタンスも素通しする', () => {
+    const sentinel = new FieldValueLike();
+    const result = removeUndefinedFields({ nested: { createdAt: sentinel, junk: undefined } });
+    expect(result.nested.createdAt).toBe(sentinel);
+    expect('junk' in result.nested).toBe(false);
+  });
 });
 
 describe('normalizeAppData', () => {

--- a/lib/firestore/common.ts
+++ b/lib/firestore/common.ts
@@ -17,6 +17,17 @@ export function getUserDocRef(userId: string) {
   return doc(getDb(), 'users', userId);
 }
 
+// プレーンなオブジェクトリテラル相当かを判定する。
+// serverTimestamp()のFieldValueセンチネル・Timestamp・Date等のクラスインスタンスを
+// Object.entriesで再構築するとFirestore SDKが認識できない値になるため、再帰処理から除外する（issue #519）
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
 // undefinedのフィールドを削除する関数。Firestoreはundefinedを保存できないため。
 export function removeUndefinedFields<T>(obj: T): T {
   if (obj === null || obj === undefined) {
@@ -27,13 +38,13 @@ export function removeUndefinedFields<T>(obj: T): T {
     return obj.map((item) => removeUndefinedFields(item)) as unknown as T;
   }
 
-  if (typeof obj === 'object') {
+  if (isPlainObject(obj)) {
     const cleaned: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+    for (const [key, value] of Object.entries(obj)) {
       if (value !== undefined) {
         const cleanedValue = removeUndefinedFields(value);
-        // 空のオブジェクトを削除
-        if (cleanedValue !== null && typeof cleanedValue === 'object' && !Array.isArray(cleanedValue)) {
+        // 空のプレーンオブジェクトを削除（クラスインスタンスは対象外）
+        if (isPlainObject(cleanedValue)) {
           if (Object.keys(cleanedValue).length > 0) {
             cleaned[key] = cleanedValue;
           }

--- a/lib/firestore/productionRecords.test.ts
+++ b/lib/firestore/productionRecords.test.ts
@@ -8,6 +8,14 @@ interface FirestoreTransactionMock {
 }
 
 const firestoreMocks = vi.hoisted(() => {
+  // 実SDKの Timestamp の代役。レガシーcreatedAt修復の instanceof 判定（issue #519）に使う
+  class Timestamp {
+    constructor(
+      public seconds: number,
+      public nanoseconds: number
+    ) {}
+  }
+
   const transaction: FirestoreTransactionMock = {
     get: vi.fn(),
     set: vi.fn(),
@@ -17,6 +25,7 @@ const firestoreMocks = vi.hoisted(() => {
 
   return {
     transaction,
+    Timestamp,
     getFirestore: vi.fn(() => ({ app: 'mock-firestore' })),
     collection: vi.fn((first: { path?: string } | unknown, ...segments: string[]) => {
       const basePath =
@@ -68,6 +77,7 @@ vi.mock('firebase/firestore', () => ({
   query: firestoreMocks.query,
   runTransaction: firestoreMocks.runTransaction,
   serverTimestamp: firestoreMocks.serverTimestamp,
+  Timestamp: firestoreMocks.Timestamp,
   where: firestoreMocks.where,
 }));
 
@@ -261,9 +271,10 @@ describe('saveProductionRecordMonth', () => {
   });
 
   it('preserves createdAt when updating an existing month document', async () => {
+    const existingCreatedAt = new firestoreMocks.Timestamp(100, 0);
     firestoreMocks.transaction.get.mockResolvedValue({
       exists: () => true,
-      data: () => ({ createdAt: 'existing-created-at' }),
+      data: () => ({ createdAt: existingCreatedAt }),
     });
     const { saveProductionRecordMonth } = await import('./productionRecords');
 
@@ -277,10 +288,53 @@ describe('saveProductionRecordMonth', () => {
     expect(firestoreMocks.transaction.set).toHaveBeenCalledWith(
       expect.objectContaining({ path: 'users/user-1/productionRecords/2026-08' }),
       expect.objectContaining({
-        createdAt: 'existing-created-at',
+        createdAt: existingCreatedAt,
         updatedAt: 'server-timestamp',
       })
     );
+  });
+
+  // issue #519: 旧removeUndefinedFieldsのバグでmapとして保存されたcreatedAtは
+  // Timestampとして読み戻せないため、編集時にserverTimestamp()で振り直して自然修復する
+  it('replaces a legacy map-shaped createdAt with serverTimestamp (issue #519)', async () => {
+    firestoreMocks.transaction.get.mockResolvedValue({
+      exists: () => true,
+      data: () => ({ createdAt: { _methodName: 'serverTimestamp' } }),
+    });
+    const { saveProductionRecordMonth } = await import('./productionRecords');
+
+    await saveProductionRecordMonth('user-1', {
+      month: '2026-08',
+      greenBeanTotalGram: 30000,
+      powderPerPackGram: 8.5,
+      blendItems: [{ beanName: 'ブラジル', ratioPercent: 100 }],
+    });
+
+    expect(firestoreMocks.transaction.set).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ createdAt: 'server-timestamp', updatedAt: 'server-timestamp' })
+    );
+  });
+
+  // 旧クライアント（古いSWキャッシュ）がTimestampを{seconds,nanoseconds}のmapに
+  // 破壊した場合は、真の作成時刻を持つためTimestampとして復元する
+  it('rebuilds a flattened {seconds, nanoseconds} createdAt as a Timestamp (issue #519)', async () => {
+    firestoreMocks.transaction.get.mockResolvedValue({
+      exists: () => true,
+      data: () => ({ createdAt: { seconds: 1748500000, nanoseconds: 5 } }),
+    });
+    const { saveProductionRecordMonth } = await import('./productionRecords');
+
+    await saveProductionRecordMonth('user-1', {
+      month: '2026-08',
+      greenBeanTotalGram: 30000,
+      powderPerPackGram: 8.5,
+      blendItems: [{ beanName: 'ブラジル', ratioPercent: 100 }],
+    });
+
+    const savedData = firestoreMocks.transaction.set.mock.calls[0][1] as { createdAt: unknown };
+    expect(savedData.createdAt).toBeInstanceOf(firestoreMocks.Timestamp);
+    expect(savedData.createdAt).toMatchObject({ seconds: 1748500000, nanoseconds: 5 });
   });
 });
 
@@ -443,9 +497,10 @@ describe('saveHandpickEntry', () => {
   });
 
   it('preserves createdAt when overwriting an existing record (same key)', async () => {
+    const existingCreatedAt = new firestoreMocks.Timestamp(100, 0);
     firestoreMocks.transaction.get.mockResolvedValue({
       exists: () => true,
-      data: () => ({ createdAt: 'existing-created-at' }),
+      data: () => ({ createdAt: existingCreatedAt }),
     });
     const { saveHandpickEntry } = await import('./productionRecords');
 
@@ -459,8 +514,49 @@ describe('saveHandpickEntry', () => {
 
     expect(firestoreMocks.transaction.set).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ createdAt: 'existing-created-at', updatedAt: 'server-timestamp' })
+      expect.objectContaining({ createdAt: existingCreatedAt, updatedAt: 'server-timestamp' })
     );
+  });
+
+  it('replaces a legacy map-shaped createdAt with serverTimestamp (issue #519)', async () => {
+    firestoreMocks.transaction.get.mockResolvedValue({
+      exists: () => true,
+      data: () => ({ createdAt: { _methodName: 'serverTimestamp' } }),
+    });
+    const { saveHandpickEntry } = await import('./productionRecords');
+
+    await saveHandpickEntry('user-1', '2026-08', {
+      workDate: '2026-08-10',
+      beanName: 'ブラジル',
+      segment: 'first',
+      greenBeanWeightGram: 10000,
+      defectBeanWeightGram: 300,
+    });
+
+    expect(firestoreMocks.transaction.set).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ createdAt: 'server-timestamp', updatedAt: 'server-timestamp' })
+    );
+  });
+
+  it('rebuilds a flattened {seconds, nanoseconds} createdAt as a Timestamp (issue #519)', async () => {
+    firestoreMocks.transaction.get.mockResolvedValue({
+      exists: () => true,
+      data: () => ({ createdAt: { seconds: 1748500000, nanoseconds: 5 } }),
+    });
+    const { saveHandpickEntry } = await import('./productionRecords');
+
+    await saveHandpickEntry('user-1', '2026-08', {
+      workDate: '2026-08-10',
+      beanName: 'ブラジル',
+      segment: 'first',
+      greenBeanWeightGram: 10000,
+      defectBeanWeightGram: 300,
+    });
+
+    const savedData = firestoreMocks.transaction.set.mock.calls[0][1] as { createdAt: unknown };
+    expect(savedData.createdAt).toBeInstanceOf(firestoreMocks.Timestamp);
+    expect(savedData.createdAt).toMatchObject({ seconds: 1748500000, nanoseconds: 5 });
   });
 
   it('deletes the previous doc when editing changes the key (rekey)', async () => {
@@ -583,6 +679,25 @@ describe('saveRoastEntry', () => {
     expect(firestoreMocks.transaction.delete).not.toHaveBeenCalled();
   });
 
+  it('replaces a legacy map-shaped createdAt with serverTimestamp (issue #519)', async () => {
+    firestoreMocks.transaction.get.mockResolvedValue({
+      exists: () => true,
+      data: () => ({ createdAt: { _methodName: 'serverTimestamp' } }),
+    });
+    const { saveRoastEntry } = await import('./productionRecords');
+
+    await saveRoastEntry('user-1', '2026-08', {
+      workDate: '2026-08-10',
+      beforeRoastWeightGram: 10000,
+      afterRoastWeightGram: 8200,
+    });
+
+    expect(firestoreMocks.transaction.set).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ createdAt: 'server-timestamp', updatedAt: 'server-timestamp' })
+    );
+  });
+
   it('deletes the previous doc when the work date changes (rekey)', async () => {
     const { saveRoastEntry } = await import('./productionRecords');
 
@@ -692,6 +807,25 @@ describe('savePackageEntry', () => {
       }
     );
     expect(firestoreMocks.transaction.delete).not.toHaveBeenCalled();
+  });
+
+  it('replaces a legacy map-shaped createdAt with serverTimestamp (issue #519)', async () => {
+    firestoreMocks.transaction.get.mockResolvedValue({
+      exists: () => true,
+      data: () => ({ createdAt: { _methodName: 'serverTimestamp' } }),
+    });
+    const { savePackageEntry } = await import('./productionRecords');
+
+    await savePackageEntry('user-1', '2026-08', {
+      workDate: '2026-08-10',
+      teamA: { goodCount: 120, defectiveCount: 4 },
+      teamB: { goodCount: 90, defectiveCount: 2 },
+    });
+
+    expect(firestoreMocks.transaction.set).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ createdAt: 'server-timestamp', updatedAt: 'server-timestamp' })
+    );
   });
 
   it('deletes the previous doc when the work date changes (rekey)', async () => {

--- a/lib/firestore/productionRecords.ts
+++ b/lib/firestore/productionRecords.ts
@@ -8,6 +8,7 @@ import {
   query,
   runTransaction,
   serverTimestamp,
+  Timestamp,
   type DocumentData,
   type Unsubscribe,
 } from 'firebase/firestore';
@@ -39,6 +40,25 @@ function assertValidMonth(month: string): void {
   if (!isValidProductionMonth(month)) {
     throw new Error('対象月が正しくありません');
   }
+}
+
+/**
+ * 既存docのcreatedAtを保持しつつ、レガシーデータを修復する（issue #519）。
+ * 旧removeUndefinedFieldsのバグで保存されたcreatedAtには2形ある:
+ * - {_methodName:'serverTimestamp'}: 時刻情報なし → serverTimestamp()で振り直す
+ * - {seconds, nanoseconds}: Timestampが破壊された形。真の作成時刻を持つ → Timestampに復元する
+ */
+function restoreCreatedAt(value: unknown) {
+  if (value instanceof Timestamp) {
+    return value;
+  }
+  if (value && typeof value === 'object') {
+    const { seconds, nanoseconds } = value as { seconds?: unknown; nanoseconds?: unknown };
+    if (typeof seconds === 'number' && typeof nanoseconds === 'number') {
+      return new Timestamp(seconds, nanoseconds);
+    }
+  }
+  return serverTimestamp();
 }
 
 export function getProductionRecordsCollectionRef(userId: string) {
@@ -129,7 +149,7 @@ export async function saveProductionRecordMonth(userId: string, input: Productio
       docRef,
       removeUndefinedFields({
         ...record,
-        createdAt: existingData?.createdAt ?? serverTimestamp(),
+        createdAt: restoreCreatedAt(existingData?.createdAt),
         updatedAt: serverTimestamp(),
       })
     );
@@ -241,7 +261,7 @@ export async function saveHandpickEntry(
     if (previousId && previousId !== id && snapshot.exists()) {
       throw new Error('同じ日付・区分・豆名の記録が既にあります。先にそちらを確認してください');
     }
-    const createdAt = snapshot.exists() ? (snapshot.data()?.createdAt ?? serverTimestamp()) : serverTimestamp();
+    const createdAt = restoreCreatedAt(snapshot.data()?.createdAt);
     if (previousId && previousId !== id) {
       transaction.delete(doc(colRef, previousId));
     }
@@ -315,7 +335,7 @@ export async function saveRoastEntry(
     if (previousId && previousId !== id && snapshot.exists()) {
       throw new Error('同じ日付の焙煎記録が既にあります。先にそちらを確認してください');
     }
-    const createdAt = snapshot.exists() ? (snapshot.data()?.createdAt ?? serverTimestamp()) : serverTimestamp();
+    const createdAt = restoreCreatedAt(snapshot.data()?.createdAt);
     if (previousId && previousId !== id) {
       transaction.delete(doc(colRef, previousId));
     }
@@ -398,7 +418,7 @@ export async function savePackageEntry(
     if (previousId && previousId !== id && snapshot.exists()) {
       throw new Error('同じ日付のパッケージ記録が既にあります。先にそちらを確認してください');
     }
-    const createdAt = snapshot.exists() ? (snapshot.data()?.createdAt ?? serverTimestamp()) : serverTimestamp();
+    const createdAt = restoreCreatedAt(snapshot.data()?.createdAt);
     if (previousId && previousId !== id) {
       transaction.delete(doc(colRef, previousId));
     }


### PR DESCRIPTION
## 概要

Issue #519 の対応です。`removeUndefinedFields` が `serverTimestamp()` センチネルや `Timestamp` インスタンスを `Object.entries` でプレーンmapに再構築してしまい、**本番の生産記録の `createdAt` / `updatedAt` がタイムスタンプとして保存されていない**バグをTDD（RED→GREEN）で修正しました。

## 変更内容

### lib/firestore/common.ts
- `isPlainObject`（プロトタイプ判定）を追加し、`removeUndefinedFields` は**プレーンオブジェクトのみ**再帰・空オブジェクト削除の対象にする
- クラスインスタンス（FieldValueセンチネル・`Timestamp`・`Date` 等）は**同一参照のまま素通し** → Firestore SDK が正しくセンチネル/タイムスタンプとして扱える

### lib/firestore/productionRecords.ts
- `restoreCreatedAt` を追加し、4つの保存関数（月doc / handpick / roast / package）で既存docの `createdAt` を修復:
  - `Timestamp` インスタンス → そのまま保持
  - `{seconds, nanoseconds}` 形（旧クライアントがTimestampを破壊した形）→ 真の作成時刻を持つため `new Timestamp()` で**復元**
  - `{_methodName:''serverTimestamp''}` 形（時刻情報なし）→ `serverTimestamp()` で振り直し
- 編集保存のたびにレガシーdocが自然修復されます

### firestore.rules（コメントのみ）
- 型検証を入れない理由と、将来 `is timestamp` を解禁できる条件（全クライアント更新＋レガシーdoc修復完了）を明記

## 一括移行の判断（issueの対応案3）

本番のレガシーdocを調査した結果、**生産記録のエントリはごく少数**（2026-06は各サブコレクション1件のみ）のため、一括移行ツールは作らず編集時の自然修復で対応します。

**移行期の既知の制約**: `orderBy(''createdAt'')` の型順序により、未修復のレガシーdoc（map）は新規doc（timestamp）より上に並びます。該当docを一度編集保存すれば解消します。なお、Firestoreのdocメタデータ `createTime` に真の作成時刻が残っているため、依頼があれば既存数件を直接修復して完全復元することも可能です（本番データ変更のため明示依頼があった場合のみ実施）。

## 検証

- `npm run test:run`: 1157 passed（`removeUndefinedFields` の素通し4テスト + 保存関数の修復6テストを追加）
- `npm run test:rules`: 45 passed（回帰なし）
- `npm run typecheck` / `npm run lint` / `npm run format:check`: すべてパス
- multi-agentコードレビュー（7観点）実施済み。指摘のうち「{seconds,nanoseconds}形の復元」「rulesコメントの陳腐化」を採用、「workDate由来の近似復元」は複雑さに見合わないため不採用

関連: #498 / #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)