### PR TITLE
Firestore購読・upsertトランザクションを共通化

### DIFF
--- a/lib/firestore/productionRecords.test.ts
+++ b/lib/firestore/productionRecords.test.ts
@@ -168,6 +168,15 @@ describe('subscribeProductionRecordMonth', () => {
     vi.clearAllMocks();
   });
 
+  async function assertMonthSubscriptionRequiresOnError() {
+    const { subscribeProductionRecordMonth } = await import('./productionRecords');
+    const callback = vi.fn();
+
+    // @ts-expect-error onError is required to surface stale or unavailable production month data.
+    subscribeProductionRecordMonth('user-1', '2026-08', callback);
+  }
+  void assertMonthSubscriptionRequiresOnError;
+
   it('normalizes the month document and passes it to the callback', async () => {
     firestoreMocks.onSnapshot.mockImplementation((_ref: unknown, onNext: (snap: unknown) => void) => {
       onNext(
@@ -189,7 +198,7 @@ describe('subscribeProductionRecordMonth', () => {
     const { subscribeProductionRecordMonth } = await import('./productionRecords');
     const callback = vi.fn();
 
-    subscribeProductionRecordMonth('user-1', '2026-08', callback);
+    subscribeProductionRecordMonth('user-1', '2026-08', callback, vi.fn());
 
     expect(callback).toHaveBeenCalledWith({
       month: '2026-08',
@@ -213,7 +222,7 @@ describe('subscribeProductionRecordMonth', () => {
     const { subscribeProductionRecordMonth } = await import('./productionRecords');
     const callback = vi.fn();
 
-    subscribeProductionRecordMonth('user-1', '2026-08', callback);
+    subscribeProductionRecordMonth('user-1', '2026-08', callback, vi.fn());
 
     expect(callback).toHaveBeenCalledWith(null);
   });
@@ -344,6 +353,15 @@ describe('subscribeRecentProductionMonths', () => {
     vi.clearAllMocks();
   });
 
+  async function assertRecentMonthsSubscriptionRequiresOnError() {
+    const { subscribeRecentProductionMonths } = await import('./productionRecords');
+    const callback = vi.fn();
+
+    // @ts-expect-error onError is required to surface stale or unavailable production month lists.
+    subscribeRecentProductionMonths('user-1', callback);
+  }
+  void assertRecentMonthsSubscriptionRequiresOnError;
+
   it('queries recent months ordered by month desc with a limit of 24', async () => {
     firestoreMocks.onSnapshot.mockImplementation((_ref: unknown, onNext: (snap: unknown) => void) => {
       onNext(
@@ -365,7 +383,7 @@ describe('subscribeRecentProductionMonths', () => {
     const { subscribeRecentProductionMonths } = await import('./productionRecords');
     const callback = vi.fn();
 
-    subscribeRecentProductionMonths('user-1', callback);
+    subscribeRecentProductionMonths('user-1', callback, vi.fn());
 
     expect(firestoreMocks.orderBy).toHaveBeenCalledWith('month', 'desc');
     expect(firestoreMocks.limit).toHaveBeenCalledWith(24);
@@ -399,6 +417,21 @@ describe('subscribeRecentProductionMonths', () => {
   });
 });
 
+async function assertEntrySubscriptionsRequireOnError() {
+  const { subscribeHandpickEntries, subscribeRoastEntries, subscribePackageEntries } = await import(
+    './productionRecords'
+  );
+  const callback = vi.fn();
+
+  // @ts-expect-error onError is required to avoid silent empty states on subscription failures.
+  subscribeHandpickEntries('user-1', '2026-08', callback);
+  // @ts-expect-error onError is required to avoid silent empty states on subscription failures.
+  subscribeRoastEntries('user-1', '2026-08', callback);
+  // @ts-expect-error onError is required to avoid silent empty states on subscription failures.
+  subscribePackageEntries('user-1', '2026-08', callback);
+}
+void assertEntrySubscriptionsRequireOnError;
+
 describe('subscribeHandpickEntries', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -428,7 +461,7 @@ describe('subscribeHandpickEntries', () => {
     const { subscribeHandpickEntries } = await import('./productionRecords');
     const callback = vi.fn();
 
-    subscribeHandpickEntries('user-1', '2026-08', callback);
+    subscribeHandpickEntries('user-1', '2026-08', callback, vi.fn());
 
     expect(firestoreMocks.orderBy).toHaveBeenCalledWith('createdAt', 'desc');
     expect(callback).toHaveBeenCalledWith([
@@ -635,7 +668,7 @@ describe('subscribeRoastEntries', () => {
     const { subscribeRoastEntries } = await import('./productionRecords');
     const callback = vi.fn();
 
-    subscribeRoastEntries('user-1', '2026-08', callback);
+    subscribeRoastEntries('user-1', '2026-08', callback, vi.fn());
 
     expect(firestoreMocks.orderBy).toHaveBeenCalledWith('createdAt', 'desc');
     expect(callback).toHaveBeenCalledWith([
@@ -765,7 +798,7 @@ describe('subscribePackageEntries', () => {
     const { subscribePackageEntries } = await import('./productionRecords');
     const callback = vi.fn();
 
-    subscribePackageEntries('user-1', '2026-08', callback);
+    subscribePackageEntries('user-1', '2026-08', callback, vi.fn());
 
     expect(firestoreMocks.orderBy).toHaveBeenCalledWith('createdAt', 'desc');
     expect(callback).toHaveBeenCalledWith([
@@ -904,7 +937,7 @@ describe('Zod validation at Firestore read boundary', () => {
 
       const { subscribeProductionRecordMonth } = await import('./productionRecords');
       const callback = vi.fn();
-      subscribeProductionRecordMonth('user-1', '2026-08', callback);
+      subscribeProductionRecordMonth('user-1', '2026-08', callback, vi.fn());
 
       expect(warnSpy).not.toHaveBeenCalled();
       expect(callback).toHaveBeenCalledWith(expect.objectContaining({ month: '2026-08', greenBeanTotalGram: 30000 }));
@@ -925,7 +958,7 @@ describe('Zod validation at Firestore read boundary', () => {
 
       const { subscribeProductionRecordMonth } = await import('./productionRecords');
       const callback = vi.fn();
-      subscribeProductionRecordMonth('user-1', '2026-08', callback);
+      subscribeProductionRecordMonth('user-1', '2026-08', callback, vi.fn());
 
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[zod]'), expect.any(Array));
       expect(callback).toHaveBeenCalledWith(expect.objectContaining({ month: '2026-08' }));
@@ -946,7 +979,7 @@ describe('Zod validation at Firestore read boundary', () => {
 
       const { subscribeProductionRecordMonth } = await import('./productionRecords');
       const callback = vi.fn();
-      subscribeProductionRecordMonth('user-1', '2026-08', callback);
+      subscribeProductionRecordMonth('user-1', '2026-08', callback, vi.fn());
 
       expect(warnSpy).toHaveBeenCalled();
       expect(callback).toHaveBeenCalledWith(expect.objectContaining({ blendItems: [] }));
@@ -975,7 +1008,7 @@ describe('Zod validation at Firestore read boundary', () => {
 
       const { subscribeHandpickEntries } = await import('./productionRecords');
       const callback = vi.fn();
-      subscribeHandpickEntries('user-1', '2026-08', callback);
+      subscribeHandpickEntries('user-1', '2026-08', callback, vi.fn());
 
       expect(warnSpy).not.toHaveBeenCalled();
       expect(callback).toHaveBeenCalledWith([expect.objectContaining({ beanName: 'Brazil', segment: 'first' })]);
@@ -1002,7 +1035,7 @@ describe('Zod validation at Firestore read boundary', () => {
 
       const { subscribeHandpickEntries } = await import('./productionRecords');
       const callback = vi.fn();
-      subscribeHandpickEntries('user-1', '2026-08', callback);
+      subscribeHandpickEntries('user-1', '2026-08', callback, vi.fn());
 
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[zod]'), expect.any(Array));
       expect(callback).toHaveBeenCalledWith([expect.objectContaining({ segment: 'first' })]);
@@ -1029,7 +1062,7 @@ describe('Zod validation at Firestore read boundary', () => {
 
       const { subscribeRoastEntries } = await import('./productionRecords');
       const callback = vi.fn();
-      subscribeRoastEntries('user-1', '2026-08', callback);
+      subscribeRoastEntries('user-1', '2026-08', callback, vi.fn());
 
       expect(warnSpy).not.toHaveBeenCalled();
       expect(callback).toHaveBeenCalledWith([
@@ -1055,7 +1088,7 @@ describe('Zod validation at Firestore read boundary', () => {
 
       const { subscribeRoastEntries } = await import('./productionRecords');
       const callback = vi.fn();
-      subscribeRoastEntries('user-1', '2026-08', callback);
+      subscribeRoastEntries('user-1', '2026-08', callback, vi.fn());
 
       expect(warnSpy).toHaveBeenCalled();
       expect(callback).toHaveBeenCalledWith([expect.objectContaining({ beforeRoastWeightGram: 0 })]);
@@ -1082,7 +1115,7 @@ describe('Zod validation at Firestore read boundary', () => {
 
       const { subscribePackageEntries } = await import('./productionRecords');
       const callback = vi.fn();
-      subscribePackageEntries('user-1', '2026-08', callback);
+      subscribePackageEntries('user-1', '2026-08', callback, vi.fn());
 
       expect(warnSpy).not.toHaveBeenCalled();
       expect(callback).toHaveBeenCalledWith([
@@ -1111,7 +1144,7 @@ describe('Zod validation at Firestore read boundary', () => {
 
       const { subscribePackageEntries } = await import('./productionRecords');
       const callback = vi.fn();
-      subscribePackageEntries('user-1', '2026-08', callback);
+      subscribePackageEntries('user-1', '2026-08', callback, vi.fn());
 
       expect(warnSpy).toHaveBeenCalled();
       expect(callback).toHaveBeenCalledWith([

--- a/lib/firestore/productionRecords.test.ts
+++ b/lib/firestore/productionRecords.test.ts
@@ -418,9 +418,8 @@ describe('subscribeRecentProductionMonths', () => {
 });
 
 async function assertEntrySubscriptionsRequireOnError() {
-  const { subscribeHandpickEntries, subscribeRoastEntries, subscribePackageEntries } = await import(
-    './productionRecords'
-  );
+  const { subscribeHandpickEntries, subscribeRoastEntries, subscribePackageEntries } =
+    await import('./productionRecords');
   const callback = vi.fn();
 
   // @ts-expect-error onError is required to avoid silent empty states on subscription failures.

--- a/lib/firestore/productionRecords.ts
+++ b/lib/firestore/productionRecords.ts
@@ -9,7 +9,9 @@ import {
   runTransaction,
   serverTimestamp,
   Timestamp,
+  type CollectionReference,
   type DocumentData,
+  type Query,
   type Unsubscribe,
 } from 'firebase/firestore';
 import { getDb, removeUndefinedFields } from './common';
@@ -143,7 +145,7 @@ export function subscribeProductionRecordMonth(
   userId: string,
   month: string,
   callback: (record: ProductionRecordMonth | null) => void,
-  onError?: (error: Error) => void
+  onError: (error: Error) => void
 ): Unsubscribe {
   const docRef = getProductionRecordMonthDocRef(userId, month);
 
@@ -158,7 +160,7 @@ export function subscribeProductionRecordMonth(
     },
     (error) => {
       console.error('Failed to subscribe production record month:', error);
-      onError?.(error);
+      onError(error);
       callback(null);
     }
   );
@@ -195,7 +197,7 @@ export async function productionRecordMonthExists(userId: string, month: string)
 export function subscribeRecentProductionMonths(
   userId: string,
   callback: (records: ProductionRecordMonth[]) => void,
-  onError?: (error: Error) => void
+  onError: (error: Error) => void
 ): Unsubscribe {
   const monthsQuery = query(
     getProductionRecordsCollectionRef(userId),
@@ -210,10 +212,71 @@ export function subscribeRecentProductionMonths(
     },
     (error) => {
       console.error('Failed to subscribe recent production months:', error);
-      onError?.(error);
+      onError(error);
       callback([]);
     }
   );
+}
+
+function subscribeEntryCollection<TEntry>({
+  entriesQuery,
+  normalize,
+  callback,
+  onError,
+  errorMessage,
+}: {
+  entriesQuery: Query<DocumentData>;
+  normalize: (id: string, data: DocumentData) => TEntry;
+  callback: (entries: TEntry[]) => void;
+  onError: (error: Error) => void;
+  errorMessage: string;
+}): Unsubscribe {
+  return onSnapshot(
+    entriesQuery,
+    (snapshot) => {
+      callback(snapshot.docs.map((entryDoc) => normalize(entryDoc.id, entryDoc.data())));
+    },
+    (error) => {
+      console.error(errorMessage, error);
+      onError(error);
+      callback([]);
+    }
+  );
+}
+
+async function upsertEntry<TEntry extends object>({
+  collectionRef,
+  id,
+  entry,
+  previousId,
+  collisionMessage,
+}: {
+  collectionRef: CollectionReference<DocumentData>;
+  id: string;
+  entry: TEntry;
+  previousId?: string;
+  collisionMessage: string;
+}): Promise<void> {
+  const docRef = doc(collectionRef, id);
+
+  await runTransaction(getDb(), async (transaction) => {
+    const snapshot = await transaction.get(docRef);
+    if (previousId && previousId !== id && snapshot.exists()) {
+      throw new Error(collisionMessage);
+    }
+    const createdAt = restoreCreatedAt(snapshot.data()?.createdAt);
+    if (previousId && previousId !== id) {
+      transaction.delete(doc(collectionRef, previousId));
+    }
+    transaction.set(
+      docRef,
+      removeUndefinedFields({
+        ...entry,
+        createdAt,
+        updatedAt: serverTimestamp(),
+      })
+    );
+  });
 }
 
 function normalizeHandpickSegment(value: unknown): HandpickSegment {
@@ -242,21 +305,17 @@ export function subscribeHandpickEntries(
   userId: string,
   month: string,
   callback: (entries: HandpickEntry[]) => void,
-  onError?: (error: Error) => void
+  onError: (error: Error) => void
 ): Unsubscribe {
   const entriesQuery = query(getHandpickEntriesCollectionRef(userId, month), orderBy('createdAt', 'desc'));
 
-  return onSnapshot(
+  return subscribeEntryCollection({
     entriesQuery,
-    (snapshot) => {
-      callback(snapshot.docs.map((entryDoc) => normalizeHandpickEntry(entryDoc.id, entryDoc.data())));
-    },
-    (error) => {
-      console.error('Failed to subscribe handpick entries:', error);
-      onError?.(error);
-      callback([]);
-    }
-  );
+    normalize: normalizeHandpickEntry,
+    callback,
+    onError,
+    errorMessage: 'Failed to subscribe handpick entries:',
+  });
 }
 
 /**
@@ -281,26 +340,13 @@ export async function saveHandpickEntry(
   const entry = buildHandpickEntry(input);
   const id = buildHandpickEntryId(entry.workDate, entry.segment, entry.beanName);
   const colRef = getHandpickEntriesCollectionRef(userId, month);
-  const docRef = doc(colRef, id);
 
-  await runTransaction(getDb(), async (transaction) => {
-    const snapshot = await transaction.get(docRef);
-    // 編集でキーを変更した先に別レコードが既にある場合、上書きするとそのデータを失うため拒否する
-    if (previousId && previousId !== id && snapshot.exists()) {
-      throw new Error(PRODUCTION_RECORD_ERROR_MESSAGES.handpickEntryCollision);
-    }
-    const createdAt = restoreCreatedAt(snapshot.data()?.createdAt);
-    if (previousId && previousId !== id) {
-      transaction.delete(doc(colRef, previousId));
-    }
-    transaction.set(
-      docRef,
-      removeUndefinedFields({
-        ...entry,
-        createdAt,
-        updatedAt: serverTimestamp(),
-      })
-    );
+  await upsertEntry({
+    collectionRef: colRef,
+    id,
+    entry,
+    previousId,
+    collisionMessage: PRODUCTION_RECORD_ERROR_MESSAGES.handpickEntryCollision,
   });
 
   return id;
@@ -327,21 +373,17 @@ export function subscribeRoastEntries(
   userId: string,
   month: string,
   callback: (entries: RoastEntry[]) => void,
-  onError?: (error: Error) => void
+  onError: (error: Error) => void
 ): Unsubscribe {
   const entriesQuery = query(getRoastEntriesCollectionRef(userId, month), orderBy('createdAt', 'desc'));
 
-  return onSnapshot(
+  return subscribeEntryCollection({
     entriesQuery,
-    (snapshot) => {
-      callback(snapshot.docs.map((entryDoc) => normalizeRoastEntry(entryDoc.id, entryDoc.data())));
-    },
-    (error) => {
-      console.error('Failed to subscribe roast entries:', error);
-      onError?.(error);
-      callback([]);
-    }
-  );
+    normalize: normalizeRoastEntry,
+    callback,
+    onError,
+    errorMessage: 'Failed to subscribe roast entries:',
+  });
 }
 
 /**
@@ -357,26 +399,13 @@ export async function saveRoastEntry(
   const entry = buildRoastEntry(input);
   const id = entry.workDate;
   const colRef = getRoastEntriesCollectionRef(userId, month);
-  const docRef = doc(colRef, id);
 
-  await runTransaction(getDb(), async (transaction) => {
-    const snapshot = await transaction.get(docRef);
-    // 編集で日付を変更した先に別の焙煎記録が既にある場合、上書きするとそのデータを失うため拒否する
-    if (previousId && previousId !== id && snapshot.exists()) {
-      throw new Error(PRODUCTION_RECORD_ERROR_MESSAGES.roastEntryCollision);
-    }
-    const createdAt = restoreCreatedAt(snapshot.data()?.createdAt);
-    if (previousId && previousId !== id) {
-      transaction.delete(doc(colRef, previousId));
-    }
-    transaction.set(
-      docRef,
-      removeUndefinedFields({
-        ...entry,
-        createdAt,
-        updatedAt: serverTimestamp(),
-      })
-    );
+  await upsertEntry({
+    collectionRef: colRef,
+    id,
+    entry,
+    previousId,
+    collisionMessage: PRODUCTION_RECORD_ERROR_MESSAGES.roastEntryCollision,
   });
 
   return id;
@@ -411,21 +440,17 @@ export function subscribePackageEntries(
   userId: string,
   month: string,
   callback: (entries: PackageEntry[]) => void,
-  onError?: (error: Error) => void
+  onError: (error: Error) => void
 ): Unsubscribe {
   const entriesQuery = query(getPackageEntriesCollectionRef(userId, month), orderBy('createdAt', 'desc'));
 
-  return onSnapshot(
+  return subscribeEntryCollection({
     entriesQuery,
-    (snapshot) => {
-      callback(snapshot.docs.map((entryDoc) => normalizePackageEntry(entryDoc.id, entryDoc.data())));
-    },
-    (error) => {
-      console.error('Failed to subscribe package entries:', error);
-      onError?.(error);
-      callback([]);
-    }
-  );
+    normalize: normalizePackageEntry,
+    callback,
+    onError,
+    errorMessage: 'Failed to subscribe package entries:',
+  });
 }
 
 /**
@@ -441,26 +466,13 @@ export async function savePackageEntry(
   const entry = buildPackageEntry(input);
   const id = entry.workDate;
   const colRef = getPackageEntriesCollectionRef(userId, month);
-  const docRef = doc(colRef, id);
 
-  await runTransaction(getDb(), async (transaction) => {
-    const snapshot = await transaction.get(docRef);
-    // 編集で日付を変更した先に別のパッケージ記録が既にある場合、上書きするとそのデータを失うため拒否する
-    if (previousId && previousId !== id && snapshot.exists()) {
-      throw new Error(PRODUCTION_RECORD_ERROR_MESSAGES.packageEntryCollision);
-    }
-    const createdAt = restoreCreatedAt(snapshot.data()?.createdAt);
-    if (previousId && previousId !== id) {
-      transaction.delete(doc(colRef, previousId));
-    }
-    transaction.set(
-      docRef,
-      removeUndefinedFields({
-        ...entry,
-        createdAt,
-        updatedAt: serverTimestamp(),
-      })
-    );
+  await upsertEntry({
+    collectionRef: colRef,
+    id,
+    entry,
+    previousId,
+    collisionMessage: PRODUCTION_RECORD_ERROR_MESSAGES.packageEntryCollision,
   });
 
   return id;


### PR DESCRIPTION
## 対象Issue

Closes #500

## 変更内容

- `productionRecords` のサブコレクション購読3種を `subscribeEntryCollection` に統合
- handpick / roast / package の upsert トランザクションを `upsertEntry` に統合
- productionRecords 内の購読APIで `onError` を必須化し、購読エラー時に通知経路を必ず通す契約を型テストで固定

## 確認結果

- `npm run typecheck`
- `npm run lint`
- `npm run test:run`（110 files / 1230 tests）
- `git diff --check`

## 残リスク

- `npm run lint` で既存の Node MODULE_TYPELESS_PACKAGE_JSON 警告が出ます（今回の変更起因ではありません）。

## 触らなかった範囲

- Firestore Rules / Storage Rules
- 画面UI、PWA、Service Worker
- 本番データ・Firebase設定