### PR TITLE
[codex] 時間ラベル削除ボタンの色を修正

### DIFF
--- a/components/today-schedule/TimeEditDialog.test.tsx
+++ b/components/today-schedule/TimeEditDialog.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TimeEditDialog } from './TimeEditDialog';
+
+describe('TimeEditDialog', () => {
+  it('削除ボタンはdangerの塗りスタイルを白背景で上書きしない', () => {
+    render(
+      <TimeEditDialog
+        initialHour="10"
+        initialMinute="00"
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+        labels={[
+          {
+            id: 'label-1',
+            time: '10:00',
+            content: '',
+          },
+        ]}
+        onDeleteLabel={vi.fn()}
+      />
+    );
+
+    const deleteButton = screen.getByRole('button', { name: '削除' });
+
+    expect(deleteButton.className).toContain('bg-danger');
+    expect(deleteButton.className).toContain('text-white');
+    expect(deleteButton.className).not.toContain('bg-white');
+  });
+});

--- a/components/today-schedule/TimeEditDialog.tsx
+++ b/components/today-schedule/TimeEditDialog.tsx
@@ -111,7 +111,7 @@ export function TimeEditDialog({
                         variant="danger"
                         size="sm"
                         onClick={() => onDeleteLabel(label.id)}
-                        className="!min-h-[36px] bg-white text-red-600 border border-red-200 hover:bg-red-50"
+                        className="!min-h-[36px]"
                       >
                         削除
                       </Button>


### PR DESCRIPTION
## 概要

- スケジュールの時間編集モーダルで、時間ラベル削除ボタンが白背景に上書きされていた問題を修正
- `danger` バリアント本来の赤背景・白文字が維持されるように調整
- 同じ上書きが再発しないよう、`TimeEditDialog` の回帰テストを追加

## 対象Issue

- なし（画面確認からの直接修正）

## 変更内容

- `components/today-schedule/TimeEditDialog.tsx`
  - 削除ボタンから `bg-white text-red-600 border border-red-200 hover:bg-red-50` の個別上書きを削除
- `components/today-schedule/TimeEditDialog.test.tsx`
  - 削除ボタンが `bg-danger` / `text-white` を持ち、`bg-white` で上書きされないことを検証

## 確認結果

- `npm run typecheck`
- `npm run lint`
  - 既存の `MODULE_TYPELESS_PACKAGE_JSON` warning は出ますが、lint は成功
- `npm run test:run`
  - 113 files / 1243 tests passed
- Playwright MCP で同じ CSS 上のボタン算出色を確認
  - 背景: `rgb(220, 38, 38)`
  - 文字: `rgb(255, 255, 255)`

## 残リスク

- ログイン後の実データ画面では未確認です。ローカル `/schedule` は未ログイン画面まで確認し、モーダル表示は同じ CSS 上の検証用断片で確認しました。

## 触らなかった範囲

- カレンダーの日付色変更
- スケジュール保存・削除ロジック
- Firestore / Rules / 本番データ