### PR TITLE
chore(#508): firestore.rules の allow false ブロックに経緯コメントを追記

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -144,6 +144,9 @@ service cloud.firestore {
     }
 
     // 担当表機能（ルート直下は無効化）
+    // 設計当初からデータは /users/{userId}/ 配下に置く構造のため、
+    // ルート直下コレクションへの誤アクセスを明示的に拒否する。
+    // 実際のアクセス許可は下記「担当表機能（ユーザー配下）」を参照。
     match /teams/{teamId} {
       allow read, write: if false;
     }
@@ -224,7 +227,8 @@ service cloud.firestore {
       allow read, write: if isOwner(userId);
     }
 
-    // メタ情報（サーバー時刻取得など）
+    // グローバル _meta（ルート直下）は使用していない。
+    // サーバー時刻取得などのメタ情報は /users/{userId}/_meta/{docId} を使用する（上記参照）。
     match /_meta/{document=**} {
       allow read, write: if false;
     }


### PR DESCRIPTION
## 概要

Issue #508 の3項目を調査・対応しました。

## 対応内容

### Item 3（本PR）: firestore.rules ルート直下 `allow false` ブロックへの経緯コメント追記

- **担当表コレクション群（ルート直下）**: 設計当初から `/users/{userId}/` 配下にデータを置く構造のため、ルート直下への誤アクセスを明示的に拒否している旨を明記
- **`/_meta/{document=**}`（ルート直下）**: ユーザー配下の `/users/{userId}/_meta/{docId}` を使用しており、グローバルパスは未使用である旨を明記

### Item 1（調査結果: 解消済み）

`getCurrentMonth()` / `getTodayDate()` は #499 リファクタリング時に `lib/productionRecords.ts` の `getTodayWorkDate` として統合済み。対応不要。

### Item 2（調査結果: 対応不要）

uuid override の3エントリはすべて現役：
- `firebase-tools → uuid: 11.1.1`（firebase-tools が要求）
- `gaxios → uuid: 11.1.1`（gaxios が要求）
- `universal-analytics → uuid: 14.0.0`（`universal-analytics@0.5.4` が `uuid@^14` を要求するため削除不可）

## 検証

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test:run` ✅（103 files / 1159 tests pass）

Closes #508