### PR TITLE
refactor: assignment共通ヘルパーとエラー通知基盤を lib/firestore/assignment に整備 (#543)

### DIFF
--- a/app/assignment/lib/firebase/helpers.ts
+++ b/app/assignment/lib/firebase/helpers.ts
@@ -1,109 +1,21 @@
-import { collection, doc } from 'firebase/firestore';
-import { db } from '@/lib/firebase';
-import { Assignment, TableSettings, ShuffleSettings, FirestoreTimestamp } from '@/types';
-
-// ===== ヘルパー関数: ユーザー配下のコレクション参照 =====
-function getUserAssignmentRoot(userId: string) {
-  return doc(db, 'users', userId);
-}
-
-export function getTeamsCollection(userId: string) {
-  return collection(getUserAssignmentRoot(userId), 'teams');
-}
-
-export function getMembersCollection(userId: string) {
-  return collection(getUserAssignmentRoot(userId), 'members');
-}
-
-export function getTaskLabelsCollection(userId: string) {
-  return collection(getUserAssignmentRoot(userId), 'taskLabels');
-}
-
-export function getAssignmentDaysCollection(userId: string) {
-  return collection(getUserAssignmentRoot(userId), 'assignmentDays');
-}
-
-export function getShuffleEventsCollection(userId: string) {
-  return collection(getUserAssignmentRoot(userId), 'shuffleEvents');
-}
-
-export function getShuffleHistoryCollection(userId: string) {
-  return collection(getUserAssignmentRoot(userId), 'shuffleHistory');
-}
-
-export function getAssignmentSettingsCollection(userId: string) {
-  return collection(getUserAssignmentRoot(userId), 'assignmentSettings');
-}
-
-export function getManagersCollection(userId: string) {
-  return collection(getUserAssignmentRoot(userId), 'managers');
-}
-
-export function getPairExclusionsCollection(userId: string) {
-  return collection(getUserAssignmentRoot(userId), 'pairExclusions');
-}
-
-const assignmentKey = (teamId: string, taskLabelId: string) => `${teamId}__${taskLabelId}`;
-
-export const toMillisSafe = (value?: FirestoreTimestamp | null): number => {
-  if (!value) return 0;
-  if (typeof value === 'string') {
-    const parsed = Date.parse(value);
-    return Number.isNaN(parsed) ? 0 : parsed;
-  }
-
-  const candidate = value as { toMillis?: () => number; seconds?: number; nanoseconds?: number };
-  if (typeof candidate.toMillis === 'function') {
-    const result = candidate.toMillis();
-    return typeof result === 'number' ? result : 0;
-  }
-
-  const seconds = typeof candidate.seconds === 'number' ? candidate.seconds : 0;
-  const nanoseconds = typeof candidate.nanoseconds === 'number' ? candidate.nanoseconds : 0;
-  return seconds * 1000 + Math.floor(nanoseconds / 1_000_000);
-};
-
-export const DEFAULT_SHUFFLE_SETTINGS: ShuffleSettings = {
-  crossTeamShuffle: false,
-  priority: 'pair',
-};
-
-export const DEFAULT_TABLE_SETTINGS: TableSettings = {
-  colWidths: {
-    taskLabel: 120,
-    note: 120,
-    teams: {},
-  },
-  rowHeights: {},
-  headerLabels: {
-    left: '担当',
-    right: 'メモ',
-  },
-};
-
-export const normalizeAssignmentsForDate = (assignments: Assignment[], date: string): Assignment[] => {
-  const map = new Map<string, Assignment>();
-  assignments.forEach((a) => {
-    map.set(assignmentKey(a.teamId, a.taskLabelId), { ...a, assignedDate: date, memberId: a.memberId ?? null });
-  });
-  return Array.from(map.values());
-};
-
-export const sortAssignmentsStable = (assignments: Assignment[]) =>
-  [...assignments].sort((a, b) => {
-    const teamDiff = a.teamId.localeCompare(b.teamId);
-    if (teamDiff !== 0) return teamDiff;
-    return a.taskLabelId.localeCompare(b.taskLabelId);
-  });
-
-export const areAssignmentsEqual = (a: Assignment[], b: Assignment[]) => {
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i++) {
-    const aItem = a[i];
-    const bItem = b[i];
-    if (aItem.teamId !== bItem.teamId || aItem.taskLabelId !== bItem.taskLabelId || aItem.memberId !== bItem.memberId) {
-      return false;
-    }
-  }
-  return true;
-};
+// レガシー互換シム（issue #543）
+// 汎用ヘルパーは lib/firestore/assignment/ へ移設済み。ここは既存 import を壊さないための再エクスポートのみ。
+// このファイルへ新しいロジックを追加しない。後続 #544〜#546 で各消費者を新モジュール直参照へ移行し、
+// 最終的に旧ディレクトリごと削除する。
+export {
+  getTeamsCollection,
+  getMembersCollection,
+  getTaskLabelsCollection,
+  getAssignmentDaysCollection,
+  getShuffleEventsCollection,
+  getShuffleHistoryCollection,
+  getAssignmentSettingsCollection,
+  getManagersCollection,
+  getPairExclusionsCollection,
+  toMillisSafe,
+  DEFAULT_SHUFFLE_SETTINGS,
+  DEFAULT_TABLE_SETTINGS,
+  normalizeAssignmentsForDate,
+  sortAssignmentsStable,
+  areAssignmentsEqual,
+} from '@/lib/firestore/assignment';

--- a/docs/superpowers/specs/2026-06-13-assignment-firestore-foundation-design.md
+++ b/docs/superpowers/specs/2026-06-13-assignment-firestore-foundation-design.md
@@ -86,7 +86,7 @@ export async function runWriteWithSync<T>(operation: () => Promise<T>): Promise<
 
 ### 4. index.ts — バレル
 
-references / helpers / sync の公開 API を re-export。
+references / helpers の公開 API を re-export。`sync.ts` の `createSyncedSubscription` / `runWriteWithSync` は消費者が現れる #544〜#546 でバレルへ追加する（未消費の API をバレルに先出しすると knip が未使用検出するため、消費と同時に公開する）。それまでは `./sync` から直接 import する。
 
 ## データフロー
 

--- a/docs/superpowers/specs/2026-06-13-assignment-firestore-foundation-design.md
+++ b/docs/superpowers/specs/2026-06-13-assignment-firestore-foundation-design.md
@@ -1,0 +1,121 @@
+# assignment データ層移行 (1/4): 共通ヘルパーとエラー通知基盤
+
+- **issue**: #543（親 #542 の最初の子）
+- **依存**: #547（dateUtils 集約）完了済み
+- **日付**: 2026-06-13
+
+## 目的
+
+`app/assignment/lib/firebase/` はデータ保護ガードレールに違反している（`onSnapshot` のエラーコールバック欠如・`setDoc` 直呼び＋`console.error` のみで保存失敗が無言）。この移行を 4 回に分けて行う。本 issue (#543) はその **土台** を作る。
+
+後続 #544〜#546 が共通して使う「購読エラー通知」「保存エラー通知」のヘルパーをここで確立し、`helpers.ts` の汎用部分を `lib/firestore/` 系へ一本化する。
+
+**スコープ境界**: 本 issue では消費者（settings/masterData/assignment/shuffle の各関数）の移行は **行わない**。土台（ヘルパー＋エラー通知基盤＋単体テスト）の用意までで止める。既存コードは壊さず動かし続ける。
+
+## 完了条件（issue より）
+
+- 移行先モジュールが存在し、汎用ヘルパーが `lib/firestore/` 系に一本化されている
+- 購読・保存のエラー通知ヘルパーが用意され、単体テストが付いている
+- `typecheck` / `lint` / `test:run` 通過
+
+## アーキテクチャ
+
+新規モジュール `lib/firestore/assignment/` を作る。
+
+```
+lib/firestore/assignment/
+  index.ts        バレルエクスポート
+  references.ts   コレクション参照（common.ts の getUserDocRef を土台に組み立てる）
+  helpers.ts      toMillisSafe・DEFAULT_* 定数・純粋関数（normalize/sort/areEqual）
+  sync.ts         createSyncedSubscription・runWriteWithSync（エラー通知基盤）
+  helpers.test.ts
+  sync.test.ts
+```
+
+旧 `app/assignment/lib/firebase/helpers.ts` は **再エクスポートの薄いシム** にする（既存 import を壊さない）。中身は新モジュールから re-export するだけ。
+
+### 1. references.ts — コレクション参照（common.ts と重複解消）
+
+旧 `helpers.ts` は `doc(db, 'users', userId)` で自前に住所を組んでいた。これを `common.ts` の `getUserDocRef(userId)` を土台に組み直す（重複解消が #543 の核心）。
+
+```ts
+import { collection } from 'firebase/firestore';
+import { getUserDocRef } from '../common';
+
+export function getTeamsCollection(userId: string) {
+  return collection(getUserDocRef(userId), 'teams');
+}
+// members / taskLabels / assignmentDays / shuffleEvents /
+// shuffleHistory / assignmentSettings / managers / pairExclusions も同様
+```
+
+### 2. helpers.ts — 汎用ロジック（移設のみ・挙動不変）
+
+旧 `helpers.ts` から **そのまま** 移す（挙動を変えない）:
+- `toMillisSafe`（Firestore 時刻 → ミリ秒。`firestoreUtils.toJSDate` と概念は近いが、`toMillis()` メソッド対応の差があるため挙動維持を優先し本 issue では統合しない）
+- `DEFAULT_SHUFFLE_SETTINGS` / `DEFAULT_TABLE_SETTINGS`
+- 純粋関数 `normalizeAssignmentsForDate` / `sortAssignmentsStable` / `areAssignmentsEqual`（＋内部の `assignmentKey`）
+
+### 3. sync.ts — エラー通知基盤（本 issue の主成果物）
+
+手本は `lib/firestore/userData/`。assignment は「小さな保存をたくさん」型なので、userData 級の write-queue はオーバースペック（YAGNI）。薄いラッパー 2 つにする。
+
+**購読ラッパー** `createSyncedSubscription` — `subscribeUserData` の再購読ロジックを汎用化。実際の `onSnapshot` 呼び出しは呼び出し側が渡す（doc / query の型差を吸収するため）。
+
+```ts
+export function createSyncedSubscription<S>(
+  attach: (onNext: (snapshot: S) => void, onError: (error: { code?: string }) => void) => () => void,
+  onData: (snapshot: S) => void
+): () => void
+```
+
+- 成功時: `retryCount` リセット、`clearSyncError()`、`onData(snapshot)`
+- 失敗時: `reportSyncError(toSyncErrorType(error))`、指数バックオフ（1s 起点・上限 30s）で再購読
+- 解除時: タイマー破棄、`unsubscribe()`、`clearSyncError()`
+
+**保存ラッパー** `runWriteWithSync` — 保存処理を包み、失敗を通知して再 throw。
+
+```ts
+export async function runWriteWithSync<T>(operation: () => Promise<T>): Promise<T>
+```
+
+- 成功時: `clearSaveError()`（write-queue と同じ挙動）、結果を返す
+- 失敗時: `reportSaveError(toSyncErrorType(error))` してから `throw`（呼び出し側にも伝える）
+
+> 補足: `reportSyncError`/`reportSaveError` は userData と同じ単一チャンネル。assignment 保存成功で `clearSaveError()` する挙動は既存 write-queue と一貫させる。
+
+### 4. index.ts — バレル
+
+references / helpers / sync の公開 API を re-export。
+
+## データフロー
+
+```
+#544〜#546 の各関数（後続）
+  └ 購読: createSyncedSubscription((onNext,onError)=>onSnapshot(ref,onNext,onError), cb)
+  └ 保存: runWriteWithSync(() => setDoc(...))
+        └ 失敗 → lib/syncStatus（reportSyncError / reportSaveError）→ 同期/保存バナー
+```
+
+本 issue ではこのフローの **道具とテスト** までを用意する。
+
+## エラーハンドリング
+
+- 業務データの購読・保存失敗は必ず `lib/syncStatus` 経由でユーザー通知（ガードレール準拠）
+- `runWriteWithSync` の `console.error` は `reportSaveError` と必ず併用（「console.error だけ」を新規に書かない）
+
+## テスト
+
+- `helpers.test.ts`: `toMillisSafe`（null/文字列/`toMillis()`/seconds・nanoseconds）、`normalizeAssignmentsForDate`、`sortAssignmentsStable`、`areAssignmentsEqual` の純粋関数テスト
+- `sync.test.ts`: `syncStatus` をモックし、
+  - 購読成功で `clearSyncError` 呼び出し・`onData` 受け渡し
+  - 購読失敗で `reportSyncError` 呼び出し・再購読タイマー発火（fake timers）
+  - 解除で `unsubscribe` と `clearSyncError`
+  - `runWriteWithSync` 成功で結果返却＋`clearSaveError`、失敗で `reportSaveError`＋再 throw
+
+## 非対象（YAGNI / 後続）
+
+- 消費者関数の移行（#544〜#546）
+- `toMillisSafe` と `firestoreUtils.toJSDate` の統合（挙動差リスクのため見送り）
+- `FirestoreTimestamp` 型の重複解消（#543 の範囲外）
+- write-queue 級の同時書き込み制御（assignment には過剰）

--- a/lib/firestore/assignment/helpers.test.ts
+++ b/lib/firestore/assignment/helpers.test.ts
@@ -45,10 +45,7 @@ describe('toMillisSafe', () => {
 
 describe('normalizeAssignmentsForDate', () => {
   it('全件に指定日を付与し memberId 未指定は null になる', () => {
-    const result = normalizeAssignmentsForDate(
-      [{ teamId: 't1', taskLabelId: 'l1' } as Assignment],
-      '2026-06-13'
-    );
+    const result = normalizeAssignmentsForDate([{ teamId: 't1', taskLabelId: 'l1' } as Assignment], '2026-06-13');
     expect(result).toEqual([{ teamId: 't1', taskLabelId: 'l1', memberId: null, assignedDate: '2026-06-13' }]);
   });
 

--- a/lib/firestore/assignment/helpers.test.ts
+++ b/lib/firestore/assignment/helpers.test.ts
@@ -1,0 +1,98 @@
+// assignment 移行(1/4): 移設した汎用ロジックの単体テスト
+import { describe, it, expect } from 'vitest';
+import {
+  toMillisSafe,
+  normalizeAssignmentsForDate,
+  sortAssignmentsStable,
+  areAssignmentsEqual,
+  DEFAULT_SHUFFLE_SETTINGS,
+  DEFAULT_TABLE_SETTINGS,
+} from './helpers';
+import type { Assignment } from '@/types';
+
+const makeAssignment = (over: Partial<Assignment> = {}): Assignment => ({
+  teamId: 't1',
+  taskLabelId: 'l1',
+  memberId: null,
+  assignedDate: '2026-06-13',
+  ...over,
+});
+
+describe('toMillisSafe', () => {
+  it('null / undefined は 0 を返す', () => {
+    expect(toMillisSafe(null)).toBe(0);
+    expect(toMillisSafe(undefined)).toBe(0);
+  });
+
+  it('ISO 文字列はパースしたミリ秒を返す', () => {
+    expect(toMillisSafe('2026-06-13T00:00:00.000Z')).toBe(Date.parse('2026-06-13T00:00:00.000Z'));
+  });
+
+  it('不正な文字列は 0 を返す', () => {
+    expect(toMillisSafe('not-a-date')).toBe(0);
+  });
+
+  it('toMillis() を持つ Timestamp はその値を返す', () => {
+    const ts = { toMillis: () => 1234 } as never;
+    expect(toMillisSafe(ts)).toBe(1234);
+  });
+
+  it('seconds / nanoseconds から計算する', () => {
+    const ts = { seconds: 2, nanoseconds: 500_000_000 };
+    expect(toMillisSafe(ts)).toBe(2500);
+  });
+});
+
+describe('normalizeAssignmentsForDate', () => {
+  it('全件に指定日を付与し memberId 未指定は null になる', () => {
+    const result = normalizeAssignmentsForDate(
+      [{ teamId: 't1', taskLabelId: 'l1' } as Assignment],
+      '2026-06-13'
+    );
+    expect(result).toEqual([{ teamId: 't1', taskLabelId: 'l1', memberId: null, assignedDate: '2026-06-13' }]);
+  });
+
+  it('teamId__taskLabelId が重複する場合は後勝ちで 1 件に統合する', () => {
+    const result = normalizeAssignmentsForDate(
+      [makeAssignment({ memberId: 'm1' }), makeAssignment({ memberId: 'm2' })],
+      '2026-06-13'
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].memberId).toBe('m2');
+  });
+});
+
+describe('sortAssignmentsStable', () => {
+  it('teamId → taskLabelId の順で安定ソートする', () => {
+    const result = sortAssignmentsStable([
+      makeAssignment({ teamId: 't2', taskLabelId: 'l1' }),
+      makeAssignment({ teamId: 't1', taskLabelId: 'l2' }),
+      makeAssignment({ teamId: 't1', taskLabelId: 'l1' }),
+    ]);
+    expect(result.map((a) => `${a.teamId}/${a.taskLabelId}`)).toEqual(['t1/l1', 't1/l2', 't2/l1']);
+  });
+});
+
+describe('areAssignmentsEqual', () => {
+  it('件数が違えば false', () => {
+    expect(areAssignmentsEqual([makeAssignment()], [])).toBe(false);
+  });
+
+  it('teamId / taskLabelId / memberId が一致すれば true', () => {
+    expect(areAssignmentsEqual([makeAssignment({ memberId: 'm1' })], [makeAssignment({ memberId: 'm1' })])).toBe(true);
+  });
+
+  it('memberId が違えば false', () => {
+    expect(areAssignmentsEqual([makeAssignment({ memberId: 'm1' })], [makeAssignment({ memberId: 'm2' })])).toBe(false);
+  });
+});
+
+describe('デフォルト定数', () => {
+  it('DEFAULT_SHUFFLE_SETTINGS を保持する', () => {
+    expect(DEFAULT_SHUFFLE_SETTINGS).toEqual({ crossTeamShuffle: false, priority: 'pair' });
+  });
+
+  it('DEFAULT_TABLE_SETTINGS の見出しを保持する', () => {
+    expect(DEFAULT_TABLE_SETTINGS.headerLabels).toEqual({ left: '担当', right: 'メモ' });
+  });
+});

--- a/lib/firestore/assignment/helpers.ts
+++ b/lib/firestore/assignment/helpers.ts
@@ -1,0 +1,69 @@
+// assignment データ層の汎用ロジック（旧 app/assignment/lib/firebase/helpers.ts から移設）
+// 挙動は変えず lib/firestore/ 系へ一本化する（issue #543）
+import type { Assignment, TableSettings, ShuffleSettings, FirestoreTimestamp } from '@/types';
+
+const assignmentKey = (teamId: string, taskLabelId: string) => `${teamId}__${taskLabelId}`;
+
+// Firestore の時刻（Timestamp / ISO 文字列）をミリ秒に変換する。ソート用。
+export const toMillisSafe = (value?: FirestoreTimestamp | null): number => {
+  if (!value) return 0;
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  }
+
+  const candidate = value as { toMillis?: () => number; seconds?: number; nanoseconds?: number };
+  if (typeof candidate.toMillis === 'function') {
+    const result = candidate.toMillis();
+    return typeof result === 'number' ? result : 0;
+  }
+
+  const seconds = typeof candidate.seconds === 'number' ? candidate.seconds : 0;
+  const nanoseconds = typeof candidate.nanoseconds === 'number' ? candidate.nanoseconds : 0;
+  return seconds * 1000 + Math.floor(nanoseconds / 1_000_000);
+};
+
+export const DEFAULT_SHUFFLE_SETTINGS: ShuffleSettings = {
+  crossTeamShuffle: false,
+  priority: 'pair',
+};
+
+export const DEFAULT_TABLE_SETTINGS: TableSettings = {
+  colWidths: {
+    taskLabel: 120,
+    note: 120,
+    teams: {},
+  },
+  rowHeights: {},
+  headerLabels: {
+    left: '担当',
+    right: 'メモ',
+  },
+};
+
+export const normalizeAssignmentsForDate = (assignments: Assignment[], date: string): Assignment[] => {
+  const map = new Map<string, Assignment>();
+  assignments.forEach((a) => {
+    map.set(assignmentKey(a.teamId, a.taskLabelId), { ...a, assignedDate: date, memberId: a.memberId ?? null });
+  });
+  return Array.from(map.values());
+};
+
+export const sortAssignmentsStable = (assignments: Assignment[]) =>
+  [...assignments].sort((a, b) => {
+    const teamDiff = a.teamId.localeCompare(b.teamId);
+    if (teamDiff !== 0) return teamDiff;
+    return a.taskLabelId.localeCompare(b.taskLabelId);
+  });
+
+export const areAssignmentsEqual = (a: Assignment[], b: Assignment[]) => {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const aItem = a[i];
+    const bItem = b[i];
+    if (aItem.teamId !== bItem.teamId || aItem.taskLabelId !== bItem.taskLabelId || aItem.memberId !== bItem.memberId) {
+      return false;
+    }
+  }
+  return true;
+};

--- a/lib/firestore/assignment/index.ts
+++ b/lib/firestore/assignment/index.ts
@@ -23,5 +23,6 @@ export {
   areAssignmentsEqual,
 } from './helpers';
 
-// 購読・保存のエラー通知基盤
-export { createSyncedSubscription, runWriteWithSync } from './sync';
+// 購読・保存のエラー通知基盤は ./sync に置く。
+// 消費者が現れる #544〜#546 で、各消費者の import に合わせてここへ再エクスポートを追加する
+// （未消費の API をバレルに先出しすると knip が未使用検出するため、消費と同時に公開する）。

--- a/lib/firestore/assignment/index.ts
+++ b/lib/firestore/assignment/index.ts
@@ -1,0 +1,27 @@
+// lib/firestore/assignment バレルエクスポート（issue #543）
+
+// コレクション参照
+export {
+  getTeamsCollection,
+  getMembersCollection,
+  getTaskLabelsCollection,
+  getAssignmentDaysCollection,
+  getShuffleEventsCollection,
+  getShuffleHistoryCollection,
+  getAssignmentSettingsCollection,
+  getManagersCollection,
+  getPairExclusionsCollection,
+} from './references';
+
+// 汎用ロジック・定数
+export {
+  toMillisSafe,
+  DEFAULT_SHUFFLE_SETTINGS,
+  DEFAULT_TABLE_SETTINGS,
+  normalizeAssignmentsForDate,
+  sortAssignmentsStable,
+  areAssignmentsEqual,
+} from './helpers';
+
+// 購読・保存のエラー通知基盤
+export { createSyncedSubscription, runWriteWithSync } from './sync';

--- a/lib/firestore/assignment/references.ts
+++ b/lib/firestore/assignment/references.ts
@@ -1,0 +1,40 @@
+// assignment 配下のコレクション参照
+// common.ts の getUserDocRef を土台にして、ユーザードキュメント参照の重複を解消する（issue #543）
+import { collection } from 'firebase/firestore';
+import { getUserDocRef } from '../common';
+
+export function getTeamsCollection(userId: string) {
+  return collection(getUserDocRef(userId), 'teams');
+}
+
+export function getMembersCollection(userId: string) {
+  return collection(getUserDocRef(userId), 'members');
+}
+
+export function getTaskLabelsCollection(userId: string) {
+  return collection(getUserDocRef(userId), 'taskLabels');
+}
+
+export function getAssignmentDaysCollection(userId: string) {
+  return collection(getUserDocRef(userId), 'assignmentDays');
+}
+
+export function getShuffleEventsCollection(userId: string) {
+  return collection(getUserDocRef(userId), 'shuffleEvents');
+}
+
+export function getShuffleHistoryCollection(userId: string) {
+  return collection(getUserDocRef(userId), 'shuffleHistory');
+}
+
+export function getAssignmentSettingsCollection(userId: string) {
+  return collection(getUserDocRef(userId), 'assignmentSettings');
+}
+
+export function getManagersCollection(userId: string) {
+  return collection(getUserDocRef(userId), 'managers');
+}
+
+export function getPairExclusionsCollection(userId: string) {
+  return collection(getUserDocRef(userId), 'pairExclusions');
+}

--- a/lib/firestore/assignment/sync.test.ts
+++ b/lib/firestore/assignment/sync.test.ts
@@ -1,0 +1,107 @@
+// assignment 移行(1/4): 購読・保存のエラー通知基盤テスト
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createSyncedSubscription, runWriteWithSync } from './sync';
+import {
+  getSyncError,
+  getSaveError,
+  clearSyncError,
+  clearSaveError,
+  reportSyncError,
+  reportSaveError,
+} from '@/lib/syncStatus';
+
+describe('createSyncedSubscription', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    clearSyncError();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    clearSyncError();
+  });
+
+  it('成功スナップショットを onData に渡し、同期エラーを解除する', () => {
+    reportSyncError('unavailable'); // 事前にエラーが残っている状態
+    const onData = vi.fn();
+
+    createSyncedSubscription<string>((onNext) => {
+      onNext('snap-1');
+      return () => {};
+    }, onData);
+
+    expect(onData).toHaveBeenCalledWith('snap-1');
+    expect(getSyncError()).toBeNull();
+  });
+
+  it('購読失敗で reportSyncError を呼び、バックオフ後に再購読する', () => {
+    let attachCount = 0;
+    let lastOnError: (error: { code?: string }) => void = () => {};
+
+    createSyncedSubscription<string>((_onNext, onError) => {
+      attachCount += 1;
+      lastOnError = onError;
+      return () => {};
+    }, vi.fn());
+
+    expect(attachCount).toBe(1);
+
+    lastOnError({ code: 'unavailable' });
+    expect(getSyncError()).toBe('unavailable');
+
+    // 1 回目のバックオフ（1000ms 起点）で再購読される
+    vi.advanceTimersByTime(1000);
+    expect(attachCount).toBe(2);
+  });
+
+  it('解除後は再購読タイマーが発火せず、同期エラーも解除する', () => {
+    let attachCount = 0;
+    let lastOnError: (error: { code?: string }) => void = () => {};
+    const unsubscribe = vi.fn();
+
+    const stop = createSyncedSubscription<string>((_onNext, onError) => {
+      attachCount += 1;
+      lastOnError = onError;
+      return unsubscribe;
+    }, vi.fn());
+
+    lastOnError({ code: 'unavailable' });
+    stop();
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    expect(getSyncError()).toBeNull();
+
+    vi.advanceTimersByTime(60_000);
+    expect(attachCount).toBe(1); // 再購読されない
+  });
+});
+
+describe('runWriteWithSync', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    clearSaveError();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    clearSaveError();
+  });
+
+  it('成功時は結果を返し、保存エラーを解除する', async () => {
+    reportSaveError('unknown'); // 事前にエラーが残っている状態
+
+    const result = await runWriteWithSync(async () => 'done');
+
+    expect(result).toBe('done');
+    expect(getSaveError()).toBeNull();
+  });
+
+  it('失敗時は reportSaveError を呼び、例外を再 throw する', async () => {
+    await expect(runWriteWithSync(async () => { throw { code: 'permission-denied' }; })).rejects.toEqual({
+      code: 'permission-denied',
+    });
+    expect(getSaveError()).toBe('permission-denied');
+  });
+});

--- a/lib/firestore/assignment/sync.test.ts
+++ b/lib/firestore/assignment/sync.test.ts
@@ -99,7 +99,11 @@ describe('runWriteWithSync', () => {
   });
 
   it('失敗時は reportSaveError を呼び、例外を再 throw する', async () => {
-    await expect(runWriteWithSync(async () => { throw { code: 'permission-denied' }; })).rejects.toEqual({
+    await expect(
+      runWriteWithSync(async () => {
+        throw { code: 'permission-denied' };
+      })
+    ).rejects.toEqual({
       code: 'permission-denied',
     });
     expect(getSaveError()).toBe('permission-denied');

--- a/lib/firestore/assignment/sync.ts
+++ b/lib/firestore/assignment/sync.ts
@@ -1,13 +1,7 @@
 // assignment の購読・保存エラーをユーザー通知（lib/syncStatus）につなぐ基盤（issue #543）
 // 手本は lib/firestore/userData/。assignment は小さな保存が多いので write-queue 級は過剰（YAGNI）。
 // 薄いラッパー 2 つに留める。後続 #544〜#546 の各関数がこれを使う。
-import {
-  reportSyncError,
-  clearSyncError,
-  reportSaveError,
-  clearSaveError,
-  toSyncErrorType,
-} from '@/lib/syncStatus';
+import { reportSyncError, clearSyncError, reportSaveError, clearSaveError, toSyncErrorType } from '@/lib/syncStatus';
 
 // onSnapshot はエラーで購読が恒久停止するため、指数バックオフで再購読する（subscribeUserData と同方針）
 const RESUBSCRIBE_BASE_DELAY_MS = 1000;

--- a/lib/firestore/assignment/sync.ts
+++ b/lib/firestore/assignment/sync.ts
@@ -1,0 +1,94 @@
+// assignment の購読・保存エラーをユーザー通知（lib/syncStatus）につなぐ基盤（issue #543）
+// 手本は lib/firestore/userData/。assignment は小さな保存が多いので write-queue 級は過剰（YAGNI）。
+// 薄いラッパー 2 つに留める。後続 #544〜#546 の各関数がこれを使う。
+import {
+  reportSyncError,
+  clearSyncError,
+  reportSaveError,
+  clearSaveError,
+  toSyncErrorType,
+} from '@/lib/syncStatus';
+
+// onSnapshot はエラーで購読が恒久停止するため、指数バックオフで再購読する（subscribeUserData と同方針）
+const RESUBSCRIBE_BASE_DELAY_MS = 1000;
+const RESUBSCRIBE_MAX_DELAY_MS = 30_000;
+
+/**
+ * onSnapshot 購読を、同期エラー通知＋指数バックオフ再購読で包む。
+ *
+ * 実際の onSnapshot 呼び出しは `attach` を通じて呼び出し側が行う。
+ * doc 購読と query 購読でスナップショット型が異なるため、型 S は呼び出し側が決める。
+ *
+ * @param attach 成功ハンドラ・エラーハンドラを受け取り onSnapshot を張って unsubscribe を返す関数
+ * @param onData 成功スナップショットの処理
+ * @returns 購読解除関数
+ */
+export function createSyncedSubscription<S>(
+  attach: (onNext: (snapshot: S) => void, onError: (error: { code?: string }) => void) => () => void,
+  onData: (snapshot: S) => void
+): () => void {
+  let stopped = false;
+  let retryCount = 0;
+  let retryTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  let unsubscribeSnapshot: () => void = () => {};
+
+  const start = () => {
+    unsubscribeSnapshot = attach(
+      (snapshot) => {
+        retryCount = 0;
+        clearSyncError();
+        onData(snapshot);
+      },
+      (error) => {
+        console.error('Error in assignment Firestore subscription:', error);
+        // エラー時は onData を呼ばない（既存データを保持）。同期できていないことを UI へ通知する
+        reportSyncError(toSyncErrorType(error));
+
+        // 同一世代でエラーが連続した場合は前のタイマーを破棄し、二重再購読を防ぐ
+        if (retryTimeoutId) {
+          clearTimeout(retryTimeoutId);
+        }
+        const delay = Math.min(RESUBSCRIBE_MAX_DELAY_MS, RESUBSCRIBE_BASE_DELAY_MS * 2 ** retryCount);
+        retryCount += 1;
+        retryTimeoutId = setTimeout(() => {
+          retryTimeoutId = null;
+          if (!stopped) {
+            start();
+          }
+        }, delay);
+      }
+    );
+  };
+
+  start();
+
+  return () => {
+    stopped = true;
+    if (retryTimeoutId) {
+      clearTimeout(retryTimeoutId);
+      retryTimeoutId = null;
+    }
+    unsubscribeSnapshot();
+    // 購読が無くなった後にバナーが残り続けないようにする（ログアウト時など）
+    clearSyncError();
+  };
+}
+
+/**
+ * 保存処理を包み、失敗をユーザー通知（保存バナー）につなげてから再 throw する。
+ * 成功時は保存エラーを解除する（write-queue と同じ単一チャンネルの挙動）。
+ *
+ * @param operation Firestore への書き込み処理
+ * @returns operation の戻り値
+ */
+export async function runWriteWithSync<T>(operation: () => Promise<T>): Promise<T> {
+  try {
+    const result = await operation();
+    clearSaveError();
+    return result;
+  } catch (error) {
+    console.error('Failed to save assignment data to Firestore:', error);
+    reportSaveError(toSyncErrorType(error as { code?: string }));
+    throw error;
+  }
+}


### PR DESCRIPTION
@
## 概要

親issue #542「assignmentデータ層を `lib/firestore/` へ移行」の子issue **#543（1/4・土台）**。後続 #544〜#546 が共通して使う「購読エラー通知」「保存エラー通知」のヘルパーを確立し、`helpers.ts` の汎用部分を `lib/firestore/` 系へ一本化する。

Closes #543

## 変更内容

### 新設 `lib/firestore/assignment/`
- **`references.ts`** — 9つのコレクション参照を、旧 `doc(db,users,userId)` 自前組み立てから `common.ts` の `getUserDocRef(userId)` を土台に再構築（common.ts との重複解消）
- **`helpers.ts`** — `toMillisSafe`・`DEFAULT_SHUFFLE_SETTINGS`・`DEFAULT_TABLE_SETTINGS`・`normalizeAssignmentsForDate`・`sortAssignmentsStable`・`areAssignmentsEqual` を**挙動不変**で移設
- **`sync.ts`**（本PRの主成果物）
  - `createSyncedSubscription(attach, onData)` — `onSnapshot` を失敗時 `reportSyncError`＋指数バックオフ再購読で包む。doc/query の型差は `attach` 注入で吸収（`subscribeUserData` と同方針）
  - `runWriteWithSync(operation)` — 保存失敗時 `reportSaveError`＋再throw、成功時 `clearSaveError`
- **`index.ts`** — バレル
- **`helpers.test.ts` / `sync.test.ts`** — 単体テスト18件

### シム化
- 旧 `app/assignment/lib/firebase/helpers.ts` を**再エクスポートのみ**に置換。消費者5ファイル（settings/masterData/assignment/shuffle/index）は無変更で動作。

## スコープ境界
- 消費者関数の実際の移行は後続 **#544〜#546**。本PRは土台＋テストまで。
- knip が `createSyncedSubscription`/`runWriteWithSync` を未使用と報告するのは #544 で消える想定（DeadCode は CI 必須外）。

## 検証
- ✅ `npm run typecheck`
- ✅ `npm run lint`
- ✅ `npm run test:run`（1285件全パス・新規18件含む）
- ✅ コードレビュー(high) 指摘なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@