### PR TITLE
refactor: TastingSessionList / defect-beans のフィルタ・ソートロジックを lib へ抽出 (#502)

### DIFF
--- a/app/defect-beans/page.tsx
+++ b/app/defect-beans/page.tsx
@@ -17,9 +17,8 @@ import { Loading } from '@/components/Loading';
 import { FilterMenu } from '@/components/defect-beans/FilterMenu';
 import { EmptyState } from '@/components/defect-beans/EmptyState';
 import type { DefectBean } from '@/types';
-
-type FilterOption = 'all' | 'shouldRemove' | 'shouldNotRemove';
-type SortOption = 'default' | 'createdAtDesc' | 'createdAtAsc' | 'nameAsc' | 'nameDesc';
+import { filterAndSortDefectBeans } from '@/lib/defectBeans';
+import type { DefectBeanFilterOption as FilterOption, DefectBeanSortOption as SortOption } from '@/lib/defectBeans';
 
 export default function DefectBeansPage() {
   const { user, loading: authLoading } = useAuth();
@@ -36,64 +35,11 @@ export default function DefectBeansPage() {
   const [compareMode, setCompareMode] = useState(false);
   const [sortOption, setSortOption] = useState<SortOption>('default');
 
-  // フィルタリングと検索（Hooksは早期リターンの前に呼び出す必要がある）
-  const filteredDefectBeans = useMemo(() => {
-    let filtered = [...allDefectBeans];
-
-    // 検索フィルタ
-    if (searchQuery.trim()) {
-      const query = searchQuery.toLowerCase();
-      filtered = filtered.filter(
-        (bean) =>
-          bean.name.toLowerCase().includes(query) ||
-          bean.characteristics.toLowerCase().includes(query) ||
-          bean.tasteImpact.toLowerCase().includes(query) ||
-          bean.removalReason.toLowerCase().includes(query)
-      );
-    }
-
-    // 設定フィルタ
-    if (filterOption === 'shouldRemove') {
-      filtered = filtered.filter((bean) => settings[bean.id]?.shouldRemove === true);
-    } else if (filterOption === 'shouldNotRemove') {
-      filtered = filtered.filter((bean) => settings[bean.id]?.shouldRemove === false);
-    }
-
-    // ソート
-    if (sortOption === 'default') {
-      // デフォルト（マスターを先に、その後ユーザー追加）
-      filtered.sort((a, b) => {
-        if (a.isMaster && !b.isMaster) return -1;
-        if (!a.isMaster && b.isMaster) return 1;
-        if (a.order !== undefined && b.order !== undefined) {
-          return a.order - b.order;
-        }
-        return a.name.localeCompare(b.name, 'ja');
-      });
-    } else if (sortOption === 'createdAtDesc') {
-      // 新しい順（作成日時降順）
-      filtered.sort((a, b) => {
-        const dateA = new Date(a.createdAt).getTime();
-        const dateB = new Date(b.createdAt).getTime();
-        return dateB - dateA;
-      });
-    } else if (sortOption === 'createdAtAsc') {
-      // 古い順（作成日時昇順）
-      filtered.sort((a, b) => {
-        const dateA = new Date(a.createdAt).getTime();
-        const dateB = new Date(b.createdAt).getTime();
-        return dateA - dateB;
-      });
-    } else if (sortOption === 'nameAsc') {
-      // 名前昇順
-      filtered.sort((a, b) => a.name.localeCompare(b.name, 'ja'));
-    } else if (sortOption === 'nameDesc') {
-      // 名前降順
-      filtered.sort((a, b) => b.name.localeCompare(a.name, 'ja'));
-    }
-
-    return filtered;
-  }, [allDefectBeans, searchQuery, filterOption, settings, sortOption]);
+  // フィルタリング・ソート（Hooksは早期リターンの前に呼び出す必要がある）
+  const filteredDefectBeans = useMemo(
+    () => filterAndSortDefectBeans(allDefectBeans, searchQuery, filterOption, settings, sortOption),
+    [allDefectBeans, searchQuery, filterOption, settings, sortOption]
+  );
 
   // 2つ選択されたら自動的に比較を表示
   useEffect(() => {

--- a/hooks/useTastingFilters.ts
+++ b/hooks/useTastingFilters.ts
@@ -1,9 +1,6 @@
 import { useState, useMemo } from 'react';
 import type { TastingSession } from '@/types';
-import {
-  filterAndSortTastingSessions,
-  countActiveTastingFilters,
-} from '@/lib/tastingFilters';
+import { filterAndSortTastingSessions, countActiveTastingFilters } from '@/lib/tastingFilters';
 import type { TastingSortOption, RoastLevel } from '@/lib/tastingFilters';
 
 export function useTastingFilters(sessions: TastingSession[]) {
@@ -14,8 +11,7 @@ export function useTastingFilters(sessions: TastingSession[]) {
   const [selectedRoastLevels, setSelectedRoastLevels] = useState<RoastLevel[]>([]);
 
   const filteredAndSortedSessions = useMemo(
-    () =>
-      filterAndSortTastingSessions(sessions, { searchQuery, sortOption, dateFrom, dateTo, selectedRoastLevels }),
+    () => filterAndSortTastingSessions(sessions, { searchQuery, sortOption, dateFrom, dateTo, selectedRoastLevels }),
     [sessions, searchQuery, sortOption, dateFrom, dateTo, selectedRoastLevels]
   );
 

--- a/hooks/useTastingFilters.ts
+++ b/hooks/useTastingFilters.ts
@@ -1,66 +1,28 @@
 import { useState, useMemo } from 'react';
 import type { TastingSession } from '@/types';
-
-type SortOption = 'newest' | 'oldest' | 'beanName';
+import {
+  filterAndSortTastingSessions,
+  countActiveTastingFilters,
+} from '@/lib/tastingFilters';
+import type { TastingSortOption, RoastLevel } from '@/lib/tastingFilters';
 
 export function useTastingFilters(sessions: TastingSession[]) {
   const [searchQuery, setSearchQuery] = useState('');
-  const [sortOption, setSortOption] = useState<SortOption>('newest');
+  const [sortOption, setSortOption] = useState<TastingSortOption>('newest');
   const [dateFrom, setDateFrom] = useState('');
   const [dateTo, setDateTo] = useState('');
-  const [selectedRoastLevels, setSelectedRoastLevels] = useState<Array<'浅煎り' | '中煎り' | '中深煎り' | '深煎り'>>(
-    []
+  const [selectedRoastLevels, setSelectedRoastLevels] = useState<RoastLevel[]>([]);
+
+  const filteredAndSortedSessions = useMemo(
+    () =>
+      filterAndSortTastingSessions(sessions, { searchQuery, sortOption, dateFrom, dateTo, selectedRoastLevels }),
+    [sessions, searchQuery, sortOption, dateFrom, dateTo, selectedRoastLevels]
   );
 
-  // フィルタリングとソート
-  const filteredAndSortedSessions = useMemo(() => {
-    let filtered = [...sessions];
-
-    // 検索フィルタ
-    if (searchQuery.trim()) {
-      const query = searchQuery.toLowerCase();
-      filtered = filtered.filter((session) => session.beanName.toLowerCase().includes(query));
-    }
-
-    // 日付範囲フィルタ
-    if (dateFrom) {
-      filtered = filtered.filter((session) => session.createdAt >= dateFrom);
-    }
-    if (dateTo) {
-      filtered = filtered.filter((session) => session.createdAt <= `${dateTo}T23:59:59.999Z`);
-    }
-
-    // 焙煎度合いフィルタ
-    if (selectedRoastLevels.length > 0) {
-      filtered = filtered.filter((session) => selectedRoastLevels.includes(session.roastLevel));
-    }
-
-    // ソート
-    filtered.sort((a, b) => {
-      switch (sortOption) {
-        case 'newest':
-          return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-        case 'oldest':
-          return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
-        case 'beanName':
-          return a.beanName.localeCompare(b.beanName, 'ja');
-        default:
-          return 0;
-      }
-    });
-
-    return filtered;
-  }, [sessions, searchQuery, sortOption, dateFrom, dateTo, selectedRoastLevels]);
-
-  // アクティブなフィルターの数を計算
-  const activeFilterCount = useMemo(() => {
-    let count = 0;
-    if (searchQuery.trim()) count++;
-    if (dateFrom) count++;
-    if (dateTo) count++;
-    if (selectedRoastLevels.length > 0) count++;
-    return count;
-  }, [searchQuery, dateFrom, dateTo, selectedRoastLevels]);
+  const activeFilterCount = useMemo(
+    () => countActiveTastingFilters({ searchQuery, dateFrom, dateTo, selectedRoastLevels }),
+    [searchQuery, dateFrom, dateTo, selectedRoastLevels]
+  );
 
   return {
     searchQuery,

--- a/lib/defectBeans.test.ts
+++ b/lib/defectBeans.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { filterDefectBeans, sortDefectBeans, filterAndSortDefectBeans } from './defectBeans';
+import type { DefectBean, DefectBeanSettings } from '@/types';
+
+const makeBean = (overrides: Partial<DefectBean> & { id: string; name: string }): DefectBean => ({
+  imageUrl: '',
+  characteristics: '',
+  tasteImpact: '',
+  removalReason: '',
+  isMaster: false,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  ...overrides,
+});
+
+const beanA = makeBean({ id: 'a', name: 'アフリカ豆', characteristics: '果実味', isMaster: true, order: 1, createdAt: '2026-01-01T00:00:00.000Z' });
+const beanB = makeBean({ id: 'b', name: 'ブラジル豆', tasteImpact: '苦味強め', isMaster: false, order: 2, createdAt: '2026-02-01T00:00:00.000Z' });
+const beanC = makeBean({ id: 'c', name: 'コロンビア豆', removalReason: '発酵臭', isMaster: false, createdAt: '2026-03-01T00:00:00.000Z' });
+
+describe('filterDefectBeans', () => {
+  it('検索クエリなし・フィルタall のとき全件返す', () => {
+    const result = filterDefectBeans([beanA, beanB, beanC], '', 'all', {});
+    expect(result).toHaveLength(3);
+  });
+
+  it('名前で絞り込める', () => {
+    const result = filterDefectBeans([beanA, beanB, beanC], 'ブラジル', 'all', {});
+    expect(result.map((b) => b.id)).toEqual(['b']);
+  });
+
+  it('characteristics で絞り込める', () => {
+    const result = filterDefectBeans([beanA, beanB, beanC], '果実', 'all', {});
+    expect(result.map((b) => b.id)).toEqual(['a']);
+  });
+
+  it('tasteImpact で絞り込める', () => {
+    const result = filterDefectBeans([beanA, beanB, beanC], '苦味', 'all', {});
+    expect(result.map((b) => b.id)).toEqual(['b']);
+  });
+
+  it('removalReason で絞り込める', () => {
+    const result = filterDefectBeans([beanA, beanB, beanC], '発酵', 'all', {});
+    expect(result.map((b) => b.id)).toEqual(['c']);
+  });
+
+  it('大文字小文字を無視して絞り込める', () => {
+    const bean = makeBean({ id: 'x', name: 'Bean X', characteristics: 'Fruity' });
+    const result = filterDefectBeans([bean], 'fruity', 'all', {});
+    expect(result).toHaveLength(1);
+  });
+
+  it('空白のみのクエリは全件返す', () => {
+    const result = filterDefectBeans([beanA, beanB], '   ', 'all', {});
+    expect(result).toHaveLength(2);
+  });
+
+  it('shouldRemove フィルタが機能する', () => {
+    const settings: DefectBeanSettings = { b: { shouldRemove: true } };
+    const result = filterDefectBeans([beanA, beanB, beanC], '', 'shouldRemove', settings);
+    expect(result.map((b) => b.id)).toEqual(['b']);
+  });
+
+  it('shouldNotRemove フィルタが機能する', () => {
+    const settings: DefectBeanSettings = { a: { shouldRemove: false }, b: { shouldRemove: true } };
+    const result = filterDefectBeans([beanA, beanB, beanC], '', 'shouldNotRemove', settings);
+    expect(result.map((b) => b.id)).toEqual(['a']);
+  });
+
+  it('元の配列を変更しない（immutable）', () => {
+    const original = [beanA, beanB];
+    filterDefectBeans(original, 'ブラジル', 'all', {});
+    expect(original).toHaveLength(2);
+  });
+});
+
+describe('sortDefectBeans', () => {
+  it('default: マスター豆が先、order 順', () => {
+    const result = sortDefectBeans([beanC, beanB, beanA], 'default');
+    expect(result[0].id).toBe('a');
+  });
+
+  it('createdAtDesc: 新しい順', () => {
+    const result = sortDefectBeans([beanA, beanB, beanC], 'createdAtDesc');
+    expect(result.map((b) => b.id)).toEqual(['c', 'b', 'a']);
+  });
+
+  it('createdAtAsc: 古い順', () => {
+    const result = sortDefectBeans([beanC, beanB, beanA], 'createdAtAsc');
+    expect(result.map((b) => b.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('nameAsc: 名前昇順（日本語）', () => {
+    const result = sortDefectBeans([beanC, beanA, beanB], 'nameAsc');
+    expect(result[0].name).toBe('アフリカ豆');
+  });
+
+  it('nameDesc: 名前降順（日本語）', () => {
+    const result = sortDefectBeans([beanA, beanB, beanC], 'nameDesc');
+    expect(result[0].name).toBe('ブラジル豆');
+  });
+
+  it('元の配列を変更しない（immutable）', () => {
+    const original = [beanC, beanA, beanB];
+    sortDefectBeans(original, 'nameAsc');
+    expect(original[0].id).toBe('c');
+  });
+});
+
+describe('filterAndSortDefectBeans', () => {
+  it('フィルタとソートを組み合わせて適用する', () => {
+    const settings: DefectBeanSettings = {};
+    const result = filterAndSortDefectBeans([beanC, beanB, beanA], '', 'all', settings, 'createdAtDesc');
+    expect(result.map((b) => b.id)).toEqual(['c', 'b', 'a']);
+  });
+});

--- a/lib/defectBeans.test.ts
+++ b/lib/defectBeans.test.ts
@@ -13,9 +13,29 @@ const makeBean = (overrides: Partial<DefectBean> & { id: string; name: string })
   ...overrides,
 });
 
-const beanA = makeBean({ id: 'a', name: 'アフリカ豆', characteristics: '果実味', isMaster: true, order: 1, createdAt: '2026-01-01T00:00:00.000Z' });
-const beanB = makeBean({ id: 'b', name: 'ブラジル豆', tasteImpact: '苦味強め', isMaster: false, order: 2, createdAt: '2026-02-01T00:00:00.000Z' });
-const beanC = makeBean({ id: 'c', name: 'コロンビア豆', removalReason: '発酵臭', isMaster: false, createdAt: '2026-03-01T00:00:00.000Z' });
+const beanA = makeBean({
+  id: 'a',
+  name: 'アフリカ豆',
+  characteristics: '果実味',
+  isMaster: true,
+  order: 1,
+  createdAt: '2026-01-01T00:00:00.000Z',
+});
+const beanB = makeBean({
+  id: 'b',
+  name: 'ブラジル豆',
+  tasteImpact: '苦味強め',
+  isMaster: false,
+  order: 2,
+  createdAt: '2026-02-01T00:00:00.000Z',
+});
+const beanC = makeBean({
+  id: 'c',
+  name: 'コロンビア豆',
+  removalReason: '発酵臭',
+  isMaster: false,
+  createdAt: '2026-03-01T00:00:00.000Z',
+});
 
 describe('filterDefectBeans', () => {
   it('検索クエリなし・フィルタall のとき全件返す', () => {

--- a/lib/defectBeans.ts
+++ b/lib/defectBeans.ts
@@ -1,0 +1,67 @@
+import type { DefectBean, DefectBeanSettings } from '@/types';
+
+export type DefectBeanFilterOption = 'all' | 'shouldRemove' | 'shouldNotRemove';
+export type DefectBeanSortOption = 'default' | 'createdAtDesc' | 'createdAtAsc' | 'nameAsc' | 'nameDesc';
+
+export function filterDefectBeans(
+  beans: DefectBean[],
+  searchQuery: string,
+  filterOption: DefectBeanFilterOption,
+  settings: DefectBeanSettings
+): DefectBean[] {
+  let filtered = [...beans];
+
+  if (searchQuery.trim()) {
+    const query = searchQuery.toLowerCase();
+    filtered = filtered.filter(
+      (bean) =>
+        bean.name.toLowerCase().includes(query) ||
+        bean.characteristics.toLowerCase().includes(query) ||
+        bean.tasteImpact.toLowerCase().includes(query) ||
+        bean.removalReason.toLowerCase().includes(query)
+    );
+  }
+
+  if (filterOption === 'shouldRemove') {
+    filtered = filtered.filter((bean) => settings[bean.id]?.shouldRemove === true);
+  } else if (filterOption === 'shouldNotRemove') {
+    filtered = filtered.filter((bean) => settings[bean.id]?.shouldRemove === false);
+  }
+
+  return filtered;
+}
+
+export function sortDefectBeans(beans: DefectBean[], sortOption: DefectBeanSortOption): DefectBean[] {
+  const sorted = [...beans];
+
+  if (sortOption === 'default') {
+    sorted.sort((a, b) => {
+      if (a.isMaster && !b.isMaster) return -1;
+      if (!a.isMaster && b.isMaster) return 1;
+      if (a.order !== undefined && b.order !== undefined) {
+        return a.order - b.order;
+      }
+      return a.name.localeCompare(b.name, 'ja');
+    });
+  } else if (sortOption === 'createdAtDesc') {
+    sorted.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  } else if (sortOption === 'createdAtAsc') {
+    sorted.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+  } else if (sortOption === 'nameAsc') {
+    sorted.sort((a, b) => a.name.localeCompare(b.name, 'ja'));
+  } else if (sortOption === 'nameDesc') {
+    sorted.sort((a, b) => b.name.localeCompare(a.name, 'ja'));
+  }
+
+  return sorted;
+}
+
+export function filterAndSortDefectBeans(
+  beans: DefectBean[],
+  searchQuery: string,
+  filterOption: DefectBeanFilterOption,
+  settings: DefectBeanSettings,
+  sortOption: DefectBeanSortOption
+): DefectBean[] {
+  return sortDefectBeans(filterDefectBeans(beans, searchQuery, filterOption, settings), sortOption);
+}

--- a/lib/tastingFilters.test.ts
+++ b/lib/tastingFilters.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import {
+  filterTastingSessions,
+  sortTastingSessions,
+  filterAndSortTastingSessions,
+  countActiveTastingFilters,
+} from './tastingFilters';
+import type { TastingSession } from '@/types';
+
+const makeSession = (overrides: Partial<TastingSession> & { id: string; beanName: string }): TastingSession => ({
+  roastLevel: '中煎り',
+  memo: '',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  userId: 'user1',
+  ...overrides,
+});
+
+const sessionA = makeSession({ id: 'a', beanName: 'エチオピア', roastLevel: '浅煎り', createdAt: '2026-01-01T00:00:00.000Z' });
+const sessionB = makeSession({ id: 'b', beanName: 'ブラジル', roastLevel: '中煎り', createdAt: '2026-02-01T00:00:00.000Z' });
+const sessionC = makeSession({ id: 'c', beanName: 'グアテマラ', roastLevel: '深煎り', createdAt: '2026-03-01T00:00:00.000Z' });
+
+describe('filterTastingSessions', () => {
+  it('クエリなし・dateFrom/To なし・roastLevels なしで全件返す', () => {
+    const result = filterTastingSessions([sessionA, sessionB, sessionC], '', '', '', []);
+    expect(result).toHaveLength(3);
+  });
+
+  it('豆名で絞り込める', () => {
+    const result = filterTastingSessions([sessionA, sessionB, sessionC], 'ブラジル', '', '', []);
+    expect(result.map((s) => s.id)).toEqual(['b']);
+  });
+
+  it('大文字小文字を無視して絞り込める', () => {
+    const s = makeSession({ id: 'x', beanName: 'Ethiopia' });
+    const result = filterTastingSessions([s], 'ethiopia', '', '', []);
+    expect(result).toHaveLength(1);
+  });
+
+  it('空白のみのクエリは全件返す', () => {
+    const result = filterTastingSessions([sessionA, sessionB], '   ', '', '', []);
+    expect(result).toHaveLength(2);
+  });
+
+  it('dateFrom で絞り込める', () => {
+    const result = filterTastingSessions([sessionA, sessionB, sessionC], '', '2026-02-01', '', []);
+    expect(result.map((s) => s.id)).toEqual(['b', 'c']);
+  });
+
+  it('dateTo で絞り込める', () => {
+    const result = filterTastingSessions([sessionA, sessionB, sessionC], '', '', '2026-02-01', []);
+    expect(result.map((s) => s.id)).toEqual(['a', 'b']);
+  });
+
+  it('焙煎度合いで絞り込める', () => {
+    const result = filterTastingSessions([sessionA, sessionB, sessionC], '', '', '', ['浅煎り', '深煎り']);
+    expect(result.map((s) => s.id)).toEqual(['a', 'c']);
+  });
+
+  it('元の配列を変更しない（immutable）', () => {
+    const original = [sessionB, sessionA];
+    filterTastingSessions(original, 'エチオピア', '', '', []);
+    expect(original[0].id).toBe('b');
+  });
+});
+
+describe('sortTastingSessions', () => {
+  it('newest: 新しい順', () => {
+    const result = sortTastingSessions([sessionA, sessionB, sessionC], 'newest');
+    expect(result.map((s) => s.id)).toEqual(['c', 'b', 'a']);
+  });
+
+  it('oldest: 古い順', () => {
+    const result = sortTastingSessions([sessionC, sessionB, sessionA], 'oldest');
+    expect(result.map((s) => s.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('beanName: 豆名の五十音順', () => {
+    const result = sortTastingSessions([sessionC, sessionA, sessionB], 'beanName');
+    expect(result[0].beanName).toBe('エチオピア');
+  });
+
+  it('元の配列を変更しない（immutable）', () => {
+    const original = [sessionC, sessionA];
+    sortTastingSessions(original, 'newest');
+    expect(original[0].id).toBe('c');
+  });
+});
+
+describe('filterAndSortTastingSessions', () => {
+  it('フィルタとソートを組み合わせて適用する', () => {
+    const result = filterAndSortTastingSessions([sessionA, sessionB, sessionC], {
+      searchQuery: '',
+      sortOption: 'newest',
+      dateFrom: '',
+      dateTo: '',
+      selectedRoastLevels: [],
+    });
+    expect(result.map((s) => s.id)).toEqual(['c', 'b', 'a']);
+  });
+});
+
+describe('countActiveTastingFilters', () => {
+  it('なにも設定されていないと 0', () => {
+    expect(countActiveTastingFilters({ searchQuery: '', dateFrom: '', dateTo: '', selectedRoastLevels: [] })).toBe(0);
+  });
+
+  it('searchQuery のみ設定で 1', () => {
+    expect(countActiveTastingFilters({ searchQuery: 'test', dateFrom: '', dateTo: '', selectedRoastLevels: [] })).toBe(1);
+  });
+
+  it('全部設定で 4', () => {
+    expect(
+      countActiveTastingFilters({
+        searchQuery: 'test',
+        dateFrom: '2026-01-01',
+        dateTo: '2026-12-31',
+        selectedRoastLevels: ['浅煎り'],
+      })
+    ).toBe(4);
+  });
+
+  it('空白のみのクエリはカウントしない', () => {
+    expect(countActiveTastingFilters({ searchQuery: '   ', dateFrom: '', dateTo: '', selectedRoastLevels: [] })).toBe(0);
+  });
+});

--- a/lib/tastingFilters.test.ts
+++ b/lib/tastingFilters.test.ts
@@ -16,9 +16,24 @@ const makeSession = (overrides: Partial<TastingSession> & { id: string; beanName
   ...overrides,
 });
 
-const sessionA = makeSession({ id: 'a', beanName: 'エチオピア', roastLevel: '浅煎り', createdAt: '2026-01-01T00:00:00.000Z' });
-const sessionB = makeSession({ id: 'b', beanName: 'ブラジル', roastLevel: '中煎り', createdAt: '2026-02-01T00:00:00.000Z' });
-const sessionC = makeSession({ id: 'c', beanName: 'グアテマラ', roastLevel: '深煎り', createdAt: '2026-03-01T00:00:00.000Z' });
+const sessionA = makeSession({
+  id: 'a',
+  beanName: 'エチオピア',
+  roastLevel: '浅煎り',
+  createdAt: '2026-01-01T00:00:00.000Z',
+});
+const sessionB = makeSession({
+  id: 'b',
+  beanName: 'ブラジル',
+  roastLevel: '中煎り',
+  createdAt: '2026-02-01T00:00:00.000Z',
+});
+const sessionC = makeSession({
+  id: 'c',
+  beanName: 'グアテマラ',
+  roastLevel: '深煎り',
+  createdAt: '2026-03-01T00:00:00.000Z',
+});
 
 describe('filterTastingSessions', () => {
   it('クエリなし・dateFrom/To なし・roastLevels なしで全件返す', () => {
@@ -106,7 +121,9 @@ describe('countActiveTastingFilters', () => {
   });
 
   it('searchQuery のみ設定で 1', () => {
-    expect(countActiveTastingFilters({ searchQuery: 'test', dateFrom: '', dateTo: '', selectedRoastLevels: [] })).toBe(1);
+    expect(countActiveTastingFilters({ searchQuery: 'test', dateFrom: '', dateTo: '', selectedRoastLevels: [] })).toBe(
+      1
+    );
   });
 
   it('全部設定で 4', () => {
@@ -121,6 +138,8 @@ describe('countActiveTastingFilters', () => {
   });
 
   it('空白のみのクエリはカウントしない', () => {
-    expect(countActiveTastingFilters({ searchQuery: '   ', dateFrom: '', dateTo: '', selectedRoastLevels: [] })).toBe(0);
+    expect(countActiveTastingFilters({ searchQuery: '   ', dateFrom: '', dateTo: '', selectedRoastLevels: [] })).toBe(
+      0
+    );
   });
 });

--- a/lib/tastingFilters.ts
+++ b/lib/tastingFilters.ts
@@ -1,0 +1,76 @@
+import type { TastingSession } from '@/types';
+
+export type TastingSortOption = 'newest' | 'oldest' | 'beanName';
+export type RoastLevel = '浅煎り' | '中煎り' | '中深煎り' | '深煎り';
+
+export interface TastingFilterParams {
+  searchQuery: string;
+  sortOption: TastingSortOption;
+  dateFrom: string;
+  dateTo: string;
+  selectedRoastLevels: RoastLevel[];
+}
+
+export function filterTastingSessions(
+  sessions: TastingSession[],
+  searchQuery: string,
+  dateFrom: string,
+  dateTo: string,
+  selectedRoastLevels: RoastLevel[]
+): TastingSession[] {
+  let filtered = [...sessions];
+
+  if (searchQuery.trim()) {
+    const query = searchQuery.toLowerCase();
+    filtered = filtered.filter((session) => session.beanName.toLowerCase().includes(query));
+  }
+
+  if (dateFrom) {
+    filtered = filtered.filter((session) => session.createdAt >= dateFrom);
+  }
+  if (dateTo) {
+    filtered = filtered.filter((session) => session.createdAt <= `${dateTo}T23:59:59.999Z`);
+  }
+
+  if (selectedRoastLevels.length > 0) {
+    filtered = filtered.filter((session) => selectedRoastLevels.includes(session.roastLevel as RoastLevel));
+  }
+
+  return filtered;
+}
+
+export function sortTastingSessions(sessions: TastingSession[], sortOption: TastingSortOption): TastingSession[] {
+  const sorted = [...sessions];
+  sorted.sort((a, b) => {
+    switch (sortOption) {
+      case 'newest':
+        return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+      case 'oldest':
+        return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+      case 'beanName':
+        return a.beanName.localeCompare(b.beanName, 'ja');
+      default:
+        return 0;
+    }
+  });
+  return sorted;
+}
+
+export function filterAndSortTastingSessions(
+  sessions: TastingSession[],
+  params: TastingFilterParams
+): TastingSession[] {
+  return sortTastingSessions(
+    filterTastingSessions(sessions, params.searchQuery, params.dateFrom, params.dateTo, params.selectedRoastLevels),
+    params.sortOption
+  );
+}
+
+export function countActiveTastingFilters(params: Pick<TastingFilterParams, 'searchQuery' | 'dateFrom' | 'dateTo' | 'selectedRoastLevels'>): number {
+  let count = 0;
+  if (params.searchQuery.trim()) count++;
+  if (params.dateFrom) count++;
+  if (params.dateTo) count++;
+  if (params.selectedRoastLevels.length > 0) count++;
+  return count;
+}

--- a/lib/tastingFilters.ts
+++ b/lib/tastingFilters.ts
@@ -3,7 +3,7 @@ import type { TastingSession } from '@/types';
 export type TastingSortOption = 'newest' | 'oldest' | 'beanName';
 export type RoastLevel = '浅煎り' | '中煎り' | '中深煎り' | '深煎り';
 
-export interface TastingFilterParams {
+interface TastingFilterParams {
   searchQuery: string;
   sortOption: TastingSortOption;
   dateFrom: string;
@@ -66,7 +66,9 @@ export function filterAndSortTastingSessions(
   );
 }
 
-export function countActiveTastingFilters(params: Pick<TastingFilterParams, 'searchQuery' | 'dateFrom' | 'dateTo' | 'selectedRoastLevels'>): number {
+export function countActiveTastingFilters(
+  params: Pick<TastingFilterParams, 'searchQuery' | 'dateFrom' | 'dateTo' | 'selectedRoastLevels'>
+): number {
   let count = 0;
   if (params.searchQuery.trim()) count++;
   if (params.dateFrom) count++;


### PR DESCRIPTION
## Summary

- `lib/tastingFilters.ts` を新規作成。`filterTastingSessions` / `sortTastingSessions` / `filterAndSortTastingSessions` / `countActiveTastingFilters` を副作用ゼロの純粋関数として追加
- `lib/defectBeans.ts` を新規作成。`filterDefectBeans` / `sortDefectBeans` / `filterAndSortDefectBeans` を純粋関数として追加
- `hooks/useTastingFilters.ts` を lib の純粋関数を呼び出すように変更（ロジックの重複を除去）
- `app/defect-beans/page.tsx` の `useMemo` 内の直書きロジックを `filterAndSortDefectBeans` 呼び出しに置換

Closes #502

## Test plan

- [x] `lib/tastingFilters.test.ts`：17 ケース（フィルタ・ソート・組み合わせ・フィルタカウント）
- [x] `lib/defectBeans.test.ts`：17 ケース（検索・設定フィルタ・ソート5種・組み合わせ）
- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] `npm run test:run` 全 105 ファイル・1193 テスト通過
- [x] `npm run docs:check` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)