### PR TITLE
feat(inventory): 在庫・不足品の共有ボードを追加 (PR2/2)

### DIFF
--- a/app/inventory/page.test.tsx
+++ b/app/inventory/page.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { InventoryItem } from '@/types';
+
+const mockUseAuth = vi.fn();
+const mockUseInventory = vi.fn();
+const mockShowToast = vi.fn();
+
+vi.mock('@/lib/auth', () => ({ useAuth: () => mockUseAuth() }));
+vi.mock('@/hooks/useInventory', () => ({ useInventory: () => mockUseInventory() }));
+vi.mock('@/lib/firestore', () => ({
+  addInventoryItem: vi.fn().mockResolvedValue(undefined),
+  updateInventoryItem: vi.fn().mockResolvedValue(undefined),
+  setInventoryItemStatus: vi.fn().mockResolvedValue(undefined),
+  deleteInventoryItem: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@/components/Toast', () => ({ useToastContext: () => ({ showToast: mockShowToast }) }));
+// Modal/Dialog は framer-motion を使うため、テストではアニメーションを素通しさせる
+vi.mock('framer-motion', () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: {
+    div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+  },
+}));
+
+import InventoryPage from './page';
+import { deleteInventoryItem } from '@/lib/firestore';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseAuth.mockReturnValue({ user: { uid: 'u1', displayName: '池田' }, loading: false });
+});
+
+describe('InventoryPage', () => {
+  it('品目があれば一覧に名前を表示する', () => {
+    const items: InventoryItem[] = [{ id: 'a', name: 'ドリップ袋', status: 'low' }];
+    mockUseInventory.mockReturnValue({ items, isLoading: false });
+    render(<InventoryPage />);
+    // low の品目は要発注リストと全品目一覧の両方に出るため複数ヒットする
+    expect(screen.getAllByText('ドリップ袋').length).toBeGreaterThan(0);
+  });
+
+  it('要発注（low/out）の件数を見出しに表示する', () => {
+    const items: InventoryItem[] = [
+      { id: 'a', name: 'ドリップ袋', status: 'low' },
+      { id: 'b', name: 'ラベル', status: 'out' },
+      { id: 'c', name: '段ボール', status: 'enough' },
+    ];
+    mockUseInventory.mockReturnValue({ items, isLoading: false });
+    render(<InventoryPage />);
+    // 件数バッジは「要発注リスト」見出しの隣の pill。見出しを含む section-head の
+    // テキストに要発注数(=2)が出ることを確認する（h1「在庫・不足品」とは name で区別）。
+    const reorderHeading = screen.getByRole('heading', { name: '要発注リスト' });
+    expect(reorderHeading.parentElement).toHaveTextContent('要発注リスト2');
+  });
+
+  it('(F) 品目が空かつ非ローディングなら全品目セクションに空状態を表示する', () => {
+    mockUseInventory.mockReturnValue({ items: [], isLoading: false });
+    render(<InventoryPage />);
+    expect(screen.getByText('品目がありません')).toBeInTheDocument();
+  });
+
+  it('(F) ローディング中は空状態を表示しない', () => {
+    mockUseInventory.mockReturnValue({ items: [], isLoading: true });
+    render(<InventoryPage />);
+    expect(screen.queryByText('品目がありません')).not.toBeInTheDocument();
+  });
+
+  it('(A) 別品目の編集に切り替えるとモーダルの値が入れ替わる', () => {
+    const items: InventoryItem[] = [
+      { id: 'a', name: 'ドリップ袋', status: 'enough' },
+      { id: 'b', name: 'ラベル', status: 'enough' },
+    ];
+    mockUseInventory.mockReturnValue({ items, isLoading: false });
+    render(<InventoryPage />);
+
+    // 1件目「ドリップ袋」の編集ボタンを押す（編集はアイコンボタンで aria-label に品目名を含む）
+    fireEvent.click(screen.getByRole('button', { name: 'ドリップ袋を編集' }));
+    expect((screen.getByLabelText('品目名') as HTMLInputElement).value).toBe('ドリップ袋');
+
+    // モーダルを閉じてから2件目「ラベル」を編集 → 値が入れ替わる
+    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+    fireEvent.click(screen.getByRole('button', { name: 'ラベルを編集' }));
+    expect((screen.getByLabelText('品目名') as HTMLInputElement).value).toBe('ラベル');
+  });
+
+  it('(D) 削除ボタンは即削除せず確認ダイアログを挟み、確定で削除する', async () => {
+    const items: InventoryItem[] = [{ id: 'a', name: 'ドリップ袋', status: 'enough' }];
+    mockUseInventory.mockReturnValue({ items, isLoading: false });
+    render(<InventoryPage />);
+
+    // 削除ボタン（アイコンボタン）押下では即時に削除されない
+    fireEvent.click(screen.getByRole('button', { name: 'ドリップ袋を削除' }));
+    expect(deleteInventoryItem).not.toHaveBeenCalled();
+
+    // 確認ダイアログが表示される
+    expect(screen.getByText('品目を削除しますか？')).toBeInTheDocument();
+    expect(screen.getByText('共有在庫なので全員に反映されます')).toBeInTheDocument();
+
+    // ダイアログの確定ボタン「削除」で初めて削除される。
+    // 一覧の削除はアイコンボタン（aria-label に品目名を含む）なので、
+    // ダイアログの確定ボタン「削除」とは name で区別できる。
+    fireEvent.click(screen.getByRole('button', { name: '削除' }));
+    await waitFor(() => expect(deleteInventoryItem).toHaveBeenCalledWith('a'));
+  });
+});

--- a/app/inventory/page.tsx
+++ b/app/inventory/page.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { useState } from 'react';
+import { MdInventory2, MdAdd } from 'react-icons/md';
+import { Button, Card, Dialog, EmptyState, FloatingNav } from '@/components/ui';
+import { InventoryItemRow } from '@/components/inventory/InventoryItemRow';
+import { InventoryItemModal } from '@/components/inventory/InventoryItemModal';
+import { ReorderList } from '@/components/inventory/ReorderList';
+import { useAuth } from '@/lib/auth';
+import { useInventory } from '@/hooks/useInventory';
+import { useToastContext } from '@/components/Toast';
+import { isE2EMode } from '@/lib/e2eMode';
+import { addInventoryItem, updateInventoryItem, setInventoryItemStatus, deleteInventoryItem } from '@/lib/firestore';
+import { countReorderItems } from '@/lib/inventory';
+import type { InventoryItem, InventoryItemInput, InventoryStatus } from '@/types';
+
+// E2Eモード(スクショ/デザイン検証)専用のサンプル品目。
+// 本番Firestoreは認証を要するため通常起動時は空になる。本番では isE2EMode() が false なので使われない。
+const E2E_SAMPLE_ITEMS: InventoryItem[] = [
+  { id: 'e1', name: '三方袋', status: 'enough', updatedAt: '2026-06-01T07:17:00' },
+  { id: 'e2', name: 'ドリップパック', status: 'out', updatedAt: '2026-06-01T07:19:00' },
+  { id: 'e3', name: 'ブレンド生豆', status: 'low', updatedAt: '2026-06-01T06:58:00' },
+  { id: 'e4', name: 'テイクアウトカップ M', status: 'enough', updatedAt: '2026-05-31T18:40:00' },
+  { id: 'e5', name: 'ペーパーフィルター', status: 'low', updatedAt: '2026-05-31T18:42:00' },
+];
+
+export default function InventoryPage() {
+  const { user, loading } = useAuth();
+  const { items: liveItems, isLoading } = useInventory();
+  const { showToast } = useToastContext();
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editing, setEditing] = useState<InventoryItem | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<InventoryItem | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  // E2Eモードかつ実データが空のときだけ、デザイン検証用サンプルを表示する
+  const usingSampleData = isE2EMode() && liveItems.length === 0;
+  const items = usingSampleData ? E2E_SAMPLE_ITEMS : liveItems;
+  // サンプル表示中はローディングを出さない（本番では usingSampleData が false なので従来どおり）
+  const showLoading = isLoading && !usingSampleData;
+  const reorderCount = countReorderItems(items);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-page px-4 pt-20 text-ink-sub transition-colors duration-1000">読み込み中...</div>
+    );
+  }
+  if (!user) {
+    return (
+      <div className="min-h-screen bg-page px-4 pt-20 text-ink-sub transition-colors duration-1000">
+        ログインが必要です
+      </div>
+    );
+  }
+
+  const handleSave = async (input: InventoryItemInput) => {
+    try {
+      if (editing) {
+        await updateInventoryItem(editing.id, input);
+        showToast('品目を更新しました', 'success');
+      } else {
+        await addInventoryItem(input);
+        showToast('品目を追加しました', 'success');
+      }
+      setModalOpen(false);
+      setEditing(null);
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : '保存に失敗しました', 'error');
+    }
+  };
+
+  // 通常の状態トグル。頻繁に押すため成功トーストは出さず、失敗時のみ通知する。
+  const handleStatusChange = async (item: InventoryItem, status: InventoryStatus) => {
+    try {
+      await setInventoryItemStatus(item.id, status);
+    } catch {
+      showToast('状態の更新に失敗しました', 'error');
+    }
+  };
+
+  // 要発注リストの「対応済みにする」。完了した安心感を伝えるため成功トーストを出す。
+  const handleResolve = async (item: InventoryItem) => {
+    try {
+      await setInventoryItemStatus(item.id, 'enough');
+      showToast('対応済みにしました', 'success');
+    } catch {
+      showToast('状態の更新に失敗しました', 'error');
+    }
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!deleteTarget) {
+      return;
+    }
+    setIsDeleting(true);
+    try {
+      await deleteInventoryItem(deleteTarget.id);
+      showToast('品目を削除しました', 'success');
+      setDeleteTarget(null);
+    } catch {
+      showToast('削除に失敗しました', 'error');
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const openEdit = (item: InventoryItem) => {
+    setEditing(item);
+    setModalOpen(true);
+  };
+
+  return (
+    <div className="min-h-screen bg-page px-4 pb-16 pt-20 transition-colors duration-1000 sm:px-6 sm:pb-20">
+      <FloatingNav backHref="/" />
+
+      <div className="mx-auto w-full max-w-3xl">
+        <header>
+          <div className="mb-1.5 flex items-center gap-1.5 text-[11px] font-bold tracking-[0.14em] text-ink-muted">
+            <MdInventory2 className="h-[15px] w-[15px]" />
+            INVENTORY
+          </div>
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h1 className="text-[22px] font-bold tracking-[0.01em] text-ink sm:text-[26px]">在庫・不足品</h1>
+              <p className="mt-1 text-[13.5px] text-ink-sub">不足品をチームで共有し、発注漏れを防ぎます。</p>
+            </div>
+            <Button
+              variant="primary"
+              onClick={() => {
+                setEditing(null);
+                setModalOpen(true);
+              }}
+              className="!min-h-0 shrink-0 gap-1.5 !rounded-[10px] !px-4 !py-2 !text-sm"
+            >
+              <MdAdd className="h-4 w-4" aria-hidden="true" />
+              品目を追加
+            </Button>
+          </div>
+        </header>
+
+        <section className="mt-7">
+          <div className="mb-2.5 flex items-center gap-2 pl-0.5">
+            <h2 className="text-[15px] font-bold text-ink">要発注リスト</h2>
+            <span
+              className={`inline-grid h-5 min-w-5 place-items-center rounded-full px-1.5 text-xs font-bold ${
+                reorderCount > 0 ? 'bg-danger-subtle text-danger' : 'bg-ground text-ink-muted'
+              }`}
+            >
+              {reorderCount}
+            </span>
+          </div>
+          <ReorderList items={items} onResolve={handleResolve} />
+        </section>
+
+        <section className="mt-7">
+          <div className="mb-2.5 pl-0.5">
+            <h2 className="text-[15px] font-bold text-ink">すべての品目</h2>
+          </div>
+          {showLoading ? (
+            <Card variant="table">
+              <div className="p-4 text-sm text-ink-sub">読み込み中...</div>
+            </Card>
+          ) : items.length === 0 ? (
+            <EmptyState title="品目がありません" description="「品目を追加」から在庫を登録しましょう" />
+          ) : (
+            <Card variant="table">
+              <div className="divide-y divide-edge-subtle">
+                {items.map((item) => (
+                  <InventoryItemRow
+                    key={item.id}
+                    item={item}
+                    onEdit={openEdit}
+                    onDelete={setDeleteTarget}
+                    onStatusChange={handleStatusChange}
+                  />
+                ))}
+              </div>
+            </Card>
+          )}
+        </section>
+      </div>
+
+      {modalOpen && (
+        <InventoryItemModal
+          key={editing?.id ?? 'new'}
+          open
+          initial={editing}
+          onClose={() => {
+            setModalOpen(false);
+            setEditing(null);
+          }}
+          onSave={handleSave}
+        />
+      )}
+
+      <Dialog
+        isOpen={deleteTarget !== null}
+        title="品目を削除しますか？"
+        description="共有在庫なので全員に反映されます"
+        variant="danger"
+        confirmText="削除"
+        isLoading={isDeleting}
+        onClose={() => {
+          if (!isDeleting) {
+            setDeleteTarget(null);
+          }
+        }}
+        onConfirm={handleConfirmDelete}
+      />
+    </div>
+  );
+}

--- a/app/inventory/page.tsx
+++ b/app/inventory/page.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from 'react';
 import { MdInventory2, MdAdd } from 'react-icons/md';
-import { Button, Card, Dialog, EmptyState, FloatingNav } from '@/components/ui';
+import { FiBell } from 'react-icons/fi';
+import { Button, Dialog, EmptyState, FloatingNav } from '@/components/ui';
 import { InventoryItemRow } from '@/components/inventory/InventoryItemRow';
 import { InventoryItemModal } from '@/components/inventory/InventoryItemModal';
 import { ReorderList } from '@/components/inventory/ReorderList';
@@ -113,7 +114,7 @@ export default function InventoryPage() {
     <div className="min-h-screen bg-page px-4 pb-16 pt-20 transition-colors duration-1000 sm:px-6 sm:pb-20">
       <FloatingNav backHref="/" />
 
-      <div className="mx-auto w-full max-w-3xl">
+      <div className="mx-auto w-full max-w-5xl">
         <header>
           <div className="mb-1.5 flex items-center gap-1.5 text-[11px] font-bold tracking-[0.14em] text-ink-muted">
             <MdInventory2 className="h-[15px] w-[15px]" />
@@ -138,33 +139,44 @@ export default function InventoryPage() {
           </div>
         </header>
 
-        <section className="mt-7">
-          <div className="mb-2.5 flex items-center gap-2 pl-0.5">
-            <h2 className="text-[15px] font-bold text-ink">要発注リスト</h2>
-            <span
-              className={`inline-grid h-5 min-w-5 place-items-center rounded-full px-1.5 text-xs font-bold ${
-                reorderCount > 0 ? 'bg-danger-subtle text-danger' : 'bg-ground text-ink-muted'
-              }`}
-            >
-              {reorderCount}
-            </span>
-          </div>
-          <ReorderList items={items} onResolve={handleResolve} />
-        </section>
+        {/* 要発注（左）と すべての品目（右）を左右に並べる。縦積みだと要発注が増えたとき
+            右の操作リストが押し下げられタップ位置が動くため、md以上では2カラムにする。
+            items-start で各列を自然な高さにし、片方の伸縮がもう片方に影響しないようにする。 */}
+        <div className="mt-7 grid grid-cols-1 gap-x-6 gap-y-7 md:grid-cols-2 md:items-start">
+          {/* 左: 要発注リスト。見出しごとパネルに内包してまとまりを出す。
+              右の状態から導出し、🟡🔴が増減してもこの列だけが伸び縮みする。 */}
+          <section className="overflow-hidden rounded-2xl border border-edge bg-surface shadow-card">
+            <div className="flex items-center gap-2 border-b border-edge-subtle px-4 py-3.5">
+              <FiBell className="h-4 w-4 text-ink-sub" aria-hidden="true" />
+              <h2 className="text-[15px] font-bold text-ink">要発注リスト</h2>
+              <span
+                className={`inline-grid h-5 min-w-5 place-items-center rounded-full px-1.5 text-xs font-bold ${
+                  reorderCount > 0 ? 'bg-danger-subtle text-danger' : 'bg-ground text-ink-muted'
+                }`}
+              >
+                {reorderCount}
+              </span>
+            </div>
+            <ReorderList items={items} onResolve={handleResolve} />
+          </section>
 
-        <section className="mt-7">
-          <div className="mb-2.5 pl-0.5">
-            <h2 className="text-[15px] font-bold text-ink">すべての品目</h2>
-          </div>
-          {showLoading ? (
-            <Card variant="table">
-              <div className="p-4 text-sm text-ink-sub">読み込み中...</div>
-            </Card>
-          ) : items.length === 0 ? (
-            <EmptyState title="品目がありません" description="「品目を追加」から在庫を登録しましょう" />
-          ) : (
-            <Card variant="table">
-              <div className="divide-y divide-edge-subtle">
+          {/* 右: すべての品目。見出しごとパネルに内包。並び順は createdAt 固定でタップしても動かない。
+              本体も白(パネルのまま)。品目カードは枠線＋薄い影で区切る。 */}
+          <section className="overflow-hidden rounded-2xl border border-edge bg-surface shadow-card">
+            <div className="flex items-center gap-2 border-b border-edge-subtle px-4 py-3.5">
+              <h2 className="text-[15px] font-bold text-ink">すべての品目</h2>
+              <span className="inline-grid h-5 min-w-5 place-items-center rounded-full bg-ground px-1.5 text-xs font-bold text-ink-muted">
+                {items.length}
+              </span>
+            </div>
+            {showLoading ? (
+              <div className="px-4 py-4 text-sm text-ink-sub">読み込み中...</div>
+            ) : items.length === 0 ? (
+              <div className="p-4">
+                <EmptyState title="品目がありません" description="「品目を追加」から在庫を登録しましょう" />
+              </div>
+            ) : (
+              <div className="space-y-2.5 p-3 sm:p-3.5">
                 {items.map((item) => (
                   <InventoryItemRow
                     key={item.id}
@@ -175,9 +187,9 @@ export default function InventoryPage() {
                   />
                 ))}
               </div>
-            </Card>
-          )}
-        </section>
+            )}
+          </section>
+        </div>
       </div>
 
       {modalOpen && (

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -40,6 +40,10 @@ vi.mock('@/hooks/useChristmasMode', () => ({
   }),
 }));
 
+vi.mock('@/hooks/useInventory', () => ({
+  useInventory: () => ({ items: [], isLoading: false }),
+}));
+
 vi.mock('@/hooks/useHomeFeatureVisibility', () => ({
   useHomeFeatureVisibility: () => ({
     isVisible: (key: string) => mocks.visibleKeys.has(key),

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,15 +5,17 @@ import { useEffect, useState } from 'react';
 import type { IconType } from 'react-icons';
 import { FaCoffee, FaUsers } from 'react-icons/fa';
 import { IoSettings } from 'react-icons/io5';
-import { MdCoffeeMaker, MdFactory } from 'react-icons/md';
+import { MdCoffeeMaker, MdFactory, MdInventory2 } from 'react-icons/md';
 import { RiBookFill, RiCalendarScheduleFill } from 'react-icons/ri';
 import { Loading } from '@/components/Loading';
 import { ActionCard } from '@/components/home/ActionCard';
 import { HomeHeader } from '@/components/home/HomeHeader';
 import { useChristmasMode } from '@/hooks/useChristmasMode';
 import { useHomeFeatureVisibility } from '@/hooks/useHomeFeatureVisibility';
+import { useInventory } from '@/hooks/useInventory';
 import { useAuth } from '@/lib/auth';
 import { getUserData } from '@/lib/firestore';
+import { countReorderItems } from '@/lib/inventory';
 import { needsConsent } from '@/lib/consent';
 import type { HomeFeatureKey } from '@/lib/homeFeatures';
 import dynamic from 'next/dynamic';
@@ -43,6 +45,7 @@ const CHRISTMAS_ICONS: Record<string, IconType> = {
   tasting: FaTree,
   'defect-beans': GiGingerbreadMan,
   'production-record': MdFactory,
+  inventory: MdInventory2,
   'drip-guide': GiCandyCanes,
   settings: IoSettings,
 };
@@ -89,6 +92,14 @@ const ACTIONS: Action[] = [
     icon: MdFactory,
   },
   {
+    key: 'inventory',
+    title: '在庫',
+    label: 'INVENTORY',
+    description: '不足品を共有・要発注',
+    href: '/inventory',
+    icon: MdInventory2,
+  },
+  {
     key: 'drip-guide',
     title: 'ドリップガイド',
     label: 'DRIP GUIDE',
@@ -122,7 +133,11 @@ export default function HomePage(_props: HomePageProps = {}) {
   const [checkingConsent, setCheckingConsent] = useState(true);
   const { isChristmasMode } = useChristmasMode();
   const { isVisible } = useHomeFeatureVisibility();
-  const visibleActions = ACTIONS.filter((action) => isVisible(action.key));
+  const { items: inventoryItems } = useInventory();
+  const reorderCount = countReorderItems(inventoryItems);
+  const visibleActions = ACTIONS.filter((action) => isVisible(action.key)).map((action) =>
+    action.key === 'inventory' ? { ...action, badge: reorderCount > 0 ? `要発注${reorderCount}` : undefined } : action
+  );
 
   // スプラッシュ画面の表示時間を管理（フェードアウト時間を加味）
   useEffect(() => {

--- a/components/inventory/InventoryItemModal.tsx
+++ b/components/inventory/InventoryItemModal.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useState } from 'react';
+import { Modal, Input } from '@/components/ui';
+import { StatusToggle } from './StatusToggle';
+import type { InventoryItem, InventoryItemInput, InventoryStatus } from '@/types';
+
+// 共通 Input は text-lg・厚いpaddingで大きいため、在庫まわりの
+// コンパクト基調(13〜14px・控えめpadding)に合わせて className で上書きする。
+const FIELD_CLASS = '!min-h-0 !rounded-[10px] !border !px-3 !py-2 !text-sm';
+
+interface InventoryItemModalProps {
+  /** モーダルの表示/非表示 */
+  open: boolean;
+  /** 編集対象。null/未指定なら新規追加モード */
+  initial?: InventoryItem | null;
+  /** モーダルを閉じるコールバック */
+  onClose: () => void;
+  /** 保存時に正規化前の入力を渡す（保存処理・トーストは親が担当） */
+  onSave: (input: InventoryItemInput) => void;
+}
+
+export function InventoryItemModal({ open, initial, onClose, onSave }: InventoryItemModalProps) {
+  const [name, setName] = useState(initial?.name ?? '');
+  const [status, setStatus] = useState<InventoryStatus>(initial?.status ?? 'enough');
+
+  const isEditing = Boolean(initial);
+  const canSave = name.trim().length > 0;
+
+  const handleSave = () => {
+    if (!canSave) {
+      return;
+    }
+    onSave({ name, status });
+  };
+
+  return (
+    <Modal
+      show={open}
+      onClose={onClose}
+      contentClassName="bg-overlay rounded-2xl shadow-xl overflow-hidden max-w-md w-full border border-edge"
+    >
+      <div className="flex flex-col gap-4 p-6">
+        <h2 className="text-lg font-bold text-ink">{isEditing ? '品目を編集' : '品目を追加'}</h2>
+
+        <Input
+          label="品目名"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="例: ドリップ袋"
+          className={FIELD_CLASS}
+        />
+
+        <div>
+          <span className="mb-2 block text-sm font-medium text-ink">状態</span>
+          <StatusToggle value={status} onChange={setStatus} />
+        </div>
+
+        <div className="flex justify-end gap-2 pt-1">
+          {/* eslint-disable-next-line local/no-raw-button -- モーダルのコンパクト基調に合わせた小型フッターボタン。共通Buttonはサイズが合わない */}
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-[38px] items-center justify-center rounded-[10px] px-4 text-[13px] font-bold text-ink-sub transition-colors hover:bg-ground focus:outline-none focus-visible:ring-2 focus-visible:ring-spot/40"
+          >
+            キャンセル
+          </button>
+          {/* eslint-disable-next-line local/no-raw-button -- 同上 */}
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!canSave}
+            className="inline-flex h-[38px] items-center justify-center rounded-[10px] bg-btn-primary px-4 text-[13px] font-bold text-white shadow-sm transition-colors hover:bg-btn-primary-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-spot/40 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            保存
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/components/inventory/InventoryItemRow.tsx
+++ b/components/inventory/InventoryItemRow.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { FiEdit2, FiTrash2 } from 'react-icons/fi';
+import { IconButton } from '@/components/ui';
+import { StatusToggle } from './StatusToggle';
+import { toJSDate } from '@/lib/firestoreUtils';
+import type { FirestoreTimestamp, InventoryItem, InventoryStatus } from '@/types';
+
+/**
+ * 最終更新時刻を「M/D HH:mm」形式に整形する。
+ * updatedAt が保留書き込み等で未確定（undefined/変換不能）なら null を返す。
+ */
+export function formatUpdatedAt(value: FirestoreTimestamp | undefined): string | null {
+  const date = toJSDate(value);
+  if (!date) {
+    return null;
+  }
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  return `${month}/${day} ${hours}:${minutes}`;
+}
+
+interface InventoryItemRowProps {
+  item: InventoryItem;
+  onEdit: (item: InventoryItem) => void;
+  onDelete: (item: InventoryItem) => void;
+  onStatusChange: (item: InventoryItem, status: InventoryStatus) => void;
+}
+
+/**
+ * 「すべての品目」リストの1行。カードの羅列ではなく、親カード内に border で区切って並べる行レイアウト。
+ * 左=品目名+最終更新 / 中=状態セグメント / 右=編集・削除アイコン。
+ * 狭い画面ではセグメントを名前の下に折り返す。
+ */
+export function InventoryItemRow({ item, onEdit, onDelete, onStatusChange }: InventoryItemRowProps) {
+  const updatedAtLabel = formatUpdatedAt(item.updatedAt);
+
+  return (
+    <div className="flex flex-wrap items-center gap-3.5 px-4 py-3">
+      <div className="min-w-0 flex-1">
+        <span className="text-sm font-bold text-ink">{item.name}</span>
+        {updatedAtLabel && <div className="mt-0.5 text-[11.5px] text-ink-muted">最終更新 {updatedAtLabel}</div>}
+      </div>
+
+      <div className="order-3 w-full sm:order-none sm:w-auto">
+        <StatusToggle value={item.status} onChange={(status) => onStatusChange(item, status)} />
+      </div>
+
+      <div className="flex shrink-0 items-center gap-0.5">
+        <IconButton
+          variant="ghost"
+          aria-label={`${item.name}を編集`}
+          onClick={() => onEdit(item)}
+          className="!min-h-0 !min-w-0 h-8 w-8 !p-0"
+        >
+          <FiEdit2 className="h-4 w-4" />
+        </IconButton>
+        <IconButton
+          variant="danger"
+          aria-label={`${item.name}を削除`}
+          onClick={() => onDelete(item)}
+          className="!min-h-0 !min-w-0 h-8 w-8 !p-0"
+        >
+          <FiTrash2 className="h-4 w-4" />
+        </IconButton>
+      </div>
+    </div>
+  );
+}

--- a/components/inventory/InventoryItemRow.tsx
+++ b/components/inventory/InventoryItemRow.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { FiEdit2, FiTrash2 } from 'react-icons/fi';
+import { FiEdit2, FiTrash2, FiClock } from 'react-icons/fi';
 import { IconButton } from '@/components/ui';
 import { StatusToggle } from './StatusToggle';
+import { STATUS_VISUAL } from './statusVisual';
 import { toJSDate } from '@/lib/firestoreUtils';
 import type { FirestoreTimestamp, InventoryItem, InventoryStatus } from '@/types';
 
@@ -30,41 +31,48 @@ interface InventoryItemRowProps {
 }
 
 /**
- * 「すべての品目」リストの1行。カードの羅列ではなく、親カード内に border で区切って並べる行レイアウト。
- * 左=品目名+最終更新 / 中=状態セグメント / 右=編集・削除アイコン。
- * 狭い画面ではセグメントを名前の下に折り返す。
+ * 「すべての品目」の1件カード。
+ * 上段=状態ドット＋品目名＋編集/削除 / 中段=最終更新 / 下段=状態セグメント、の縦構成。
+ * 1件ずつ独立したカードにし、状態を変えても並び順・タップ位置が動かないようにする。
  */
 export function InventoryItemRow({ item, onEdit, onDelete, onStatusChange }: InventoryItemRowProps) {
   const updatedAtLabel = formatUpdatedAt(item.updatedAt);
+  const visual = STATUS_VISUAL[item.status];
 
   return (
-    <div className="flex flex-wrap items-center gap-3.5 px-4 py-3">
-      <div className="min-w-0 flex-1">
-        <span className="text-sm font-bold text-ink">{item.name}</span>
-        {updatedAtLabel && <div className="mt-0.5 text-[11.5px] text-ink-muted">最終更新 {updatedAtLabel}</div>}
+    <div className="rounded-xl border border-edge bg-surface p-3.5 shadow-card-glow">
+      <div className="flex items-center gap-2">
+        {/* 状態ドット（緑=十分 / アンバー=少ない / 赤=切れた）。一目で状態が分かる */}
+        <span className={`h-[9px] w-[9px] shrink-0 rounded-full ${visual.dot}`} aria-hidden="true" />
+        <span className="min-w-0 truncate text-sm font-bold text-ink">{item.name}</span>
+        {/* 最終更新は品目名の横に置いてコンパクト化。estimate により値が消えずチラつかない */}
+        {updatedAtLabel && (
+          <span className="flex shrink-0 items-center gap-1 text-[11px] text-ink-muted">
+            <FiClock className="h-3 w-3 shrink-0" aria-hidden="true" />
+            {updatedAtLabel}
+          </span>
+        )}
+        <div className="ml-auto flex shrink-0 items-center gap-0.5">
+          <IconButton
+            variant="ghost"
+            aria-label={`${item.name}を編集`}
+            onClick={() => onEdit(item)}
+            className="!min-h-0 !min-w-0 h-8 w-8 !p-0"
+          >
+            <FiEdit2 className="h-4 w-4" />
+          </IconButton>
+          <IconButton
+            variant="danger"
+            aria-label={`${item.name}を削除`}
+            onClick={() => onDelete(item)}
+            className="!min-h-0 !min-w-0 h-8 w-8 !p-0"
+          >
+            <FiTrash2 className="h-4 w-4" />
+          </IconButton>
+        </div>
       </div>
-
-      <div className="order-3 w-full sm:order-none sm:w-auto">
+      <div className="mt-2.5">
         <StatusToggle value={item.status} onChange={(status) => onStatusChange(item, status)} />
-      </div>
-
-      <div className="flex shrink-0 items-center gap-0.5">
-        <IconButton
-          variant="ghost"
-          aria-label={`${item.name}を編集`}
-          onClick={() => onEdit(item)}
-          className="!min-h-0 !min-w-0 h-8 w-8 !p-0"
-        >
-          <FiEdit2 className="h-4 w-4" />
-        </IconButton>
-        <IconButton
-          variant="danger"
-          aria-label={`${item.name}を削除`}
-          onClick={() => onDelete(item)}
-          className="!min-h-0 !min-w-0 h-8 w-8 !p-0"
-        >
-          <FiTrash2 className="h-4 w-4" />
-        </IconButton>
       </div>
     </div>
   );

--- a/components/inventory/InventoryItemRow.tsx
+++ b/components/inventory/InventoryItemRow.tsx
@@ -10,7 +10,7 @@ import type { FirestoreTimestamp, InventoryItem, InventoryStatus } from '@/types
  * 最終更新時刻を「M/D HH:mm」形式に整形する。
  * updatedAt が保留書き込み等で未確定（undefined/変換不能）なら null を返す。
  */
-export function formatUpdatedAt(value: FirestoreTimestamp | undefined): string | null {
+function formatUpdatedAt(value: FirestoreTimestamp | undefined): string | null {
   const date = toJSDate(value);
   if (!date) {
     return null;

--- a/components/inventory/ReorderList.tsx
+++ b/components/inventory/ReorderList.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { FiCheck, FiCheckCircle } from 'react-icons/fi';
+import { Card } from '@/components/ui';
+import { selectReorderItems } from '@/lib/inventory';
+import { STATUS_VISUAL } from './statusVisual';
+import type { InventoryItem } from '@/types';
+
+interface ReorderListProps {
+  items: InventoryItem[];
+  onResolve: (item: InventoryItem) => void;
+}
+
+/**
+ * 要発注リスト。1枚のカード内に行を border で区切って並べるリスト型。
+ * 各行は「品目名 + 状態タグ(淡色) + 補足」と、塗らない success ゴーストの「対応済みにする」。
+ * 空のときは安心感のあるチェック付きメッセージを出す。
+ *
+ * CTA は共通 Button だとタップ用に大きすぎるため、デザイン指定のコンパクトな専用ボタンを用いる。
+ */
+export function ReorderList({ items, onResolve }: ReorderListProps) {
+  const reorder = selectReorderItems(items);
+
+  return (
+    <Card variant="table">
+      {reorder.length === 0 ? (
+        <div className="flex items-center gap-2.5 p-4 text-sm text-ink-sub">
+          <FiCheckCircle className="h-[18px] w-[18px] shrink-0 text-success" aria-hidden="true" />
+          発注が必要な品目はありません。
+        </div>
+      ) : (
+        <ul className="divide-y divide-edge-subtle">
+          {reorder.map((item) => {
+            const visual = STATUS_VISUAL[item.status];
+            return (
+              <li key={item.id} className="flex flex-wrap items-center gap-3 px-4 py-3">
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-sm font-bold text-ink">{item.name}</span>
+                    <span
+                      className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11.5px] font-bold ${visual.subtleBg} ${visual.text}`}
+                    >
+                      <span className={`h-1.5 w-1.5 rounded-full ${visual.dot}`} aria-hidden="true" />
+                      {visual.label}
+                    </span>
+                  </div>
+                </div>
+                {/* eslint-disable-next-line local/no-raw-button -- デザイン指定のコンパクトな success ゴーストCTA。共通Buttonはサイズが合わない */}
+                <button
+                  type="button"
+                  onClick={() => onResolve(item)}
+                  aria-label={`${item.name}を対応済みにする`}
+                  className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-[10px] border border-success px-3 py-[7px] text-[13px] font-bold text-success transition-colors hover:bg-success-subtle focus:outline-none focus-visible:ring-2 focus-visible:ring-success/40 motion-reduce:transition-none max-sm:w-full"
+                >
+                  <FiCheck className="h-4 w-4" aria-hidden="true" />
+                  対応済みにする
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </Card>
+  );
+}

--- a/components/inventory/ReorderList.tsx
+++ b/components/inventory/ReorderList.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { FiCheck, FiCheckCircle } from 'react-icons/fi';
-import { Card } from '@/components/ui';
 import { selectReorderItems } from '@/lib/inventory';
 import { STATUS_VISUAL } from './statusVisual';
 import type { InventoryItem } from '@/types';
@@ -12,8 +11,8 @@ interface ReorderListProps {
 }
 
 /**
- * 要発注リスト。1枚のカード内に行を border で区切って並べるリスト型。
- * 各行は「品目名 + 状態タグ(淡色) + 補足」と、塗らない success ゴーストの「対応済みにする」。
+ * 要発注リストの中身（外枠パネルと見出しは親ページが用意する）。
+ * 各行は「品目名（上）＋状態ドット付きラベル（下）」と、塗らない success ゴーストの「対応済みにする」。
  * 空のときは安心感のあるチェック付きメッセージを出す。
  *
  * CTA は共通 Button だとタップ用に大きすぎるため、デザイン指定のコンパクトな専用ボタンを用いる。
@@ -21,45 +20,41 @@ interface ReorderListProps {
 export function ReorderList({ items, onResolve }: ReorderListProps) {
   const reorder = selectReorderItems(items);
 
+  if (reorder.length === 0) {
+    return (
+      <div className="flex items-center gap-2.5 px-4 py-4 text-sm text-ink-sub">
+        <FiCheckCircle className="h-[18px] w-[18px] shrink-0 text-success" aria-hidden="true" />
+        発注が必要な品目はありません。
+      </div>
+    );
+  }
+
   return (
-    <Card variant="table">
-      {reorder.length === 0 ? (
-        <div className="flex items-center gap-2.5 p-4 text-sm text-ink-sub">
-          <FiCheckCircle className="h-[18px] w-[18px] shrink-0 text-success" aria-hidden="true" />
-          発注が必要な品目はありません。
-        </div>
-      ) : (
-        <ul className="divide-y divide-edge-subtle">
-          {reorder.map((item) => {
-            const visual = STATUS_VISUAL[item.status];
-            return (
-              <li key={item.id} className="flex flex-wrap items-center gap-3 px-4 py-3">
-                <div className="min-w-0 flex-1">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-sm font-bold text-ink">{item.name}</span>
-                    <span
-                      className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11.5px] font-bold ${visual.subtleBg} ${visual.text}`}
-                    >
-                      <span className={`h-1.5 w-1.5 rounded-full ${visual.dot}`} aria-hidden="true" />
-                      {visual.label}
-                    </span>
-                  </div>
-                </div>
-                {/* eslint-disable-next-line local/no-raw-button -- デザイン指定のコンパクトな success ゴーストCTA。共通Buttonはサイズが合わない */}
-                <button
-                  type="button"
-                  onClick={() => onResolve(item)}
-                  aria-label={`${item.name}を対応済みにする`}
-                  className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-[10px] border border-success px-3 py-[7px] text-[13px] font-bold text-success transition-colors hover:bg-success-subtle focus:outline-none focus-visible:ring-2 focus-visible:ring-success/40 motion-reduce:transition-none max-sm:w-full"
-                >
-                  <FiCheck className="h-4 w-4" aria-hidden="true" />
-                  対応済みにする
-                </button>
-              </li>
-            );
-          })}
-        </ul>
-      )}
-    </Card>
+    <ul className="divide-y divide-edge-subtle">
+      {reorder.map((item) => {
+        const visual = STATUS_VISUAL[item.status];
+        return (
+          <li key={item.id} className="flex items-center gap-3 px-4 py-3">
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-sm font-bold text-ink">{item.name}</div>
+              <div className={`mt-1 inline-flex items-center gap-1.5 text-[12.5px] font-bold ${visual.text}`}>
+                <span className={`h-[7px] w-[7px] shrink-0 rounded-full ${visual.dot}`} aria-hidden="true" />
+                {visual.label}
+              </div>
+            </div>
+            {/* eslint-disable-next-line local/no-raw-button -- デザイン指定のコンパクトな success ゴーストCTA。共通Buttonはサイズが合わない */}
+            <button
+              type="button"
+              onClick={() => onResolve(item)}
+              aria-label={`${item.name}を対応済みにする`}
+              className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-[10px] border border-success px-3 py-[7px] text-[13px] font-bold text-success transition-colors hover:bg-success-subtle focus:outline-none focus-visible:ring-2 focus-visible:ring-success/40 motion-reduce:transition-none"
+            >
+              <FiCheck className="h-4 w-4" aria-hidden="true" />
+              対応済みにする
+            </button>
+          </li>
+        );
+      })}
+    </ul>
   );
 }

--- a/components/inventory/StatusToggle.tsx
+++ b/components/inventory/StatusToggle.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { STATUS_VISUAL, STATUS_VISUAL_ORDER } from './statusVisual';
+import type { InventoryStatus } from '@/types';
+
+interface StatusToggleProps {
+  value: InventoryStatus;
+  onChange: (status: InventoryStatus) => void;
+  disabled?: boolean;
+}
+
+/**
+ * 在庫状態のセグメントコントロール。
+ *
+ * ニュートラルの外枠(bg-ground)の中で、選択中の1つだけが状態色で塗られる。
+ * 各セグメントは「ドット + ラベル」で示し、未選択はドット・文字とも薄いグレー(currentColor)。
+ *
+ * 共通 Button はタップ用に min-height が大きく、コンパクトなセグメント表現に合わないため、
+ * ここでは専用の小ボタンを用いる。生 button の使用はこの特殊コントロールに限った意図的なもの。
+ */
+export function StatusToggle({ value, onChange, disabled }: StatusToggleProps) {
+  return (
+    <div
+      className="inline-flex w-full gap-0.5 rounded-[10px] border border-edge bg-ground p-0.5 sm:w-auto"
+      role="group"
+      aria-label="在庫状態"
+    >
+      {STATUS_VISUAL_ORDER.map((status) => {
+        const visual = STATUS_VISUAL[status];
+        const selected = status === value;
+        // 選択中は状態色で塗り(statusVisual.segActive)、未選択はドット・文字とも薄いグレー
+        const stateClass = selected
+          ? `${visual.segActive} shadow-sm`
+          : 'bg-transparent text-ink-muted hover:text-ink-sub';
+        return (
+          // eslint-disable-next-line local/no-raw-button -- セグメントコントロール専用の小ボタン。共通Buttonはサイズが合わない
+          <button
+            key={status}
+            type="button"
+            aria-pressed={selected}
+            disabled={disabled}
+            onClick={() => onChange(status)}
+            className={`inline-flex h-[34px] flex-1 items-center justify-center gap-1.5 rounded-[7px] px-3 text-[13px] font-bold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-spot/40 motion-reduce:transition-none disabled:cursor-not-allowed disabled:opacity-50 sm:min-w-[72px] sm:flex-none ${stateClass}`}
+          >
+            <span
+              className={`h-[7px] w-[7px] shrink-0 rounded-full bg-current ${selected ? 'opacity-100' : 'opacity-50'}`}
+              aria-hidden="true"
+            />
+            {visual.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/inventory/StatusToggle.tsx
+++ b/components/inventory/StatusToggle.tsx
@@ -21,7 +21,7 @@ interface StatusToggleProps {
 export function StatusToggle({ value, onChange, disabled }: StatusToggleProps) {
   return (
     <div
-      className="inline-flex w-full gap-0.5 rounded-[10px] border border-edge bg-ground p-0.5 sm:w-auto"
+      className="flex w-full gap-0.5 rounded-[10px] border border-edge bg-ground p-0.5"
       role="group"
       aria-label="在庫状態"
     >
@@ -40,7 +40,7 @@ export function StatusToggle({ value, onChange, disabled }: StatusToggleProps) {
             aria-pressed={selected}
             disabled={disabled}
             onClick={() => onChange(status)}
-            className={`inline-flex h-[34px] flex-1 items-center justify-center gap-1.5 rounded-[7px] px-3 text-[13px] font-bold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-spot/40 motion-reduce:transition-none disabled:cursor-not-allowed disabled:opacity-50 sm:min-w-[72px] sm:flex-none ${stateClass}`}
+            className={`inline-flex h-[34px] flex-1 items-center justify-center gap-1.5 rounded-[7px] px-3 text-[13px] font-bold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-spot/40 motion-reduce:transition-none disabled:cursor-not-allowed disabled:opacity-50 ${stateClass}`}
           >
             <span
               className={`h-[7px] w-[7px] shrink-0 rounded-full bg-current ${selected ? 'opacity-100' : 'opacity-50'}`}

--- a/components/inventory/statusVisual.tsx
+++ b/components/inventory/statusVisual.tsx
@@ -1,0 +1,51 @@
+import { STATUS_LABELS } from '@/lib/inventory';
+import type { InventoryStatus } from '@/types';
+
+/**
+ * 在庫状態(十分/少ない/切れた)の視覚表現を一元定義する。
+ *
+ * StatusToggle(セグメントコントロール) / InventoryItemRow / ReorderList が必ずこの定義を参照し、
+ * 表現を統一する。色は既存のセマンティックCSS変数(--success/--warning/--danger とその -subtle)を
+ * Tailwindユーティリティ経由で参照し、ハードコード色は使わず7テーマで自動対応する。
+ *
+ * 状態は色だけに頼らず「色 + ドット + 日本語ラベル」で示し、セグメントは選択中のみ着色する。
+ */
+export interface StatusVisual {
+  /** 日本語ラベル（十分/少ない/切れた） */
+  label: string;
+  /** セグメント選択中の塗り(背景+文字色)。 */
+  segActive: string;
+  /** 淡色チップの背景（要発注タグ用） */
+  subtleBg: string;
+  /** 状態色のテキスト */
+  text: string;
+  /** 状態ドットの色 */
+  dot: string;
+}
+
+export const STATUS_VISUAL: Record<InventoryStatus, StatusVisual> = {
+  enough: {
+    label: STATUS_LABELS.enough,
+    segActive: 'bg-success text-white',
+    subtleBg: 'bg-success-subtle',
+    text: 'text-success',
+    dot: 'bg-success',
+  },
+  low: {
+    label: STATUS_LABELS.low,
+    segActive: 'bg-warning text-white',
+    subtleBg: 'bg-warning-subtle',
+    text: 'text-warning',
+    dot: 'bg-warning',
+  },
+  out: {
+    label: STATUS_LABELS.out,
+    segActive: 'bg-danger text-white',
+    subtleBg: 'bg-danger-subtle',
+    text: 'text-danger',
+    dot: 'bg-danger',
+  },
+};
+
+/** トグルで状態を並べる順序（十分 → 少ない → 切れた） */
+export const STATUS_VISUAL_ORDER: InventoryStatus[] = ['enough', 'low', 'out'];

--- a/components/inventory/statusVisual.tsx
+++ b/components/inventory/statusVisual.tsx
@@ -10,7 +10,7 @@ import type { InventoryStatus } from '@/types';
  *
  * 状態は色だけに頼らず「色 + ドット + 日本語ラベル」で示し、セグメントは選択中のみ着色する。
  */
-export interface StatusVisual {
+interface StatusVisual {
   /** 日本語ラベル（十分/少ない/切れた） */
   label: string;
   /** セグメント選択中の塗り(背景+文字色)。 */

--- a/components/inventory/statusVisual.tsx
+++ b/components/inventory/statusVisual.tsx
@@ -13,34 +13,34 @@ import type { InventoryStatus } from '@/types';
 interface StatusVisual {
   /** 日本語ラベル（十分/少ない/切れた） */
   label: string;
-  /** セグメント選択中の塗り(背景+文字色)。 */
+  /** セグメント選択中の塗り。薄い状態色背景＋状態色文字（DESIGN.md 9.7 準拠・塗りつぶしにしない） */
   segActive: string;
   /** 淡色チップの背景（要発注タグ用） */
   subtleBg: string;
   /** 状態色のテキスト */
   text: string;
-  /** 状態ドットの色 */
+  /** 状態ドットの色（カード左端のカラーバーにも流用） */
   dot: string;
 }
 
 export const STATUS_VISUAL: Record<InventoryStatus, StatusVisual> = {
   enough: {
     label: STATUS_LABELS.enough,
-    segActive: 'bg-success text-white',
+    segActive: 'bg-success-subtle text-success',
     subtleBg: 'bg-success-subtle',
     text: 'text-success',
     dot: 'bg-success',
   },
   low: {
     label: STATUS_LABELS.low,
-    segActive: 'bg-warning text-white',
+    segActive: 'bg-warning-subtle text-warning',
     subtleBg: 'bg-warning-subtle',
     text: 'text-warning',
     dot: 'bg-warning',
   },
   out: {
     label: STATUS_LABELS.out,
-    segActive: 'bg-danger text-white',
+    segActive: 'bg-danger-subtle text-danger',
     subtleBg: 'bg-danger-subtle',
     text: 'text-danger',
     dot: 'bg-danger',

--- a/data/legal/privacy-policy.ts
+++ b/data/legal/privacy-policy.ts
@@ -30,6 +30,7 @@ export const PRIVACY_POLICY_SECTIONS: PrivacyPolicySection[] = [
       '・試飲感想記録（評価スコア、感想コメント、豆名など）',
       '・欠点豆図鑑（欠点豆の名前、特徴など）',
       '・ドリップガイド（レシピ名、抽出手順など）',
+      '・在庫・不足品（品目名、在庫状態など。チーム内で共有されます）',
       '',
       '【画像データ】',
       '・欠点豆の画像（Firebase Storageに保存）',
@@ -159,4 +160,4 @@ export const PRIVACY_POLICY_SECTIONS: PrivacyPolicySection[] = [
   },
 ];
 
-export const PRIVACY_POLICY_LAST_UPDATED = '2026年6月5日';
+export const PRIVACY_POLICY_LAST_UPDATED = '2026年6月13日';

--- a/data/legal/terms.ts
+++ b/data/legal/terms.ts
@@ -17,7 +17,7 @@ export const TERMS_SECTIONS: TermsSection[] = [
     title: '第2条（サービスの概要）',
     content: [
       '本サービスは、コーヒー加工業務の支援を目的としたアプリケーションです。',
-      '主な機能として、担当表、スケジュール、生産記録、試飲感想記録、ドリップガイド、欠点豆図鑑などを提供します。',
+      '主な機能として、担当表、スケジュール、生産記録、試飲感想記録、ドリップガイド、欠点豆図鑑、在庫・不足品の共有などを提供します。',
     ],
   },
   {
@@ -100,4 +100,4 @@ export const TERMS_SECTIONS: TermsSection[] = [
   },
 ];
 
-export const TERMS_LAST_UPDATED = '2026年6月5日';
+export const TERMS_LAST_UPDATED = '2026年6月13日';

--- a/hooks/useInventory.test.ts
+++ b/hooks/useInventory.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+const mockSubscribe = vi.fn();
+vi.mock('@/lib/firestore', () => ({
+  subscribeInventoryItems: (...args: unknown[]) => mockSubscribe(...args),
+}));
+
+import { useInventory } from './useInventory';
+import type { InventoryItem } from '@/types';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useInventory', () => {
+  it('購読のcallbackで受け取った items を返し、isLoading を解除する', async () => {
+    const sample: InventoryItem[] = [{ id: 'a', name: 'ドリップ袋', status: 'low' }];
+    let captured: ((items: InventoryItem[]) => void) | undefined;
+    mockSubscribe.mockImplementation((cb: (items: InventoryItem[]) => void) => {
+      captured = cb;
+      return () => {};
+    });
+
+    const { result } = renderHook(() => useInventory());
+    expect(result.current.isLoading).toBe(true);
+
+    act(() => {
+      captured?.(sample);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.items).toEqual(sample);
+    });
+  });
+});

--- a/hooks/useInventory.ts
+++ b/hooks/useInventory.ts
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { subscribeInventoryItems } from '@/lib/firestore';
+import type { InventoryItem } from '@/types';
+
+/**
+ * トップレベル共有コレクション `inventory` をリアルタイム購読するフック。
+ * @returns { items, isLoading }
+ */
+export function useInventory(): { items: InventoryItem[]; isLoading: boolean } {
+  const [items, setItems] = useState<InventoryItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 購読開始のローディング同期に必要
+    setIsLoading(true);
+    const unsubscribe = subscribeInventoryItems(
+      (next) => {
+        setItems(next);
+        setIsLoading(false);
+      },
+      (error) => {
+        console.error('Failed to subscribe inventory items:', error);
+        setIsLoading(false);
+      }
+    );
+    return () => unsubscribe();
+  }, []);
+
+  return { items, isLoading };
+}

--- a/lib/consent.test.ts
+++ b/lib/consent.test.ts
@@ -5,11 +5,11 @@ import type { UserConsent } from '@/types';
 describe('consent', () => {
   describe('定数', () => {
     it('TERMS_VERSIONが定義されている', () => {
-      expect(TERMS_VERSION).toBe('1.1.0');
+      expect(TERMS_VERSION).toBe('1.2.0');
     });
 
     it('PRIVACY_POLICY_VERSIONが定義されている', () => {
-      expect(PRIVACY_POLICY_VERSION).toBe('1.2.0');
+      expect(PRIVACY_POLICY_VERSION).toBe('1.3.0');
     });
   });
 

--- a/lib/consent.ts
+++ b/lib/consent.ts
@@ -1,8 +1,8 @@
 import { UserConsent } from '@/types';
 
 // バージョン定義
-export const TERMS_VERSION = '1.1.0';
-export const PRIVACY_POLICY_VERSION = '1.2.0';
+export const TERMS_VERSION = '1.2.0';
+export const PRIVACY_POLICY_VERSION = '1.3.0';
 
 // 同意が必要かどうかをチェック
 export function needsConsent(userConsent: UserConsent | undefined): boolean {

--- a/lib/firestore/index.ts
+++ b/lib/firestore/index.ts
@@ -15,7 +15,6 @@ export {
   subscribePackageEntries,
 } from './productionRecords';
 export {
-  getInventoryCollectionRef,
   subscribeInventoryItems,
   addInventoryItem,
   updateInventoryItem,

--- a/lib/firestore/index.ts
+++ b/lib/firestore/index.ts
@@ -14,3 +14,11 @@ export {
   subscribeRoastEntries,
   subscribePackageEntries,
 } from './productionRecords';
+export {
+  getInventoryCollectionRef,
+  subscribeInventoryItems,
+  addInventoryItem,
+  updateInventoryItem,
+  setInventoryItemStatus,
+  deleteInventoryItem,
+} from './inventory';

--- a/lib/firestore/inventory.test.ts
+++ b/lib/firestore/inventory.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockAddDoc = vi.fn();
+const mockSetDoc = vi.fn();
+const mockDeleteDoc = vi.fn();
+const mockServerTimestamp = vi.fn(() => 'SERVER_TS');
+
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn(() => ({ __type: 'collection' })),
+  doc: vi.fn(() => ({ __type: 'doc' })),
+  addDoc: (...args: unknown[]) => mockAddDoc(...args),
+  setDoc: (...args: unknown[]) => mockSetDoc(...args),
+  deleteDoc: (...args: unknown[]) => mockDeleteDoc(...args),
+  serverTimestamp: () => mockServerTimestamp(),
+  onSnapshot: vi.fn(),
+  orderBy: vi.fn(() => ({ __type: 'orderBy' })),
+  query: vi.fn(() => ({ __type: 'query' })),
+}));
+
+vi.mock('./common', () => ({
+  getDb: vi.fn(() => ({ __type: 'db' })),
+}));
+
+import { addInventoryItem, updateInventoryItem, setInventoryItemStatus, deleteInventoryItem } from './inventory';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('addInventoryItem', () => {
+  it('正規化した入力に createdAt/updatedAt を付けて addDoc する', async () => {
+    await addInventoryItem({ name: ' ドリップ袋 ', status: 'low' });
+    expect(mockAddDoc).toHaveBeenCalledTimes(1);
+    const saved = mockAddDoc.mock.calls[0][1];
+    expect(saved).toMatchObject({
+      name: 'ドリップ袋',
+      status: 'low',
+      createdAt: 'SERVER_TS',
+      updatedAt: 'SERVER_TS',
+    });
+  });
+});
+
+describe('updateInventoryItem', () => {
+  it('正規化した入力に updatedAt を付けて merge で setDoc する', async () => {
+    await updateInventoryItem('item-1', { name: ' ドリップ袋 ', status: 'low' });
+    expect(mockSetDoc).toHaveBeenCalledTimes(1);
+    const [, payload, options] = mockSetDoc.mock.calls[0];
+    expect(payload).toMatchObject({ name: 'ドリップ袋', status: 'low', updatedAt: 'SERVER_TS' });
+    expect(options).toEqual({ merge: true });
+  });
+});
+
+describe('setInventoryItemStatus', () => {
+  it('status と updatedAt を merge で更新する', async () => {
+    await setInventoryItemStatus('item-1', 'out');
+    expect(mockSetDoc).toHaveBeenCalledTimes(1);
+    const [, payload, options] = mockSetDoc.mock.calls[0];
+    expect(payload).toMatchObject({ status: 'out', updatedAt: 'SERVER_TS' });
+    expect(options).toEqual({ merge: true });
+  });
+});
+
+describe('deleteInventoryItem', () => {
+  it('deleteDoc を呼ぶ', async () => {
+    await deleteInventoryItem('item-1');
+    expect(mockDeleteDoc).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/firestore/inventory.ts
+++ b/lib/firestore/inventory.ts
@@ -15,7 +15,7 @@ import { getDb } from './common';
 import { buildInventoryItemInput, normalizeInventoryStatus } from '@/lib/inventory';
 import type { InventoryItem, InventoryItemInput } from '@/types';
 
-export function getInventoryCollectionRef() {
+function getInventoryCollectionRef() {
   return collection(getDb(), 'inventory');
 }
 

--- a/lib/firestore/inventory.ts
+++ b/lib/firestore/inventory.ts
@@ -37,7 +37,14 @@ export function subscribeInventoryItems(
   return onSnapshot(
     itemsQuery,
     (snapshot) => {
-      callback(snapshot.docs.map((itemDoc) => normalizeInventoryItem(itemDoc.id, itemDoc.data())));
+      // serverTimestamps: 'estimate' … 書き込み確定前の serverTimestamp を null にせず
+      // ローカル推定時刻で埋める。これで状態変更直後に「最終更新」の日付が一瞬消えて
+      // 再表示される（チラつく）のを防ぐ。推定と確定の差は表示の分単位では変わらない。
+      callback(
+        snapshot.docs.map((itemDoc) =>
+          normalizeInventoryItem(itemDoc.id, itemDoc.data({ serverTimestamps: 'estimate' }))
+        )
+      );
     },
     (error) => {
       console.error('Failed to subscribe inventory items:', error);

--- a/lib/firestore/inventory.ts
+++ b/lib/firestore/inventory.ts
@@ -1,0 +1,77 @@
+import {
+  addDoc,
+  collection,
+  deleteDoc,
+  doc,
+  onSnapshot,
+  orderBy,
+  query,
+  serverTimestamp,
+  setDoc,
+  type DocumentData,
+  type Unsubscribe,
+} from 'firebase/firestore';
+import { getDb } from './common';
+import { buildInventoryItemInput, normalizeInventoryStatus } from '@/lib/inventory';
+import type { InventoryItem, InventoryItemInput } from '@/types';
+
+export function getInventoryCollectionRef() {
+  return collection(getDb(), 'inventory');
+}
+
+function normalizeInventoryItem(id: string, data: DocumentData): InventoryItem {
+  return {
+    id,
+    name: typeof data.name === 'string' ? data.name : '',
+    status: normalizeInventoryStatus(data.status),
+    createdAt: data.createdAt,
+    updatedAt: data.updatedAt,
+  };
+}
+
+export function subscribeInventoryItems(
+  callback: (items: InventoryItem[]) => void,
+  onError?: (error: Error) => void
+): Unsubscribe {
+  const itemsQuery = query(getInventoryCollectionRef(), orderBy('createdAt', 'desc'));
+  return onSnapshot(
+    itemsQuery,
+    (snapshot) => {
+      callback(snapshot.docs.map((itemDoc) => normalizeInventoryItem(itemDoc.id, itemDoc.data())));
+    },
+    (error) => {
+      console.error('Failed to subscribe inventory items:', error);
+      onError?.(error);
+      callback([]);
+    }
+  );
+}
+
+/** 新規品目を追加（自動ID）。 */
+export async function addInventoryItem(input: InventoryItemInput): Promise<void> {
+  const normalized = buildInventoryItemInput(input);
+  await addDoc(getInventoryCollectionRef(), {
+    ...normalized,
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp(),
+  });
+}
+
+/** 既存品目の内容を更新（merge）。createdAt は触らない。 */
+export async function updateInventoryItem(id: string, input: InventoryItemInput): Promise<void> {
+  const normalized = buildInventoryItemInput(input);
+  await setDoc(doc(getInventoryCollectionRef(), id), { ...normalized, updatedAt: serverTimestamp() }, { merge: true });
+}
+
+/** ステータスだけを1タップ変更（merge）。 */
+export async function setInventoryItemStatus(id: string, status: InventoryItem['status']): Promise<void> {
+  await setDoc(
+    doc(getInventoryCollectionRef(), id),
+    { status: normalizeInventoryStatus(status), updatedAt: serverTimestamp() },
+    { merge: true }
+  );
+}
+
+export async function deleteInventoryItem(id: string): Promise<void> {
+  await deleteDoc(doc(getInventoryCollectionRef(), id));
+}

--- a/lib/homeFeatures.ts
+++ b/lib/homeFeatures.ts
@@ -25,6 +25,11 @@ export const HOME_FEATURES = [
     description: '月次の生産実績を記録',
   },
   {
+    key: 'inventory',
+    title: '在庫',
+    description: '不足品を共有・要発注',
+  },
+  {
     key: 'drip-guide',
     title: 'ドリップガイド',
     description: '淹れ方の手順',

--- a/lib/inventory.test.ts
+++ b/lib/inventory.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isReorderStatus,
+  selectReorderItems,
+  countReorderItems,
+  normalizeInventoryStatus,
+  buildInventoryItemInput,
+  STATUS_LABELS,
+} from './inventory';
+import type { InventoryItem } from '@/types';
+
+function makeItem(id: string, status: InventoryItem['status']): InventoryItem {
+  return { id, name: id, status };
+}
+
+describe('isReorderStatus', () => {
+  it('low と out が要発注', () => {
+    expect(isReorderStatus('low')).toBe(true);
+    expect(isReorderStatus('out')).toBe(true);
+    expect(isReorderStatus('enough')).toBe(false);
+  });
+});
+
+describe('selectReorderItems / countReorderItems', () => {
+  it('low と out だけを抽出し、out を先頭に並べ件数を返す', () => {
+    const items = [makeItem('a', 'enough'), makeItem('b', 'low'), makeItem('c', 'out')];
+    expect(selectReorderItems(items).map((i) => i.id)).toEqual(['c', 'b']);
+    expect(countReorderItems(items)).toBe(2);
+  });
+
+  it('緊急度順に out(切れた)を low(少ない)より前に並べる', () => {
+    const items = [makeItem('a', 'low'), makeItem('b', 'out'), makeItem('c', 'low'), makeItem('d', 'out')];
+    expect(selectReorderItems(items).map((i) => i.id)).toEqual(['b', 'd', 'a', 'c']);
+  });
+
+  it('同一 status 内は元の順序を維持する(安定ソート)', () => {
+    const items = [makeItem('x', 'out'), makeItem('y', 'out'), makeItem('z', 'out')];
+    expect(selectReorderItems(items).map((i) => i.id)).toEqual(['x', 'y', 'z']);
+
+    const lows = [makeItem('p', 'low'), makeItem('q', 'low'), makeItem('r', 'low')];
+    expect(selectReorderItems(lows).map((i) => i.id)).toEqual(['p', 'q', 'r']);
+  });
+});
+
+describe('normalizeInventoryStatus', () => {
+  it('正しい値はそのまま、未知の値は enough にフォールバック', () => {
+    expect(normalizeInventoryStatus('low')).toBe('low');
+    expect(normalizeInventoryStatus('xxx')).toBe('enough');
+    expect(normalizeInventoryStatus(undefined)).toBe('enough');
+  });
+});
+
+describe('buildInventoryItemInput', () => {
+  it('name をトリムし、status を正規化する', () => {
+    const result = buildInventoryItemInput({ name: '  ドリップ袋 ', status: 'low' });
+    expect(result).toEqual({ name: 'ドリップ袋', status: 'low' });
+  });
+
+  it('未知の status は enough にフォールバックする', () => {
+    const result = buildInventoryItemInput({ name: '砂糖', status: 'xxx' as InventoryItem['status'] });
+    expect(result.status).toBe('enough');
+  });
+
+  it('name が空ならエラー', () => {
+    expect(() => buildInventoryItemInput({ name: '   ', status: 'enough' })).toThrow('品目名を入力してください');
+  });
+});
+
+describe('ラベル定数', () => {
+  it('全 status にラベルがある', () => {
+    expect(STATUS_LABELS.enough).toBe('十分');
+    expect(STATUS_LABELS.low).toBe('少ない');
+    expect(STATUS_LABELS.out).toBe('切れた');
+  });
+});

--- a/lib/inventory.ts
+++ b/lib/inventory.ts
@@ -1,0 +1,48 @@
+import type { InventoryItem, InventoryItemInput, InventoryStatus } from '@/types';
+
+export const STATUS_LABELS: Record<InventoryStatus, string> = {
+  enough: '十分',
+  low: '少ない',
+  out: '切れた',
+};
+
+const VALID_STATUSES: InventoryStatus[] = ['enough', 'low', 'out'];
+
+export function normalizeInventoryStatus(value: unknown): InventoryStatus {
+  return VALID_STATUSES.includes(value as InventoryStatus) ? (value as InventoryStatus) : 'enough';
+}
+
+/** low / out が「要発注」状態 */
+export function isReorderStatus(status: InventoryStatus): boolean {
+  return status === 'low' || status === 'out';
+}
+
+/**
+ * 要発注(low / out)品目を抽出する。
+ * 緊急度順に out(切れた)を low(少ない)より前に並べる。
+ * 同一 status 内は元の順序を維持する(Array.prototype.sort は安定ソート)。
+ */
+export function selectReorderItems(items: InventoryItem[]): InventoryItem[] {
+  const reorderItems = items.filter((item) => isReorderStatus(item.status));
+  const urgency: Record<'out' | 'low', number> = { out: 0, low: 1 };
+  return reorderItems.sort((a, b) => urgency[a.status as 'out' | 'low'] - urgency[b.status as 'out' | 'low']);
+}
+
+export function countReorderItems(items: InventoryItem[]): number {
+  return selectReorderItems(items).length;
+}
+
+/**
+ * 入力を正規化し保存可能な形にする。
+ * name をトリムし空なら例外。status を正規化する。
+ */
+export function buildInventoryItemInput(input: InventoryItemInput): InventoryItemInput {
+  const name = input.name.trim();
+  if (name.length === 0) {
+    throw new Error('品目名を入力してください');
+  }
+  return {
+    name,
+    status: normalizeInventoryStatus(input.status),
+  };
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roastplus",
-  "version": "0.17.7",
+  "version": "0.18.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/types/index.ts
+++ b/types/index.ts
@@ -9,3 +9,4 @@ export * from './settings';
 export * from './notification';
 export * from './defect-beans';
 export * from './production-record';
+export * from './inventory';

--- a/types/inventory.ts
+++ b/types/inventory.ts
@@ -1,0 +1,14 @@
+import type { FirestoreTimestamp } from './common';
+
+export type InventoryStatus = 'enough' | 'low' | 'out';
+
+export interface InventoryItemInput {
+  name: string;
+  status: InventoryStatus;
+}
+
+export interface InventoryItem extends InventoryItemInput {
+  id: string;
+  createdAt?: FirestoreTimestamp;
+  updatedAt?: FirestoreTimestamp;
+}


### PR DESCRIPTION
## 概要

在庫・不足品の共有ボード機能の **PR2（機能本体）** です。ルールは PR1 (#559) で追加済み。

**この機能は何か**: 現場メンバーが「足りない」を信号機方式（🟢十分 / 🟡少ない / 🔴切れた）で共有し、本社が遠隔で要発注リストを見て発注できるチーム共有ボード。高離職の現場でも在庫把握が属人化せず継続することを狙う。

## 変更内容

- **機能移植**: `types/inventory.ts`・`lib/inventory.ts`・`lib/firestore/inventory.ts`・`hooks/useInventory.ts`・`components/inventory/*`・`app/inventory/page.tsx` を最新 main へ移植
- **設計判断の反映（grill-me で決定した「引き算」）**:
  - 更新者名(updatedBy)を廃止 … 共有アカウントのため常に同じ名前になり無意味（タイムスタンプは残す）
  - カテゴリを廃止 … 表示バッジと入力選択にしか使われない飾りで、境界も曖昧
  - メモ欄を廃止 … 信号機で「足/不足」は伝わるため冗長
- **ホーム統合**: 「在庫」カード＋「要発注N」バッジを追加（`app/page.tsx`・`lib/homeFeatures.ts`）
- **export 配線**: `lib/firestore/index.ts`・`types/index.ts`
- **法的文書**: ページ追加に伴い privacy-policy / terms にデータ・機能を追記、PP 1.3.0 / TERMS 1.2.0 へ、アプリを 0.18.0 へ

## 検証

- `npm run typecheck` ✅ / `npm run lint` ✅ / `npm run test:run`（**1305件**）✅ / `npm run docs:check` ✅ / `npm run format:check` ✅

## マージ順

- **先に PR1 (#559) をマージ**して inventory ルールを本番反映してから、この PR をマージしてください（本番で在庫の読み書きが許可されるため）。

## 残（follow-up）

- `docs/steering/FEATURES.md`・`TECH_SPEC.md` への在庫機能の記載（docs:check は通過済み・番号付きセクション構成のため別途丁寧に追加）。
- 発注主体（本社直接 / 管理者経由）の運用ルールは会社確認事項（アプリ外）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)