### PR TITLE
fix: productionRecords のエラーメッセージを一元化 (#501)

### DIFF
--- a/lib/firestore/productionRecords.test.ts
+++ b/lib/firestore/productionRecords.test.ts
@@ -132,9 +132,7 @@ describe('getProductionRecordMonthDocRef', () => {
   it('rejects invalid months before building a Firestore document path', async () => {
     const { getProductionRecordMonthDocRef } = await import('./productionRecords');
 
-    expect(() => getProductionRecordMonthDocRef('user-1', '2026-13')).toThrow(
-      PRODUCTION_RECORD_ERROR_MESSAGES.month
-    );
+    expect(() => getProductionRecordMonthDocRef('user-1', '2026-13')).toThrow(PRODUCTION_RECORD_ERROR_MESSAGES.month);
   });
 });
 
@@ -161,9 +159,7 @@ describe('subcollection refs', () => {
   it('rejects invalid months when building subcollection refs', async () => {
     const { getHandpickEntriesCollectionRef } = await import('./productionRecords');
 
-    expect(() => getHandpickEntriesCollectionRef('user-1', '2026-13')).toThrow(
-      PRODUCTION_RECORD_ERROR_MESSAGES.month
-    );
+    expect(() => getHandpickEntriesCollectionRef('user-1', '2026-13')).toThrow(PRODUCTION_RECORD_ERROR_MESSAGES.month);
   });
 });
 

--- a/lib/firestore/productionRecords.test.ts
+++ b/lib/firestore/productionRecords.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PRODUCTION_RECORD_ERROR_MESSAGES } from '@/lib/productionRecords';
 
 interface FirestoreTransactionMock {
   get: ReturnType<typeof vi.fn>;
@@ -131,7 +132,9 @@ describe('getProductionRecordMonthDocRef', () => {
   it('rejects invalid months before building a Firestore document path', async () => {
     const { getProductionRecordMonthDocRef } = await import('./productionRecords');
 
-    expect(() => getProductionRecordMonthDocRef('user-1', '2026-13')).toThrow('対象月が正しくありません');
+    expect(() => getProductionRecordMonthDocRef('user-1', '2026-13')).toThrow(
+      PRODUCTION_RECORD_ERROR_MESSAGES.month
+    );
   });
 });
 
@@ -158,7 +161,9 @@ describe('subcollection refs', () => {
   it('rejects invalid months when building subcollection refs', async () => {
     const { getHandpickEntriesCollectionRef } = await import('./productionRecords');
 
-    expect(() => getHandpickEntriesCollectionRef('user-1', '2026-13')).toThrow('対象月が正しくありません');
+    expect(() => getHandpickEntriesCollectionRef('user-1', '2026-13')).toThrow(
+      PRODUCTION_RECORD_ERROR_MESSAGES.month
+    );
   });
 });
 
@@ -601,7 +606,7 @@ describe('saveHandpickEntry', () => {
         },
         'old-handpick-id'
       )
-    ).rejects.toThrow();
+    ).rejects.toThrow(PRODUCTION_RECORD_ERROR_MESSAGES.handpickEntryCollision);
     expect(firestoreMocks.transaction.set).not.toHaveBeenCalled();
     expect(firestoreMocks.transaction.delete).not.toHaveBeenCalled();
   });
@@ -731,7 +736,7 @@ describe('saveRoastEntry', () => {
         { workDate: '2026-08-11', beforeRoastWeightGram: 12000, afterRoastWeightGram: 9800 },
         '2026-08-10'
       )
-    ).rejects.toThrow();
+    ).rejects.toThrow(PRODUCTION_RECORD_ERROR_MESSAGES.roastEntryCollision);
     expect(firestoreMocks.transaction.set).not.toHaveBeenCalled();
     expect(firestoreMocks.transaction.delete).not.toHaveBeenCalled();
   });
@@ -865,7 +870,7 @@ describe('savePackageEntry', () => {
         },
         '2026-08-10'
       )
-    ).rejects.toThrow();
+    ).rejects.toThrow(PRODUCTION_RECORD_ERROR_MESSAGES.packageEntryCollision);
     expect(firestoreMocks.transaction.set).not.toHaveBeenCalled();
     expect(firestoreMocks.transaction.delete).not.toHaveBeenCalled();
   });

--- a/lib/firestore/productionRecords.ts
+++ b/lib/firestore/productionRecords.ts
@@ -14,6 +14,7 @@ import {
 } from 'firebase/firestore';
 import { getDb, removeUndefinedFields } from './common';
 import {
+  PRODUCTION_RECORD_ERROR_MESSAGES,
   buildHandpickEntry,
   buildPackageEntry,
   buildProductionRecordMonth,
@@ -45,7 +46,7 @@ const RECENT_PRODUCTION_MONTHS_LIMIT = 24;
 
 function assertValidMonth(month: string): void {
   if (!isValidProductionMonth(month)) {
-    throw new Error('対象月が正しくありません');
+    throw new Error(PRODUCTION_RECORD_ERROR_MESSAGES.month);
   }
 }
 
@@ -286,7 +287,7 @@ export async function saveHandpickEntry(
     const snapshot = await transaction.get(docRef);
     // 編集でキーを変更した先に別レコードが既にある場合、上書きするとそのデータを失うため拒否する
     if (previousId && previousId !== id && snapshot.exists()) {
-      throw new Error('同じ日付・区分・豆名の記録が既にあります。先にそちらを確認してください');
+      throw new Error(PRODUCTION_RECORD_ERROR_MESSAGES.handpickEntryCollision);
     }
     const createdAt = restoreCreatedAt(snapshot.data()?.createdAt);
     if (previousId && previousId !== id) {
@@ -362,7 +363,7 @@ export async function saveRoastEntry(
     const snapshot = await transaction.get(docRef);
     // 編集で日付を変更した先に別の焙煎記録が既にある場合、上書きするとそのデータを失うため拒否する
     if (previousId && previousId !== id && snapshot.exists()) {
-      throw new Error('同じ日付の焙煎記録が既にあります。先にそちらを確認してください');
+      throw new Error(PRODUCTION_RECORD_ERROR_MESSAGES.roastEntryCollision);
     }
     const createdAt = restoreCreatedAt(snapshot.data()?.createdAt);
     if (previousId && previousId !== id) {
@@ -446,7 +447,7 @@ export async function savePackageEntry(
     const snapshot = await transaction.get(docRef);
     // 編集で日付を変更した先に別のパッケージ記録が既にある場合、上書きするとそのデータを失うため拒否する
     if (previousId && previousId !== id && snapshot.exists()) {
-      throw new Error('同じ日付のパッケージ記録が既にあります。先にそちらを確認してください');
+      throw new Error(PRODUCTION_RECORD_ERROR_MESSAGES.packageEntryCollision);
     }
     const createdAt = restoreCreatedAt(snapshot.data()?.createdAt);
     if (previousId && previousId !== id) {

--- a/lib/productionRecords.ts
+++ b/lib/productionRecords.ts
@@ -20,16 +20,21 @@ const PREMIX_BAG_GRAM = 500;
 const THIRTY_KG_BASE_GRAM = 30000;
 export const MAX_BLEND_ITEMS = 4;
 
-const WEIGHT_INPUT_ERROR = '0以上の数値で入力してください';
-const COUNT_INPUT_ERROR = '0以上の整数で入力してください';
-const BLEND_ITEMS_ERROR = '配合は1〜4件、各比率は0以上、合計100%で入力してください';
-const MONTH_INPUT_ERROR = '対象月が正しくありません';
-const GREEN_BEAN_TOTAL_ERROR = '生豆総量は0より大きい値で入力してください';
-const POWDER_PER_PACK_ERROR = '1袋粉量は0より大きい値で入力してください';
-const WORK_DATE_ERROR = '作業日が正しくありません';
-const HANDPICK_SEGMENT_ERROR = '区分は1回目または2回目を選択してください';
-const HANDPICK_GREEN_ERROR = '今回生豆重量は0より大きい値で入力してください';
-const ROAST_WEIGHT_ERROR = '焙煎前後の重量を正しく入力してください';
+export const PRODUCTION_RECORD_ERROR_MESSAGES = {
+  weightInput: '0以上の数値で入力してください',
+  countInput: '0以上の整数で入力してください',
+  blendItems: '配合は1〜4件、各比率は0以上、合計100%で入力してください',
+  month: '対象月が正しくありません',
+  greenBeanTotal: '生豆総量は0より大きい値で入力してください',
+  powderPerPack: '1袋粉量は0より大きい値で入力してください',
+  workDate: '作業日が正しくありません',
+  handpickSegment: '区分は1回目または2回目を選択してください',
+  handpickGreen: '今回生豆重量は0より大きい値で入力してください',
+  roastWeight: '焙煎前後の重量を正しく入力してください',
+  handpickEntryCollision: '同じ日付・区分・豆名の記録が既にあります。先にそちらを確認してください',
+  roastEntryCollision: '同じ日付の焙煎記録が既にあります。先にそちらを確認してください',
+  packageEntryCollision: '同じ日付のパッケージ記録が既にあります。先にそちらを確認してください',
+} as const;
 
 export function isValidProductionMonth(month: string): boolean {
   if (!WORK_MONTH_PATTERN.test(month)) {
@@ -219,46 +224,46 @@ export function buildMonthlySummary(
 
 export function normalizeWeightInput(value: number): number {
   if (!Number.isFinite(value) || value < 0) {
-    throw new Error(WEIGHT_INPUT_ERROR);
+    throw new Error(PRODUCTION_RECORD_ERROR_MESSAGES.weightInput);
   }
   return value;
 }
 
 export function normalizeCountInput(value: number): number {
   if (!Number.isInteger(value) || value < 0) {
-    throw new Error(COUNT_INPUT_ERROR);
+    throw new Error(PRODUCTION_RECORD_ERROR_MESSAGES.countInput);
   }
   return value;
 }
 
 export function validateBlendItems(items: BlendItem[]): void {
   if (items.length < 1 || items.length > MAX_BLEND_ITEMS) {
-    throw new Error(BLEND_ITEMS_ERROR);
+    throw new Error(PRODUCTION_RECORD_ERROR_MESSAGES.blendItems);
   }
 
   let sum = 0;
   for (const item of items) {
     if (!Number.isFinite(item.ratioPercent) || item.ratioPercent < 0) {
-      throw new Error(BLEND_ITEMS_ERROR);
+      throw new Error(PRODUCTION_RECORD_ERROR_MESSAGES.blendItems);
     }
     sum += item.ratioPercent;
   }
 
   if (sum !== 100) {
-    throw new Error(BLEND_ITEMS_ERROR);
+    throw new Error(PRODUCTION_RECORD_ERROR_MESSAGES.blendItems);
   }
 }
 
 export function buildProductionRecordMonth(input: ProductionRecordMonthInput): ProductionRecordMonthInput {
   if (!isValidProductionMonth(input.month)) {
-    throw new Error(MONTH_INPUT_ERROR);
+    throw new Error(PRODUCTION_RECORD_ERROR_MESSAGES.month);
   }
   validateBlendItems(input.blendItems);
   if (!(input.greenBeanTotalGram > 0)) {
-    throw new Error(GREEN_BEAN_TOTAL_ERROR);
+    throw new Error(PRODUCTION_RECORD_ERROR_MESSAGES.greenBeanTotal);
   }
   if (!(input.powderPerPackGram > 0)) {
-    throw new Error(POWDER_PER_PACK_ERROR);
+    throw new Error(PRODUCTION_RECORD_ERROR_MESSAGES.powderPerPack);
   }
 
   return {
@@ -271,13 +276,13 @@ export function buildProductionRecordMonth(input: ProductionRecordMonthInput): P
 
 export function buildHandpickEntry(input: HandpickEntryInput): HandpickEntryInput {
   if (!isValidWorkDate(input.workDate)) {
-    throw new Error(WORK_DATE_ERROR);
+    throw new Error(PRODUCTION_RECORD_ERROR_MESSAGES.workDate);
   }
   if (input.segment !== 'first' && input.segment !== 'second') {
-    throw new Error(HANDPICK_SEGMENT_ERROR);
+    throw new Error(PRODUCTION_RECORD_ERROR_MESSAGES.handpickSegment);
   }
   if (!(input.greenBeanWeightGram > 0)) {
-    throw new Error(HANDPICK_GREEN_ERROR);
+    throw new Error(PRODUCTION_RECORD_ERROR_MESSAGES.handpickGreen);
   }
   const defectBeanWeightGram = normalizeWeightInput(input.defectBeanWeightGram);
 
@@ -292,13 +297,13 @@ export function buildHandpickEntry(input: HandpickEntryInput): HandpickEntryInpu
 
 export function buildRoastEntry(input: RoastEntryInput): RoastEntryInput {
   if (!isValidWorkDate(input.workDate)) {
-    throw new Error(WORK_DATE_ERROR);
+    throw new Error(PRODUCTION_RECORD_ERROR_MESSAGES.workDate);
   }
   if (!(input.beforeRoastWeightGram > 0) || !(input.afterRoastWeightGram > 0)) {
-    throw new Error(ROAST_WEIGHT_ERROR);
+    throw new Error(PRODUCTION_RECORD_ERROR_MESSAGES.roastWeight);
   }
   if (input.afterRoastWeightGram > input.beforeRoastWeightGram) {
-    throw new Error(ROAST_WEIGHT_ERROR);
+    throw new Error(PRODUCTION_RECORD_ERROR_MESSAGES.roastWeight);
   }
 
   return {
@@ -310,7 +315,7 @@ export function buildRoastEntry(input: RoastEntryInput): RoastEntryInput {
 
 export function buildPackageEntry(input: PackageEntryInput): PackageEntryInput {
   if (!isValidWorkDate(input.workDate)) {
-    throw new Error(WORK_DATE_ERROR);
+    throw new Error(PRODUCTION_RECORD_ERROR_MESSAGES.workDate);
   }
 
   return {


### PR DESCRIPTION
## 概要
- lib/productionRecords.ts に production record 系のエラーメッセージ定数を集約
- lib/firestore/productionRecords.ts の対象月チェックと rekey 衝突エラーを共有定数参照へ置換
- Firestore テストも共有定数を期待する形へ更新

## 対象Issue
- Closes #501

## 確認したこと
- 
pm run typecheck
- 
pm run lint
- 
pm run test:run

## 残リスク
- エラーメッセージの文言変更は productionRecords 系で一元管理されるため、他機能に同趣旨の直書きが残っていないかは別 issue での横断確認が必要

## 触らなかった範囲
- productionRecords 以外の文言定数化
- UI 表示や Firestore 保存ロジック自体の挙動変更