### PR TITLE
feat: Storage アップロード後のマジックバイト検証を追加（#505）

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3,3 +3,4 @@
 
 export { ocrScheduleFromImage } from './ocr-schedule';
 export { analyzeTastingSession } from './tasting-analysis';
+export { validateUploadedImage } from './storage-image-validate';

--- a/functions/src/storage-image-validate.test.ts
+++ b/functions/src/storage-image-validate.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { isValidImageBuffer, isDefectBeanPath } from './storage-image-validate';
+
+describe('isValidImageBuffer', () => {
+  it('JPEGのマジックバイト（FF D8 FF）を持つバッファを有効と判定する', () => {
+    const buf = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46]);
+    expect(isValidImageBuffer(buf)).toBe(true);
+  });
+
+  it('PNGのマジックバイトを持つバッファを有効と判定する', () => {
+    const buf = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    expect(isValidImageBuffer(buf)).toBe(true);
+  });
+
+  it('WebPのマジックバイトを持つバッファを有効と判定する', () => {
+    const buf = Buffer.alloc(12);
+    // RIFF
+    buf[0] = 0x52;
+    buf[1] = 0x49;
+    buf[2] = 0x46;
+    buf[3] = 0x46;
+    // WEBP (offset 8)
+    buf[8] = 0x57;
+    buf[9] = 0x45;
+    buf[10] = 0x42;
+    buf[11] = 0x50;
+    expect(isValidImageBuffer(buf)).toBe(true);
+  });
+
+  it('PDFバッファ（%PDF）を無効と判定する', () => {
+    const buf = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34]);
+    expect(isValidImageBuffer(buf)).toBe(false);
+  });
+
+  it('実行ファイルバッファ（MZ）を無効と判定する', () => {
+    const buf = Buffer.from([0x4d, 0x5a, 0x90, 0x00, 0x03, 0x00, 0x00, 0x00]);
+    expect(isValidImageBuffer(buf)).toBe(false);
+  });
+
+  it('ZIPバッファを無効と判定する', () => {
+    const buf = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x14, 0x00, 0x00, 0x00]);
+    expect(isValidImageBuffer(buf)).toBe(false);
+  });
+
+  it('8バイト未満のバッファを無効と判定する', () => {
+    const buf = Buffer.from([0xff, 0xd8, 0xff]);
+    expect(isValidImageBuffer(buf)).toBe(false);
+  });
+
+  it('空バッファを無効と判定する', () => {
+    const buf = Buffer.alloc(0);
+    expect(isValidImageBuffer(buf)).toBe(false);
+  });
+
+  it('RIFFヘッダーでもWEBPマーカーがなければ無効と判定する', () => {
+    const buf = Buffer.alloc(12);
+    // RIFF
+    buf[0] = 0x52;
+    buf[1] = 0x49;
+    buf[2] = 0x46;
+    buf[3] = 0x46;
+    // AVI (not WEBP) at offset 8
+    buf[8] = 0x41;
+    buf[9] = 0x56;
+    buf[10] = 0x49;
+    buf[11] = 0x20;
+    expect(isValidImageBuffer(buf)).toBe(false);
+  });
+});
+
+describe('isDefectBeanPath', () => {
+  it('defect-beans/ 配下のパスをtrueと判定する', () => {
+    expect(isDefectBeanPath('defect-beans/user1/bean1/photo.jpg')).toBe(true);
+  });
+
+  it('defect-beans/ 直下のファイルをtrueと判定する', () => {
+    expect(isDefectBeanPath('defect-beans/user1/photo.jpg')).toBe(true);
+  });
+
+  it('defect-beans-master/ のパスをfalseと判定する', () => {
+    expect(isDefectBeanPath('defect-beans-master/photo.jpg')).toBe(false);
+  });
+
+  it('その他のパスをfalseと判定する', () => {
+    expect(isDefectBeanPath('uploads/user1/photo.jpg')).toBe(false);
+  });
+
+  it('空文字をfalseと判定する', () => {
+    expect(isDefectBeanPath('')).toBe(false);
+  });
+});

--- a/functions/src/storage-image-validate.ts
+++ b/functions/src/storage-image-validate.ts
@@ -1,0 +1,63 @@
+import { onObjectFinalized } from 'firebase-functions/v2/storage';
+import { getStorage } from 'firebase-admin/storage';
+import { logDetailedError } from './helpers';
+
+// マジックバイト定義
+const JPEG_MAGIC = [0xff, 0xd8, 0xff];
+const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+const WEBP_RIFF = [0x52, 0x49, 0x46, 0x46];
+const WEBP_MARKER = [0x57, 0x45, 0x42, 0x50];
+
+/**
+ * バッファが有効な画像かどうかをマジックバイトで確認する
+ */
+export function isValidImageBuffer(buf: Buffer): boolean {
+  if (buf.length < 8) return false;
+
+  if (JPEG_MAGIC.every((b, i) => buf[i] === b)) return true;
+  if (PNG_MAGIC.every((b, i) => buf[i] === b)) return true;
+
+  // WebP: RIFF....WEBP
+  if (
+    buf.length >= 12 &&
+    WEBP_RIFF.every((b, i) => buf[i] === b) &&
+    WEBP_MARKER.every((b, i) => buf[8 + i] === b)
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * パスが defect-beans/ 配下（マスターデータ除く）かどうかを確認する
+ */
+export function isDefectBeanPath(filePath: string): boolean {
+  return filePath.startsWith('defect-beans/') && !filePath.startsWith('defect-beans-master/');
+}
+
+/**
+ * Storage アップロード後にマジックバイトでバイナリ検証し、
+ * 非画像ファイルを削除するトリガー
+ */
+export const validateUploadedImage = onObjectFinalized(async (event) => {
+  const filePath = event.data.name;
+  if (!filePath || !isDefectBeanPath(filePath)) {
+    return;
+  }
+
+  const bucket = getStorage().bucket(event.data.bucket);
+  const file = bucket.file(filePath);
+
+  try {
+    // 先頭12バイトのみダウンロードしてマジックバイトを確認
+    const [buffer] = await file.download({ start: 0, end: 11 });
+
+    if (!isValidImageBuffer(buffer)) {
+      await file.delete();
+      console.warn(`不正なファイルを削除しました: ${filePath}`);
+    }
+  } catch (error) {
+    logDetailedError('validateUploadedImage', error, { filePath });
+  }
+});

--- a/functions/src/storage-image-validate.ts
+++ b/functions/src/storage-image-validate.ts
@@ -18,11 +18,7 @@ export function isValidImageBuffer(buf: Buffer): boolean {
   if (PNG_MAGIC.every((b, i) => buf[i] === b)) return true;
 
   // WebP: RIFF....WEBP
-  if (
-    buf.length >= 12 &&
-    WEBP_RIFF.every((b, i) => buf[i] === b) &&
-    WEBP_MARKER.every((b, i) => buf[8 + i] === b)
-  ) {
+  if (buf.length >= 12 && WEBP_RIFF.every((b, i) => buf[i] === b) && WEBP_MARKER.every((b, i) => buf[8 + i] === b)) {
     return true;
   }
 

--- a/functions/vitest.config.ts
+++ b/functions/vitest.config.ts
@@ -5,5 +5,12 @@ export default defineConfig({
     environment: 'node',
     globals: true,
     include: ['src/**/*.test.ts'],
+    env: {
+      FIREBASE_CONFIG: JSON.stringify({
+        projectId: 'roastplus-test',
+        storageBucket: 'roastplus-test.appspot.com',
+      }),
+      GCLOUD_PROJECT: 'roastplus-test',
+    },
   },
 });


### PR DESCRIPTION
## Summary

- `defect-beans/` 配下へのアップロード完了後、Cloud Functions の `onObjectFinalized` トリガーで先頭12バイト（マジックバイト）を読み取り、実バイナリが JPEG / PNG / WebP かどうかを検証する
- マジックバイトが一致しない不正ファイルは即削除する
- 既存の `storage.rules` の MIME ヘッダー検証（クライアント提供）と組み合わせた多層防御になる

## 変更ファイル

| ファイル | 内容 |
|----------|------|
| `functions/src/storage-image-validate.ts` | マジックバイト検証の純粋関数 + Storageトリガー |
| `functions/src/storage-image-validate.test.ts` | テスト14件（JPEG/PNG/WebP/PDF/EXE/ZIP/短いバッファ等） |
| `functions/src/index.ts` | `validateUploadedImage` をエクスポート追加 |
| `functions/vitest.config.ts` | テスト用 `FIREBASE_CONFIG` / `GCLOUD_PROJECT` 環境変数を追加 |

## 検証済みのマジックバイト

| 形式 | バイト列 |
|------|---------|
| JPEG | `FF D8 FF` |
| PNG | `89 50 4E 47 0D 0A 1A 0A` |
| WebP | `52 49 46 46` (RIFF) + offset 8: `57 45 42 50` (WEBP) |

## Test plan

- [x] `functions` テスト 26/26 通過（`storage-image-validate.test.ts` 14件含む）
- [x] `npm run typecheck` 0エラー
- [x] `npm run lint` 新規エラーなし
- [x] `npm run test:run` 1200/1200 通過

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)