### PR TITLE
feat(inventory): Firestore Rules に inventory コレクションを追加 (PR1/2)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -143,6 +143,14 @@ service cloud.firestore {
       allow write: if false;
     }
 
+    // 在庫・不足品（チーム共有・シングルテナント前提）
+    // 認証済みメンバー全員が読み書き・削除可能（owner isolation の意図的な例外）。
+    // 「現場メンバーが"足りない"を共有し、本社が見て発注する」共有ボードのため、
+    // 全員が同じ inventory コレクションを編集できる必要がある。
+    match /inventory/{itemId} {
+      allow read, write: if request.auth != null;
+    }
+
     // 担当表機能（ルート直下は無効化）
     // 設計当初からデータは /users/{userId}/ 配下に置く構造のため、
     // ルート直下コレクションへの誤アクセスを明示的に拒否する。

--- a/tests/rules/firebase.rules.test.ts
+++ b/tests/rules/firebase.rules.test.ts
@@ -471,6 +471,27 @@ describe('Firestore rules', () => {
       await assertFails(firestoreFor(OWN_UID).doc(nestedPath).get());
     });
   });
+
+  describe('inventory', () => {
+    it('allows any signed-in member to read/write, denies anonymous (team-shared)', async () => {
+      const item = { name: 'ドリップ袋', status: 'low' };
+      const ownerDoc = firestoreFor(OWN_UID).doc('inventory/item_1');
+      const otherDoc = firestoreFor(OTHER_UID).doc('inventory/item_1');
+      const anonymousDoc = firestoreFor().doc('inventory/item_1');
+
+      // 未認証は読み書きとも拒否
+      await assertFails(anonymousDoc.get());
+      await assertFails(anonymousDoc.set(item));
+
+      // 認証済みメンバーは読み書き可
+      await assertSucceeds(ownerDoc.set(item));
+      await assertSucceeds(ownerDoc.get());
+
+      // 別メンバーも読み書き可（チーム共有。defectBeans と異なり全員が編集可）
+      await assertSucceeds(otherDoc.get());
+      await assertSucceeds(otherDoc.set({ name: 'ドリップ袋', status: 'out' }));
+    });
+  });
 });
 
 describe('Storage rules', () => {


### PR DESCRIPTION
## 概要

在庫・不足品の共有ボード機能を main に載せ替える作業の **PR1（ルールのみ）** です。機能本体は後続の PR2 で移植します。

## 変更内容

- `firestore.rules`: `inventory` コレクションの match を追加
  - 認証済みメンバー全員が read/write/delete 可能（owner isolation の意図的な例外）
  - 「現場メンバーが"足りない"を共有し、本社が見て発注する」共有ボードのため、全員が同じ `inventory` を編集できる必要がある
- `tests/rules/firebase.rules.test.ts`: 在庫ルールのテストを追加（未認証は拒否・認証済みは全員読み書き可）

## 検証

- `npm run test:rules` … ルールテスト **全46件通過**
- `npm run typecheck` … 通過
- `npm run lint` … 通過

## 補足

- 本番ルールはこの PR を main にマージした時点で CI により自動デプロイされます（権限を緩める変更のため、マージ＝最終承認）。
- まだ誰も `inventory` に書き込まないため、PR2（機能本体）より先行してマージしても安全です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)