### PR TITLE
refactor: 日付・時刻フォーマット処理を lib/dateUtils.ts に集約 (#547)

### DIFF
--- a/app/clock/page.tsx
+++ b/app/clock/page.tsx
@@ -43,7 +43,7 @@ function getPreviewChime(): DueWorkChime | null {
   };
 }
 
-function formatTime(date: Date, use24Hour: boolean): { h: string; m: string; s: string; ampm?: string } {
+function buildClockTimeParts(date: Date, use24Hour: boolean): { h: string; m: string; s: string; ampm?: string } {
   let hours = date.getHours();
   let ampm: string | undefined;
 
@@ -60,7 +60,7 @@ function formatTime(date: Date, use24Hour: boolean): { h: string; m: string; s: 
   };
 }
 
-function formatDate(date: Date): string {
+function buildClockDateString(date: Date): string {
   const y = date.getFullYear();
   const m = date.getMonth() + 1;
   const d = date.getDate();
@@ -146,7 +146,7 @@ export default function ClockPage() {
     );
   }
 
-  const time = formatTime(now, settings.use24Hour);
+  const time = buildClockTimeParts(now, settings.use24Hour);
 
   return (
     <div
@@ -211,7 +211,7 @@ export default function ClockPage() {
               color: colors.dateText,
             }}
           >
-            {formatDate(now)}
+            {buildClockDateString(now)}
           </p>
         )}
 

--- a/components/TastingRecordForm.tsx
+++ b/components/TastingRecordForm.tsx
@@ -10,7 +10,7 @@ import { User, Calendar, Thermometer, Coffee } from 'phosphor-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Input, Select, Textarea, Button } from '@/components/ui';
 import { ROAST_LEVELS } from '@/lib/constants';
-import { formatDateString } from '@/lib/dateUtils';
+import { getTodayDateString } from '@/lib/dateUtils';
 import { TastingRecordFormScores } from './TastingRecordFormScores';
 
 interface TastingRecordFormProps {
@@ -58,7 +58,7 @@ export function TastingRecordForm({
   const [selectedMemberId, setSelectedMemberId] = useState<string>(record?.memberId || '');
   const [beanName, setBeanName] = useState(record?.beanName || sessionInfo?.beanName || '');
   const [tastingDate, setTastingDate] = useState(
-    record?.tastingDate || (sessionInfo ? sessionInfo.createdAt.split('T')[0] : formatDateString())
+    record?.tastingDate || (sessionInfo ? sessionInfo.createdAt.split('T')[0] : getTodayDateString())
   );
   const [roastLevel, setRoastLevel] = useState<'浅煎り' | '中煎り' | '中深煎り' | '深煎り'>(
     record?.roastLevel || sessionInfo?.roastLevel || '中深煎り'

--- a/components/TastingSessionForm.tsx
+++ b/components/TastingSessionForm.tsx
@@ -7,7 +7,7 @@ import { motion } from 'framer-motion';
 import { Coffee, CalendarBlank, Thermometer, Trash, Plus, Warning } from 'phosphor-react';
 import { Input, Select, Button } from '@/components/ui';
 import { ROAST_LEVELS } from '@/lib/constants';
-import { formatDateString } from '@/lib/dateUtils';
+import { getTodayDateString } from '@/lib/dateUtils';
 
 interface TastingSessionFormProps {
   session: TastingSession | null;
@@ -21,7 +21,7 @@ export function TastingSessionForm({ session, onSave, onCancel, onDelete }: Tast
   const { showToast } = useToastContext();
 
   const [beanName, setBeanName] = useState(session?.beanName || '');
-  const [createdAt, setCreatedAt] = useState(session?.createdAt ? session.createdAt.split('T')[0] : formatDateString());
+  const [createdAt, setCreatedAt] = useState(session?.createdAt ? session.createdAt.split('T')[0] : getTodayDateString());
   const [roastLevel, setRoastLevel] = useState<'浅煎り' | '中煎り' | '中深煎り' | '深煎り'>(
     session?.roastLevel || '中深煎り'
   );

--- a/components/TastingSessionForm.tsx
+++ b/components/TastingSessionForm.tsx
@@ -21,7 +21,9 @@ export function TastingSessionForm({ session, onSave, onCancel, onDelete }: Tast
   const { showToast } = useToastContext();
 
   const [beanName, setBeanName] = useState(session?.beanName || '');
-  const [createdAt, setCreatedAt] = useState(session?.createdAt ? session.createdAt.split('T')[0] : getTodayDateString());
+  const [createdAt, setCreatedAt] = useState(
+    session?.createdAt ? session.createdAt.split('T')[0] : getTodayDateString()
+  );
   const [roastLevel, setRoastLevel] = useState<'浅煎り' | '中煎り' | '中深煎り' | '深煎り'>(
     session?.roastLevel || '中深煎り'
   );

--- a/components/clock/WorkChimeScheduleModal.tsx
+++ b/components/clock/WorkChimeScheduleModal.tsx
@@ -2,6 +2,7 @@
 
 import { HiXMark } from 'react-icons/hi2';
 import { MdAdd, MdDelete } from 'react-icons/md';
+import { formatMinutesToHHMM } from '@/lib/dateUtils';
 
 import { Button, IconButton, Input, Modal } from '@/components/ui';
 import { type WorkChimePeriod, type WorkChimePeriodKind, type WorkChimeSettings } from '@/lib/workChime';
@@ -20,9 +21,7 @@ function minutesFromTime(value: string): number {
 
 function timeFromMinutes(value: number): string {
   const normalized = Math.max(0, Math.min(23 * 60 + 59, value));
-  const hours = Math.floor(normalized / 60);
-  const minutes = normalized % 60;
-  return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+  return formatMinutesToHHMM(normalized);
 }
 
 function getNextPeriodDraft(periods: WorkChimePeriod[]): WorkChimePeriod {

--- a/components/date-picker/useDatePicker.ts
+++ b/components/date-picker/useDatePicker.ts
@@ -1,4 +1,5 @@
 import { useState, useMemo } from 'react';
+import { getTomorrowDateString, getNextWeekday, formatDateToYMD } from '@/lib/dateUtils';
 
 export type ViewMode = 'calendar' | 'year' | 'month';
 
@@ -24,41 +25,10 @@ export function useDatePicker({ selectedDate, isWeekend, getTodayString }: UseDa
   const todayDate = new Date(today + 'T00:00:00');
   const currentYear = todayDate.getFullYear();
 
-  // 翌日の日付を取得
-  const getTomorrowString = () => {
-    const now = new Date();
-    now.setDate(now.getDate() + 1);
-    const year = now.getFullYear();
-    const month = String(now.getMonth() + 1).padStart(2, '0');
-    const day = String(now.getDate()).padStart(2, '0');
-    return `${year}-${month}-${day}`;
-  };
-
-  // 次の平日を取得する関数
-  const getNextWeekday = (dateString: string): string => {
-    const date = new Date(dateString + 'T00:00:00');
-    date.setDate(date.getDate() + 1);
-    while (date.getDay() === 0 || date.getDay() === 6) {
-      date.setDate(date.getDate() + 1);
-    }
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
-    return `${year}-${month}-${day}`;
-  };
-
-  const tomorrow = getTomorrowString();
+  const tomorrow = getTomorrowDateString();
   // 翌日（土日なら次の平日）が最大選択可能日
   const maxSelectableDate = isWeekend(tomorrow) ? getNextWeekday(today) : tomorrow;
   const maxSelectableDateObj = useMemo(() => new Date(maxSelectableDate + 'T00:00:00'), [maxSelectableDate]);
-
-  // 日付文字列フォーマット関数
-  const formatDateString = (date: Date): string => {
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
-    return `${year}-${month}-${day}`;
-  };
 
   // カレンダーの日付配列を生成
   const calendarDays = useMemo(() => {
@@ -78,7 +48,7 @@ export function useDatePicker({ selectedDate, isWeekend, getTodayString }: UseDa
       days.push({
         date,
         isCurrentMonth: false,
-        dateString: formatDateString(date),
+        dateString: formatDateToYMD(date),
       });
     }
 
@@ -88,7 +58,7 @@ export function useDatePicker({ selectedDate, isWeekend, getTodayString }: UseDa
       days.push({
         date,
         isCurrentMonth: true,
-        dateString: formatDateString(date),
+        dateString: formatDateToYMD(date),
       });
     }
 
@@ -99,7 +69,7 @@ export function useDatePicker({ selectedDate, isWeekend, getTodayString }: UseDa
       days.push({
         date,
         isCurrentMonth: false,
-        dateString: formatDateString(date),
+        dateString: formatDateToYMD(date),
       });
     }
 

--- a/components/drip-guide/dialogs/shared/RecipeStepTable.tsx
+++ b/components/drip-guide/dialogs/shared/RecipeStepTable.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { DripStep } from '@/lib/drip-guide/types';
-import { formatTime } from '@/lib/drip-guide/formatTime';
+import { formatSecondsAsTimer as formatTime } from '@/lib/dateUtils';
 import { Button } from '@/components/ui';
 
 interface RecipeStepTableProps {

--- a/components/drip-guide/dialogs/shared/RecipeSummary.tsx
+++ b/components/drip-guide/dialogs/shared/RecipeSummary.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { Coffee, Drop, Timer } from 'phosphor-react';
-import { formatTime } from '@/lib/drip-guide/formatTime';
+import { formatSecondsAsTimer as formatTime } from '@/lib/dateUtils';
 
 interface RecipeSummaryProps {
   beanAmountGram: number;

--- a/components/drip-guide/runner/FocusGuideDisplay.tsx
+++ b/components/drip-guide/runner/FocusGuideDisplay.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { formatTime } from '@/lib/drip-guide/formatTime';
+import { formatSecondsAsTimer as formatTime } from '@/lib/dateUtils';
 import type { DripStep } from '@/lib/drip-guide/types';
 
 interface FocusGuideDisplayProps {

--- a/docs/steering/GUIDELINES.md
+++ b/docs/steering/GUIDELINES.md
@@ -378,19 +378,19 @@ const DIFFICULTY_STYLES = {
 
 ```typescript
 import { describe, it, expect } from 'vitest';
-import { formatTime } from '@/lib/drip-guide/formatTime';
+import { formatSecondsAsTimer } from '@/lib/dateUtils';
 
-describe('formatTime', () => {
+describe('formatSecondsAsTimer', () => {
   it('should format seconds correctly', () => {
-    expect(formatTime(60)).toBe('1:00');
+    expect(formatSecondsAsTimer(60)).toBe('01:00');
   });
 
   it('should format minutes and seconds correctly', () => {
-    expect(formatTime(90)).toBe('1:30');
+    expect(formatSecondsAsTimer(90)).toBe('01:30');
   });
 
   it('should handle zero seconds', () => {
-    expect(formatTime(0)).toBe('0:00');
+    expect(formatSecondsAsTimer(0)).toBe('00:00');
   });
 });
 ```

--- a/hooks/useScheduleDateNavigation.ts
+++ b/hooks/useScheduleDateNavigation.ts
@@ -1,25 +1,15 @@
 import { useState, useCallback, useEffect } from 'react';
+import {
+  getTodayDateString,
+  getTomorrowDateString,
+  getPreviousWeekday,
+  getNextWeekday,
+  formatDateToJapanese,
+  formatDateStringToJapanese,
+  formatTimeHMS,
+} from '@/lib/dateUtils';
 
 export function useScheduleDateNavigation() {
-  // 今日の日付を取得（YYYY-MM-DD形式）
-  const getTodayString = () => {
-    const now = new Date();
-    const year = now.getFullYear();
-    const month = String(now.getMonth() + 1).padStart(2, '0');
-    const day = String(now.getDate()).padStart(2, '0');
-    return `${year}-${month}-${day}`;
-  };
-
-  // 翌日の日付を取得
-  const getTomorrowString = () => {
-    const now = new Date();
-    now.setDate(now.getDate() + 1);
-    const year = now.getFullYear();
-    const month = String(now.getMonth() + 1).padStart(2, '0');
-    const day = String(now.getDate()).padStart(2, '0');
-    return `${year}-${month}-${day}`;
-  };
-
   // 土日判定関数（0=日曜、6=土曜）
   const isWeekend = useCallback((dateString: string): boolean => {
     const date = new Date(dateString + 'T00:00:00');
@@ -27,46 +17,14 @@ export function useScheduleDateNavigation() {
     return dayOfWeek === 0 || dayOfWeek === 6;
   }, []);
 
-  // 前の平日を取得する関数
-  const getPreviousWeekday = useCallback((dateString: string): string => {
-    const date = new Date(dateString + 'T00:00:00');
-    date.setDate(date.getDate() - 1);
-
-    // 土日をスキップ
-    while (date.getDay() === 0 || date.getDay() === 6) {
-      date.setDate(date.getDate() - 1);
-    }
-
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
-    return `${year}-${month}-${day}`;
-  }, []);
-
-  // 次の平日を取得する関数
-  const getNextWeekday = useCallback((dateString: string): string => {
-    const date = new Date(dateString + 'T00:00:00');
-    date.setDate(date.getDate() + 1);
-
-    // 土日をスキップ
-    while (date.getDay() === 0 || date.getDay() === 6) {
-      date.setDate(date.getDate() + 1);
-    }
-
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
-    return `${year}-${month}-${day}`;
-  }, []);
-
   // 初期日付を取得（今日が土日の場合は前の平日）
   const getInitialDate = useCallback((): string => {
-    const today = getTodayString();
+    const today = getTodayDateString();
     if (isWeekend(today)) {
       return getPreviousWeekday(today);
     }
     return today;
-  }, [isWeekend, getPreviousWeekday]);
+  }, [isWeekend]);
 
   const [selectedDate, setSelectedDate] = useState<string>(getInitialDate());
   const [currentTime, setCurrentTime] = useState<Date>(new Date());
@@ -80,30 +38,6 @@ export function useScheduleDateNavigation() {
     return () => clearInterval(timer);
   }, []);
 
-  // 日付と時刻のフォーマット関数
-  const formatDate = (date: Date): string => {
-    const year = date.getFullYear();
-    const month = date.getMonth() + 1;
-    const day = date.getDate();
-    const weekdays = ['日', '月', '火', '水', '木', '金', '土'];
-    const weekday = weekdays[date.getDay()];
-
-    return `${year}年${month}月${day}日（${weekday}）`;
-  };
-
-  const formatDateString = (dateString: string): string => {
-    const date = new Date(dateString + 'T00:00:00');
-    return formatDate(date);
-  };
-
-  const formatTime = (date: Date): string => {
-    const hours = date.getHours().toString().padStart(2, '0');
-    const minutes = date.getMinutes().toString().padStart(2, '0');
-    const seconds = date.getSeconds().toString().padStart(2, '0');
-
-    return `${hours}:${minutes}:${seconds}`;
-  };
-
   // 日付移動関数
   const moveToPreviousDay = () => {
     const previousWeekday = getPreviousWeekday(selectedDate);
@@ -111,8 +45,8 @@ export function useScheduleDateNavigation() {
   };
 
   const moveToNextDay = useCallback(() => {
-    const today = getTodayString();
-    const tomorrow = getTomorrowString();
+    const today = getTodayDateString();
+    const tomorrow = getTomorrowDateString();
     const nextWeekday = getNextWeekday(selectedDate);
 
     // 翌日まで移動可能にする
@@ -121,11 +55,11 @@ export function useScheduleDateNavigation() {
     if (nextWeekday <= maxDate) {
       setSelectedDate(nextWeekday);
     }
-  }, [selectedDate, getNextWeekday, isWeekend]);
+  }, [selectedDate, isWeekend]);
 
   // 選択日が今日かどうか（実際の今日の日付と比較）
-  const today = getTodayString();
-  const tomorrow = getTomorrowString();
+  const today = getTodayDateString();
+  const tomorrow = getTomorrowDateString();
   const isToday = selectedDate === today;
   // 翌日（土日なら次の平日）が最大選択可能日
   const maxSelectableDate = isWeekend(tomorrow) ? getNextWeekday(today) : tomorrow;
@@ -138,10 +72,10 @@ export function useScheduleDateNavigation() {
     isToday,
     isMaxDate,
     isWeekend,
-    getTodayString,
-    formatDate,
-    formatDateString,
-    formatTime,
+    getTodayString: getTodayDateString,
+    formatDate: formatDateToJapanese,
+    formatDateString: formatDateStringToJapanese,
+    formatTime: formatTimeHMS,
     moveToPreviousDay,
     moveToNextDay,
   };

--- a/lib/dateUtils.test.ts
+++ b/lib/dateUtils.test.ts
@@ -1,41 +1,147 @@
-import { describe, it, expect, vi } from 'vitest';
-import { formatDateString } from './dateUtils';
+import { describe, it, expect } from 'vitest';
+import {
+  formatDateToYMD,
+  getTodayDateString,
+  getTomorrowDateString,
+  getCurrentMonth,
+  getPreviousWeekday,
+  getNextWeekday,
+  formatDateToJapanese,
+  formatDateStringToJapanese,
+  formatTimeHMS,
+  formatTimeHM,
+  formatMinutesToHHMM,
+  formatSecondsAsTimer,
+} from './dateUtils';
 
-describe('formatDateString', () => {
-  it('Dateオブジェクトを YYYY-MM-DD 形式に変換する', () => {
-    const date = new Date('2024-12-25T15:30:00Z');
-    expect(formatDateString(date)).toBe('2024-12-25');
+describe('formatDateToYMD', () => {
+  it('DateオブジェクトをYYYY-MM-DD形式に変換する（JST基準）', () => {
+    expect(formatDateToYMD(new Date(2024, 0, 15))).toBe('2024-01-15');
+    expect(formatDateToYMD(new Date(2024, 11, 31))).toBe('2024-12-31');
   });
 
-  it('日付の時刻部分は無視される', () => {
-    const morning = new Date('2024-01-15T09:00:00Z');
-    const evening = new Date('2024-01-15T21:00:00Z');
-
-    expect(formatDateString(morning)).toBe('2024-01-15');
-    expect(formatDateString(evening)).toBe('2024-01-15');
+  it('1桁の月・日をゼロ埋めする', () => {
+    expect(formatDateToYMD(new Date(2024, 0, 5))).toBe('2024-01-05');
+    expect(formatDateToYMD(new Date(2024, 8, 1))).toBe('2024-09-01');
   });
 
-  it('引数なしの場合は現在日時を使用する', () => {
-    // 現在日時をモック
-    const mockDate = new Date('2024-06-15T12:00:00Z');
-    vi.setSystemTime(mockDate);
+  it('閏年を正しく処理する', () => {
+    expect(formatDateToYMD(new Date(2024, 1, 29))).toBe('2024-02-29');
+  });
+});
 
-    expect(formatDateString()).toBe('2024-06-15');
+describe('getTodayDateString', () => {
+  it('指定日付をYYYY-MM-DD形式で返す', () => {
+    expect(getTodayDateString(new Date(2026, 5, 13))).toBe('2026-06-13');
+  });
+});
 
-    // モックをクリア
-    vi.useRealTimers();
+describe('getTomorrowDateString', () => {
+  it('翌日をYYYY-MM-DD形式で返す', () => {
+    expect(getTomorrowDateString(new Date(2026, 5, 13))).toBe('2026-06-14');
   });
 
-  it('閏年の日付を正しく処理する', () => {
-    const leapDay = new Date('2024-02-29T00:00:00Z');
-    expect(formatDateString(leapDay)).toBe('2024-02-29');
+  it('月をまたぐ場合も正しく返す', () => {
+    expect(getTomorrowDateString(new Date(2026, 5, 30))).toBe('2026-07-01');
   });
 
-  it('年末年始の日付を正しく処理する', () => {
-    const newYear = new Date('2024-01-01T00:00:00Z');
-    const newYearEve = new Date('2024-12-31T23:59:59Z');
+  it('年をまたぐ場合も正しく返す', () => {
+    expect(getTomorrowDateString(new Date(2026, 11, 31))).toBe('2027-01-01');
+  });
+});
 
-    expect(formatDateString(newYear)).toBe('2024-01-01');
-    expect(formatDateString(newYearEve)).toBe('2024-12-31');
+describe('getCurrentMonth', () => {
+  it('当月をYYYY-MM形式で返す', () => {
+    expect(getCurrentMonth(new Date(2026, 0, 15))).toBe('2026-01');
+    expect(getCurrentMonth(new Date(2026, 8, 1))).toBe('2026-09');
+    expect(getCurrentMonth(new Date(2026, 11, 31))).toBe('2026-12');
+  });
+});
+
+describe('getPreviousWeekday', () => {
+  it('前日が平日なら前日を返す', () => {
+    expect(getPreviousWeekday('2026-06-10')).toBe('2026-06-09'); // 水→火
+  });
+
+  it('月曜日からは前の金曜日を返す', () => {
+    expect(getPreviousWeekday('2026-06-08')).toBe('2026-06-05'); // 月→金
+  });
+
+  it('日曜日からは前の金曜日を返す', () => {
+    expect(getPreviousWeekday('2026-06-07')).toBe('2026-06-05'); // 日→金
+  });
+});
+
+describe('getNextWeekday', () => {
+  it('翌日が平日なら翌日を返す', () => {
+    expect(getNextWeekday('2026-06-09')).toBe('2026-06-10'); // 火→水
+  });
+
+  it('金曜日からは翌月曜日を返す', () => {
+    expect(getNextWeekday('2026-06-05')).toBe('2026-06-08'); // 金→月
+  });
+
+  it('土曜日からは翌月曜日を返す', () => {
+    expect(getNextWeekday('2026-06-06')).toBe('2026-06-08'); // 土→月
+  });
+});
+
+describe('formatDateToJapanese', () => {
+  it('Y年M月D日（曜）形式に変換する', () => {
+    expect(formatDateToJapanese(new Date(2026, 5, 13))).toBe('2026年6月13日（土）');
+    expect(formatDateToJapanese(new Date(2026, 5, 8))).toBe('2026年6月8日（月）');
+  });
+
+  it('1桁の月・日はゼロ埋めしない', () => {
+    expect(formatDateToJapanese(new Date(2026, 0, 5))).toBe('2026年1月5日（月）');
+  });
+});
+
+describe('formatDateStringToJapanese', () => {
+  it('YYYY-MM-DD文字列をY年M月D日（曜）形式に変換する', () => {
+    expect(formatDateStringToJapanese('2026-06-13')).toBe('2026年6月13日（土）');
+    expect(formatDateStringToJapanese('2026-01-05')).toBe('2026年1月5日（月）');
+  });
+});
+
+describe('formatTimeHMS', () => {
+  it('HH:MM:SS形式に変換する', () => {
+    const date = new Date(2026, 5, 13, 9, 5, 3);
+    expect(formatTimeHMS(date)).toBe('09:05:03');
+  });
+
+  it('午後の時刻も正しく変換する', () => {
+    const date = new Date(2026, 5, 13, 14, 30, 45);
+    expect(formatTimeHMS(date)).toBe('14:30:45');
+  });
+});
+
+describe('formatTimeHM', () => {
+  it('HH:MM形式に変換する', () => {
+    const date = new Date(2026, 5, 13, 9, 5);
+    expect(formatTimeHM(date)).toBe('09:05');
+  });
+
+  it('1桁の時・分をゼロ埋めする', () => {
+    const date = new Date(2026, 5, 13, 0, 0);
+    expect(formatTimeHM(date)).toBe('00:00');
+  });
+});
+
+describe('formatMinutesToHHMM', () => {
+  it('総分数をHH:MM形式に変換する', () => {
+    expect(formatMinutesToHHMM(570)).toBe('09:30');
+    expect(formatMinutesToHHMM(0)).toBe('00:00');
+    expect(formatMinutesToHHMM(60)).toBe('01:00');
+    expect(formatMinutesToHHMM(1439)).toBe('23:59');
+  });
+});
+
+describe('formatSecondsAsTimer', () => {
+  it('秒数をMM:SS形式に変換する', () => {
+    expect(formatSecondsAsTimer(90)).toBe('01:30');
+    expect(formatSecondsAsTimer(0)).toBe('00:00');
+    expect(formatSecondsAsTimer(60)).toBe('01:00');
+    expect(formatSecondsAsTimer(3661)).toBe('61:01');
   });
 });

--- a/lib/dateUtils.ts
+++ b/lib/dateUtils.ts
@@ -1,12 +1,97 @@
 /**
- * 日付フォーマットユーティリティ関数
+ * 日付・時刻フォーマットユーティリティ
+ * JST（日本標準時）前提。toISOString() は使用しない（UTCずれ防止）。
  */
 
-/**
- * DateオブジェクトをYYYY-MM-DD形式の文字列に変換
- * @param date 変換対象の日付（省略時は現在日時）
- * @returns YYYY-MM-DD形式の文字列
- */
-export function formatDateString(date: Date = new Date()): string {
-  return date.toISOString().split('T')[0];
+const DAY_NAMES_JA = ['日', '月', '火', '水', '木', '金', '土'] as const;
+
+/** DateオブジェクトをYYYY-MM-DD形式の文字列に変換（JST基準） */
+export function formatDateToYMD(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/** 今日の日付をYYYY-MM-DD形式で返す（JST基準） */
+export function getTodayDateString(now: Date = new Date()): string {
+  return formatDateToYMD(now);
+}
+
+/** 明日の日付をYYYY-MM-DD形式で返す（JST基準） */
+export function getTomorrowDateString(now: Date = new Date()): string {
+  const tomorrow = new Date(now);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  return formatDateToYMD(tomorrow);
+}
+
+/** 当月をYYYY-MM形式で返す（JST基準） */
+export function getCurrentMonth(now: Date = new Date()): string {
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  return `${year}-${month}`;
+}
+
+/** YYYY-MM-DD文字列の前の平日を返す（土日をスキップ） */
+export function getPreviousWeekday(dateString: string): string {
+  const date = new Date(dateString + 'T00:00:00');
+  date.setDate(date.getDate() - 1);
+  while (date.getDay() === 0 || date.getDay() === 6) {
+    date.setDate(date.getDate() - 1);
+  }
+  return formatDateToYMD(date);
+}
+
+/** YYYY-MM-DD文字列の次の平日を返す（土日をスキップ） */
+export function getNextWeekday(dateString: string): string {
+  const date = new Date(dateString + 'T00:00:00');
+  date.setDate(date.getDate() + 1);
+  while (date.getDay() === 0 || date.getDay() === 6) {
+    date.setDate(date.getDate() + 1);
+  }
+  return formatDateToYMD(date);
+}
+
+/** DateオブジェクトをY年M月D日（曜）形式に変換 */
+export function formatDateToJapanese(date: Date): string {
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const weekday = DAY_NAMES_JA[date.getDay()];
+  return `${year}年${month}月${day}日（${weekday}）`;
+}
+
+/** YYYY-MM-DD文字列をY年M月D日（曜）形式に変換 */
+export function formatDateStringToJapanese(dateString: string): string {
+  const date = new Date(dateString + 'T00:00:00');
+  return formatDateToJapanese(date);
+}
+
+/** DateオブジェクトをHH:MM:SS形式に変換（秒表示付き時刻用） */
+export function formatTimeHMS(date: Date): string {
+  const hours = date.getHours().toString().padStart(2, '0');
+  const minutes = date.getMinutes().toString().padStart(2, '0');
+  const seconds = date.getSeconds().toString().padStart(2, '0');
+  return `${hours}:${minutes}:${seconds}`;
+}
+
+/** DateオブジェクトをHH:MM形式に変換（時刻キー・比較用） */
+export function formatTimeHM(date: Date): string {
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  return `${hours}:${minutes}`;
+}
+
+/** 総分数をHH:MM形式に変換（例: 570 → "09:30"） */
+export function formatMinutesToHHMM(totalMinutes: number): string {
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+}
+
+/** 秒数をMM:SS形式に変換（ドリップタイマー表示用、例: 90 → "01:30"） */
+export function formatSecondsAsTimer(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
 }

--- a/lib/drip-guide/formatTime.test.ts
+++ b/lib/drip-guide/formatTime.test.ts
@@ -1,32 +1,32 @@
 import { describe, it, expect } from 'vitest';
-import { formatTime } from './formatTime';
+import { formatSecondsAsTimer } from '@/lib/dateUtils';
 
-describe('formatTime', () => {
+describe('formatSecondsAsTimer', () => {
   it('0秒 → "00:00"', () => {
-    expect(formatTime(0)).toBe('00:00');
+    expect(formatSecondsAsTimer(0)).toBe('00:00');
   });
 
   it('5秒 → "00:05"', () => {
-    expect(formatTime(5)).toBe('00:05');
+    expect(formatSecondsAsTimer(5)).toBe('00:05');
   });
 
   it('59秒 → "00:59"', () => {
-    expect(formatTime(59)).toBe('00:59');
+    expect(formatSecondsAsTimer(59)).toBe('00:59');
   });
 
   it('60秒 → "01:00"', () => {
-    expect(formatTime(60)).toBe('01:00');
+    expect(formatSecondsAsTimer(60)).toBe('01:00');
   });
 
   it('65秒 → "01:05"', () => {
-    expect(formatTime(65)).toBe('01:05');
+    expect(formatSecondsAsTimer(65)).toBe('01:05');
   });
 
   it('120秒 → "02:00"', () => {
-    expect(formatTime(120)).toBe('02:00');
+    expect(formatSecondsAsTimer(120)).toBe('02:00');
   });
 
   it('3600秒 → "60:00"', () => {
-    expect(formatTime(3600)).toBe('60:00');
+    expect(formatSecondsAsTimer(3600)).toBe('60:00');
   });
 });

--- a/lib/drip-guide/formatTime.ts
+++ b/lib/drip-guide/formatTime.ts
@@ -1,8 +1,0 @@
-/**
- * 秒数を MM:SS 形式にフォーマット
- */
-export const formatTime = (seconds: number): string => {
-  const m = Math.floor(seconds / 60);
-  const s = seconds % 60;
-  return `${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
-};

--- a/lib/productionRecords.ts
+++ b/lib/productionRecords.ts
@@ -57,21 +57,8 @@ export function isValidWorkDate(date: string): boolean {
   return parsed.getUTCFullYear() === year && parsed.getUTCMonth() === month - 1 && parsed.getUTCDate() === day;
 }
 
-// 当月を yyyy-MM で返す（ローカル時刻=現場のJST基準）。新規作成フォームの初期値に使う。
-// 日付キーは toISOString() を使わず getMonth()+1 で組む（UTCずれで月がまたがるのを防ぐ）。
-export function getCurrentProductionMonth(now: Date = new Date()): string {
-  const year = now.getFullYear();
-  const month = String(now.getMonth() + 1).padStart(2, '0');
-  return `${year}-${month}`;
-}
-
-// 今日を yyyy-MM-dd で返す（ローカル時刻=現場のJST基準）。入力モーダルの作業日初期値に使う。
-export function getTodayWorkDate(now: Date = new Date()): string {
-  const year = now.getFullYear();
-  const month = String(now.getMonth() + 1).padStart(2, '0');
-  const day = String(now.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-}
+export { getCurrentMonth as getCurrentProductionMonth } from '@/lib/dateUtils';
+export { getTodayDateString as getTodayWorkDate } from '@/lib/dateUtils';
 
 export function calculateDefectRate(defectTotalGram: number, handpickedTotalGram: number): number {
   if (handpickedTotalGram <= 0) {

--- a/lib/workChime.ts
+++ b/lib/workChime.ts
@@ -1,3 +1,5 @@
+import { formatDateToYMD, formatTimeHM } from '@/lib/dateUtils';
+
 export type WorkChimeKind = 'break' | 'work-start' | 'work-resume' | 'cleanup-start';
 export type WorkChimePeriodKind = 'work' | 'break' | 'cleanup';
 
@@ -132,18 +134,8 @@ function normalizeSettings(value: unknown): WorkChimeSettings {
   };
 }
 
-function dateKey(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-}
-
-function timeKey(date: Date): string {
-  const hours = String(date.getHours()).padStart(2, '0');
-  const minutes = String(date.getMinutes()).padStart(2, '0');
-  return `${hours}:${minutes}`;
-}
+const dateKey = formatDateToYMD;
+const timeKey = formatTimeHM;
 
 function getSortedPeriods(settings: WorkChimeSettings): WorkChimePeriod[] {
   return [...settings.periods].sort((a, b) => a.start.localeCompare(b.start));


### PR DESCRIPTION
## Summary

- `lib/dateUtils.ts` に12個の関数を新規定義（JST基準・`toISOString()` 不使用）
- 5ファイル以上に分散していた YYYY-MM-DD 組立処理を `formatDateToYMD` に一本化
- 同名異目的の `formatTime` を目的別の名前に分離（`formatSecondsAsTimer` / `formatTimeHMS` / `buildClockTimeParts`）
- `lib/drip-guide/formatTime.ts` を削除し、3つの呼び出し元を `dateUtils` に移行
- `lib/productionRecords.ts` はバレル再エクスポートで後方互換を維持（呼び出し元変更なし）

## Closes

Closes #547

## 追加した関数（lib/dateUtils.ts）

| 関数名 | 説明 |
|--------|------|
| `formatDateToYMD` | Date → `yyyy-MM-dd`（JST基準） |
| `getTodayDateString` | 今日の日付文字列 |
| `getTomorrowDateString` | 明日の日付文字列 |
| `getCurrentMonth` | 当月 `yyyy-MM` |
| `getPreviousWeekday` | 前の平日 |
| `getNextWeekday` | 次の平日 |
| `formatDateToJapanese` | Date → `y年m月d日（曜）` |
| `formatDateStringToJapanese` | `yyyy-MM-dd` → 日本語形式 |
| `formatTimeHMS` | Date → `HH:MM:SS` |
| `formatTimeHM` | Date → `HH:MM` |
| `formatMinutesToHHMM` | 分数 → `HH:MM` |
| `formatSecondsAsTimer` | 秒数 → `MM:SS`（旧 `formatTime`） |

## Test plan

- [x] `npm run typecheck` — EXIT:0
- [x] `npm run lint` — EXIT:0
- [x] `npm run test:run` — 113ファイル / 1261テスト全通過
- [x] `npm run docs:check` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)