### PR TITLE
test: clock / login / schedule / tasting ページの単体テスト追加（#503）

### DIFF
--- a/app/clock/page.test.tsx
+++ b/app/clock/page.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import ClockPage from './page';
+
+const mocks = vi.hoisted(() => ({
+  useClockSettings: vi.fn(),
+  useWorkChime: vi.fn(),
+}));
+
+vi.mock('@/hooks/useClockSettings', () => ({
+  useClockSettings: () => mocks.useClockSettings(),
+}));
+
+vi.mock('@/hooks/useWorkChime', () => ({
+  useWorkChime: () => mocks.useWorkChime(),
+}));
+
+vi.mock('@/lib/clockSettings', () => ({
+  getThemeColors: () => ({
+    bg: '#fff',
+    text: '#000',
+    accent: '#666',
+    accentSub: '#999',
+    uiText: '#333',
+    dateText: '#444',
+  }),
+  getFontFamily: () => 'sans-serif',
+  getFontWidthFactor: () => 1,
+  getScaledClamp: (min: number) => `${min}rem`,
+}));
+
+vi.mock('@/components/clock/ClockHeaderNav', () => ({
+  ClockHeaderNav: () => <div>時計ヘッダーナビ</div>,
+}));
+
+vi.mock('@/components/clock/ClockSettingsModal', () => ({
+  ClockSettingsModal: () => null,
+}));
+
+vi.mock('@/components/clock/NextChimeStrip', () => ({
+  NextChimeStrip: () => null,
+}));
+
+vi.mock('@/components/clock/WorkChimeAlert', () => ({
+  WorkChimeAlert: () => null,
+}));
+
+vi.mock('@/components/clock/WorkChimeScheduleModal', () => ({
+  WorkChimeScheduleModal: () => null,
+}));
+
+const baseWorkChime = {
+  settings: { enabled: false, soundEnabled: false, periods: [] },
+  currentPeriod: null,
+  nextChime: null,
+  activeChime: null,
+  isAudioEnabled: true,
+  enableAudio: vi.fn(),
+  testWorkChime: vi.fn(),
+  updateSettings: vi.fn(),
+  dismissActiveChime: vi.fn(),
+};
+
+const baseClockSettings = {
+  settings: {
+    use24Hour: true,
+    showSeconds: true,
+    showDate: true,
+    theme: 'dark' as const,
+    fontKey: 'mono',
+    fontScale: 1,
+  },
+  isLoaded: true,
+  updateSettings: vi.fn(),
+  resetSettings: vi.fn(),
+};
+
+describe('ClockPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useClockSettings.mockReturnValue(baseClockSettings);
+    mocks.useWorkChime.mockReturnValue(baseWorkChime);
+  });
+
+  it('設定読み込み前はローディングを表示する', () => {
+    mocks.useClockSettings.mockReturnValue({ ...baseClockSettings, isLoaded: false });
+    render(<ClockPage />);
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+  });
+
+  it('設定読み込み完了後は時計ヘッダーを表示する', () => {
+    render(<ClockPage />);
+    expect(screen.getByText('時計ヘッダーナビ')).toBeInTheDocument();
+  });
+
+  it('24時間モード時にAM/PM表示をしない', () => {
+    render(<ClockPage />);
+    expect(screen.queryByText('AM')).not.toBeInTheDocument();
+    expect(screen.queryByText('PM')).not.toBeInTheDocument();
+  });
+
+  it('12時間モード時にAMまたはPMを表示する', () => {
+    mocks.useClockSettings.mockReturnValue({
+      ...baseClockSettings,
+      settings: { ...baseClockSettings.settings, use24Hour: false },
+    });
+    render(<ClockPage />);
+    const amPm = screen.queryByText('AM') ?? screen.queryByText('PM');
+    expect(amPm).toBeInTheDocument();
+  });
+});

--- a/app/login/page.test.tsx
+++ b/app/login/page.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import LoginPage from './page';
+
+const mocks = vi.hoisted(() => ({
+  signInWithEmailAndPassword: vi.fn(),
+  push: vi.fn(),
+  getSearchParam: vi.fn(),
+  showToast: vi.fn(),
+}));
+
+vi.mock('firebase/auth', () => ({
+  signInWithEmailAndPassword: mocks.signInWithEmailAndPassword,
+}));
+
+vi.mock('@/lib/firebase', () => ({
+  auth: {},
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mocks.push }),
+  useSearchParams: () => ({ get: mocks.getSearchParam }),
+}));
+
+vi.mock('@/lib/e2eMode', () => ({
+  isE2EMode: () => false,
+  E2E_EMAIL: 'e2e@test.com',
+  E2E_PASSWORD: 'e2epass',
+  signInE2EUser: vi.fn(),
+}));
+
+vi.mock('@/lib/returnUrl', () => ({
+  getSafeReturnUrl: (_url: string | null, fallback: string) => fallback,
+}));
+
+vi.mock('@/components/Toast', () => ({
+  useToastContext: () => ({ showToast: mocks.showToast }),
+}));
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSearchParam.mockReturnValue(null);
+  });
+
+  it('ログインフォームが表示される', async () => {
+    render(<LoginPage />);
+    expect(await screen.findByLabelText('メールアドレス')).toBeInTheDocument();
+    expect(screen.getByLabelText('パスワード')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'ログイン' })).toBeInTheDocument();
+  });
+
+  it('ログイン成功時にホームへリダイレクトする', async () => {
+    mocks.signInWithEmailAndPassword.mockResolvedValue({});
+    render(<LoginPage />);
+
+    fireEvent.change(await screen.findByLabelText('メールアドレス'), {
+      target: { value: 'test@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('パスワード'), { target: { value: 'password123' } });
+    fireEvent.click(screen.getByRole('button', { name: 'ログイン' }));
+
+    await waitFor(() => {
+      expect(mocks.push).toHaveBeenCalledWith('/');
+    });
+  });
+
+  it('認証エラー時にエラーメッセージを表示する', async () => {
+    mocks.signInWithEmailAndPassword.mockRejectedValue({ code: 'auth/invalid-credential' });
+    render(<LoginPage />);
+
+    fireEvent.change(await screen.findByLabelText('メールアドレス'), {
+      target: { value: 'wrong@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('パスワード'), { target: { value: 'wrongpass' } });
+    fireEvent.click(screen.getByRole('button', { name: 'ログイン' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('メールアドレスもしくはパスワードが違います')).toBeInTheDocument();
+    });
+  });
+
+  it('ネットワークエラー時に適切なエラーメッセージを表示する', async () => {
+    mocks.signInWithEmailAndPassword.mockRejectedValue({ code: 'auth/network-request-failed' });
+    render(<LoginPage />);
+
+    fireEvent.change(await screen.findByLabelText('メールアドレス'), {
+      target: { value: 'test@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('パスワード'), { target: { value: 'password123' } });
+    fireEvent.click(screen.getByRole('button', { name: 'ログイン' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('ネットワークエラーが発生しました')).toBeInTheDocument();
+    });
+  });
+});

--- a/app/schedule/page.test.tsx
+++ b/app/schedule/page.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import SchedulePage from './page';
+import type { AppData } from '@/types';
+
+const mocks = vi.hoisted(() => ({
+  useAuth: vi.fn(),
+  useAppData: vi.fn(),
+  useScheduleDateNavigation: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  useAuth: () => mocks.useAuth(),
+}));
+
+vi.mock('@/hooks/useAppData', () => ({
+  useAppData: () => mocks.useAppData(),
+}));
+
+vi.mock('@/hooks/useScheduleDateNavigation', () => ({
+  useScheduleDateNavigation: () => mocks.useScheduleDateNavigation(),
+}));
+
+vi.mock('@/hooks/useScheduleOCR', () => ({
+  useScheduleOCR: () => ({ handleOCRSuccess: vi.fn() }),
+}));
+
+vi.mock('@/components/TodaySchedule', () => ({
+  TodaySchedule: () => <div>本日スケジュール</div>,
+}));
+
+vi.mock('@/components/RoastSchedulerTab', () => ({
+  RoastSchedulerTab: () => <div>ローストスケジュール</div>,
+}));
+
+vi.mock('@/components/Loading', () => ({
+  Loading: ({ message }: { message?: string }) => <div>{message ?? '読み込み中...'}</div>,
+}));
+
+vi.mock('@/app/login/page', () => ({
+  default: () => <div>ログイン画面</div>,
+}));
+
+vi.mock('@/components/DatePickerModal', () => ({
+  DatePickerModal: () => null,
+}));
+
+vi.mock('@/components/ScheduleOCRModal', () => ({
+  ScheduleOCRModal: () => null,
+}));
+
+const baseNavigation = {
+  selectedDate: '2026-06-12',
+  setSelectedDate: vi.fn(),
+  currentTime: new Date('2026-06-12T10:00:00'),
+  isToday: true,
+  isMaxDate: false,
+  isWeekend: () => false,
+  getTodayString: () => '2026-06-12',
+  formatDateString: (d: string) => d,
+  formatTime: () => '10:00',
+  moveToPreviousDay: vi.fn(),
+  moveToNextDay: vi.fn(),
+};
+
+const baseData: AppData = {
+  todaySchedules: [],
+  roastSchedules: [],
+  tastingSessions: [],
+  tastingRecords: [],
+  notifications: [],
+  encouragementCount: 0,
+  dripRecipes: [],
+};
+
+describe('SchedulePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useAuth.mockReturnValue({ user: { uid: 'user-1' }, loading: false });
+    mocks.useAppData.mockReturnValue({ data: baseData, updateData: vi.fn(), isLoading: false });
+    mocks.useScheduleDateNavigation.mockReturnValue(baseNavigation);
+  });
+
+  it('認証ローディング中はLoading表示する', () => {
+    mocks.useAuth.mockReturnValue({ user: null, loading: true });
+    render(<SchedulePage />);
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+  });
+
+  it('未ログイン時はログイン画面を表示する', () => {
+    mocks.useAuth.mockReturnValue({ user: null, loading: false });
+    render(<SchedulePage />);
+    expect(screen.getByText('ログイン画面')).toBeInTheDocument();
+  });
+
+  it('データロード中はLoading表示する', () => {
+    mocks.useAppData.mockReturnValue({ data: baseData, updateData: vi.fn(), isLoading: true });
+    render(<SchedulePage />);
+    expect(screen.getByText('データを読み込み中...')).toBeInTheDocument();
+  });
+
+  it('ログイン済み・データ読み込み完了後はスケジュールコンテンツを表示する', () => {
+    render(<SchedulePage />);
+    // モバイル+デスクトップの両レイアウトに同じコンポーネントが表示される
+    expect(screen.getAllByText('本日スケジュール').length).toBeGreaterThan(0);
+  });
+});

--- a/app/tasting/page.test.tsx
+++ b/app/tasting/page.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import TastingPage from './page';
+import type { AppData } from '@/types';
+
+const mocks = vi.hoisted(() => ({
+  useAuth: vi.fn(),
+  useAppData: vi.fn(),
+  push: vi.fn(),
+  getSearchParam: vi.fn(),
+  showToast: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  useAuth: () => mocks.useAuth(),
+}));
+
+vi.mock('@/hooks/useAppData', () => ({
+  useAppData: () => mocks.useAppData(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mocks.push }),
+  useSearchParams: () => ({ get: mocks.getSearchParam }),
+}));
+
+vi.mock('@/components/Loading', () => ({
+  Loading: ({ message }: { message?: string }) => <div>{message ?? '読み込み中...'}</div>,
+}));
+
+vi.mock('@/components/TastingSessionList', () => ({
+  TastingSessionList: () => <div>テイスティングセッション一覧</div>,
+}));
+
+vi.mock('@/components/TastingSessionDetail', () => ({
+  TastingSessionDetail: () => <div>セッション詳細</div>,
+}));
+
+vi.mock('@/components/TastingRecordForm', () => ({
+  TastingRecordForm: () => <div>記録フォーム</div>,
+}));
+
+vi.mock('@/components/TastingSessionForm', () => ({
+  TastingSessionForm: () => <div>セッション編集フォーム</div>,
+}));
+
+vi.mock('@/components/Toast', () => ({
+  useToastContext: () => ({ showToast: mocks.showToast }),
+}));
+
+const baseData: AppData = {
+  tastingSessions: [],
+  tastingRecords: [],
+  todaySchedules: [],
+  roastSchedules: [],
+  notifications: [],
+  encouragementCount: 0,
+  dripRecipes: [],
+};
+
+describe('TastingPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useAuth.mockReturnValue({ user: { uid: 'user-1' }, loading: false });
+    mocks.useAppData.mockReturnValue({ data: baseData, updateData: vi.fn(), isLoading: false });
+    mocks.getSearchParam.mockReturnValue(null);
+  });
+
+  it('認証ローディング中はLoading表示する', () => {
+    mocks.useAuth.mockReturnValue({ user: null, loading: true });
+    render(<TastingPage />);
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+  });
+
+  it('未ログイン時は何も表示せずリダイレクトする', () => {
+    mocks.useAuth.mockReturnValue({ user: null, loading: false });
+    const { container } = render(<TastingPage />);
+    expect(mocks.push).toHaveBeenCalledWith('/login?returnUrl=/tasting');
+    expect(container.querySelector('main')).not.toBeInTheDocument();
+  });
+
+  it('データロード中はLoading表示する', () => {
+    mocks.useAppData.mockReturnValue({ data: baseData, updateData: vi.fn(), isLoading: true });
+    render(<TastingPage />);
+    expect(screen.getByText('データを読み込み中...')).toBeInTheDocument();
+  });
+
+  it('ログイン済み・デフォルト表示でTastingSessionListを表示する', () => {
+    render(<TastingPage />);
+    expect(screen.getByText('テイスティングセッション一覧')).toBeInTheDocument();
+  });
+
+  it('sessionId+edit=trueで存在しないセッションは「セッションが見つかりません」を表示する', () => {
+    mocks.getSearchParam.mockImplementation((key: string) => {
+      if (key === 'sessionId') return 'non-existent-id';
+      if (key === 'edit') return 'true';
+      return null;
+    });
+    render(<TastingPage />);
+    expect(screen.getByText('セッションが見つかりません')).toBeInTheDocument();
+  });
+
+  it('sessionIdのみで存在しないセッションは「セッションが見つかりません」を表示する', () => {
+    mocks.getSearchParam.mockImplementation((key: string) => {
+      if (key === 'sessionId') return 'non-existent-id';
+      return null;
+    });
+    render(<TastingPage />);
+    expect(screen.getByText('セッションが見つかりません')).toBeInTheDocument();
+  });
+
+  it('recordIdで存在しない記録は「記録が見つかりません」を表示する', () => {
+    mocks.getSearchParam.mockImplementation((key: string) => {
+      if (key === 'recordId') return 'non-existent-record';
+      return null;
+    });
+    render(<TastingPage />);
+    expect(screen.getByText('記録が見つかりません')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- `app/clock/page.tsx`・`app/login/page.tsx`・`app/schedule/page.tsx`・`app/tasting/page.tsx` の4ページに単体テストを追加
- 認証分岐・ローディング分岐・URLパラメータ別表示分岐・エラー表示分岐を網羅
- 計19テスト追加、全1200テスト通過

## 各テストの概要

| ページ | テスト数 | 主な検証内容 |
|---|---|---|
| clock | 4 | 設定読み込み前ローディング・24h/12hモード切替 |
| login | 4 | フォーム表示・ログイン成功・エラーコード別メッセージ |
| schedule | 4 | 認証分岐・データロード分岐・コンテンツ表示 |
| tasting | 7 | 認証分岐・未認証リダイレクト・URLパラメータ別表示分岐 |

## Test plan

- [x] `npm run test:run` — 1200 tests passed
- [x] `npm run typecheck` — エラーなし
- [x] `npm run lint` — 警告なし

Closes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)