### PR TITLE
feat: ドリップガイド実行画面に次ステップ予告と直前アラートを追加

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -644,6 +644,65 @@ select option {
   }
 }
 
+/* ドリップガイド: 次ステップ直前アラート（画面外周のリング＋せり上がる予告バー） */
+@keyframes drip-alert-ring {
+  0%,
+  100% {
+    opacity: 0.45;
+    box-shadow: inset 0 0 0 8px var(--spot);
+  }
+  50% {
+    opacity: 1;
+    box-shadow: inset 0 0 0 18px var(--spot);
+  }
+}
+
+@keyframes drip-alert-beat {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.12);
+  }
+}
+
+@keyframes drip-alert-slide-up {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+.animate-drip-alert-ring {
+  animation: drip-alert-ring 1s ease-in-out infinite;
+}
+
+.animate-drip-alert-beat {
+  animation: drip-alert-beat 1s ease-in-out infinite;
+}
+
+.animate-drip-alert-slide-up {
+  animation: drip-alert-slide-up 0.4s cubic-bezier(0.2, 0.9, 0.3, 1) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* 点滅・拍動は止め、色と面積だけで直前を伝える */
+  .animate-drip-alert-ring {
+    animation: none;
+    opacity: 1;
+    box-shadow: inset 0 0 0 14px var(--spot);
+  }
+
+  .animate-drip-alert-beat,
+  .animate-drip-alert-slide-up {
+    animation: none;
+    transform: none;
+  }
+}
+
 /* Scrollbar Hiding Utilities */
 .scrollbar-hide {
   -ms-overflow-style: none;

--- a/components/drip-guide/DripGuideRunner.test.tsx
+++ b/components/drip-guide/DripGuideRunner.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { act } from '@testing-library/react';
 import { DripGuideRunner } from './DripGuideRunner';
@@ -92,10 +92,168 @@ describe('DripGuideRunner', () => {
     expect(screen.getAllByText('粉全体にまんべんなくお湯を注いで、均一に湿らせます。')).toHaveLength(2);
   });
 
-  it('次の注水量を作業カード内に表示しない', () => {
+  it('次の注水量を現在の巨大数字として表示しない', () => {
     render(<DripGuideRunner recipe={recipe} />);
 
     expect(screen.queryByText('40gまで')).not.toBeInTheDocument();
+    screen.getAllByTestId('drip-current-water').forEach((element) => {
+      expect(element).not.toHaveTextContent('40g');
+    });
+  });
+
+  describe('次ステップ予告', () => {
+    beforeEach(() => {
+      vi.mocked(useRunnerTimer).mockReset();
+    });
+
+    const renderWithTime = (targetRecipe: DripRecipe, seconds: number) => {
+      let capturedOnTick: (updater: (prev: number) => number) => void = () => {};
+      vi.mocked(useRunnerTimer).mockImplementation(({ onTick }) => {
+        capturedOnTick = onTick;
+        return { current: null };
+      });
+
+      const result = render(<DripGuideRunner recipe={targetRecipe} />);
+      act(() => {
+        capturedOnTick(() => seconds);
+      });
+      return result;
+    };
+
+    it('予告行は残り3秒以内でも見た目を変えない', () => {
+      renderWithTime(autoRecipe, 27);
+
+      screen.getAllByTestId('drip-next-preview').forEach((element) => {
+        expect(element).not.toHaveAttribute('data-soon');
+      });
+    });
+
+    it('自動モードで次のステップ・目標湯量・残り秒を出す', () => {
+      renderWithTime(autoRecipe, 10);
+
+      const previews = screen.getAllByTestId('drip-next-preview');
+      expect(previews).toHaveLength(2);
+      previews.forEach((element) => {
+        expect(element).toHaveTextContent('2投目 → 150g');
+        expect(element).toHaveTextContent('あと 20秒');
+      });
+    });
+
+    it('残り3秒以内でも予告行の書式は変わらない', () => {
+      renderWithTime(autoRecipe, 27);
+
+      screen.getAllByTestId('drip-next-preview').forEach((element) => {
+        expect(element).toHaveTextContent('あと 3秒');
+      });
+    });
+
+    it('自動モードの最終ステップでは完了までの残りを出す', () => {
+      renderWithTime(autoRecipe, 60);
+
+      screen.getAllByTestId('drip-next-preview').forEach((element) => {
+        expect(element).toHaveTextContent('完了まで');
+        expect(element).toHaveTextContent('あと 1:00');
+      });
+    });
+
+    it('手動モードでは残り秒を出さず見出しと目標湯量だけ出す', () => {
+      render(<DripGuideRunner recipe={recipe} />);
+
+      screen.getAllByTestId('drip-next-preview').forEach((element) => {
+        expect(element).toHaveTextContent('2投目 → 40g');
+        expect(element).not.toHaveTextContent('あと');
+      });
+    });
+  });
+
+  describe('次ステップ直前アラート', () => {
+    beforeEach(() => {
+      vi.mocked(useRunnerTimer).mockReset();
+    });
+
+    const renderRunning = (targetRecipe: DripRecipe, seconds: number) => {
+      let capturedOnTick: (updater: (prev: number) => number) => void = () => {};
+      vi.mocked(useRunnerTimer).mockImplementation(({ onTick }) => {
+        capturedOnTick = onTick;
+        return { current: null };
+      });
+
+      render(<DripGuideRunner recipe={targetRecipe} />);
+      // 再生してタイマーを動かしてから経過時間を進める
+      fireEvent.click(screen.getByLabelText('再生'));
+      act(() => {
+        capturedOnTick(() => seconds);
+      });
+    };
+
+    it('残り3秒でリングとバーを出し、次の湯量を「まで注ぐ」付きで示す', () => {
+      renderRunning(autoRecipe, 27);
+
+      expect(screen.getByTestId('drip-alert-ring')).toBeInTheDocument();
+      const bar = screen.getByTestId('drip-alert-bar');
+      expect(bar).toHaveTextContent('まもなく次の注湯');
+      expect(bar).toHaveTextContent('2投目');
+      expect(bar).toHaveTextContent('→ 150g');
+      expect(bar).toHaveTextContent('まで注ぐ');
+      expect(screen.getByTestId('drip-alert-countdown')).toHaveTextContent('3');
+    });
+
+    it('残り4秒以上では出さない', () => {
+      renderRunning(autoRecipe, 26);
+
+      expect(screen.queryByTestId('drip-alert-bar')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('drip-alert-ring')).not.toBeInTheDocument();
+    });
+
+    it('一時停止中は出さない', () => {
+      let capturedOnTick: (updater: (prev: number) => number) => void = () => {};
+      vi.mocked(useRunnerTimer).mockImplementation(({ onTick }) => {
+        capturedOnTick = onTick;
+        return { current: null };
+      });
+
+      render(<DripGuideRunner recipe={autoRecipe} />);
+      act(() => {
+        capturedOnTick(() => 27);
+      });
+
+      expect(screen.queryByTestId('drip-alert-bar')).not.toBeInTheDocument();
+    });
+
+    it('手動モードでは出さない', () => {
+      render(<DripGuideRunner recipe={recipe} />);
+      fireEvent.click(screen.getByLabelText('再生'));
+
+      expect(screen.queryByTestId('drip-alert-bar')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('進捗バー', () => {
+    beforeEach(() => {
+      vi.mocked(useRunnerTimer).mockReset();
+    });
+
+    it('自動モードは経過時間の比率を示す', () => {
+      let capturedOnTick: (updater: (prev: number) => number) => void = () => {};
+      vi.mocked(useRunnerTimer).mockImplementation(({ onTick }) => {
+        capturedOnTick = onTick;
+        return { current: null };
+      });
+
+      render(<DripGuideRunner recipe={autoRecipe} />);
+      act(() => {
+        capturedOnTick(() => 60); // 120秒中の60秒 → 50%
+      });
+
+      expect(screen.getByTestId('drip-progress-bar')).toHaveAttribute('aria-valuenow', '50');
+    });
+
+    it('手動モードはステップ数の比率を示す', () => {
+      render(<DripGuideRunner recipe={recipe} />);
+
+      // 全2ステップの1つ目 → 50%
+      expect(screen.getByTestId('drip-progress-bar')).toHaveAttribute('aria-valuenow', '50');
+    });
   });
 
   describe('カウントダウン音', () => {

--- a/components/drip-guide/DripGuideRunner.tsx
+++ b/components/drip-guide/DripGuideRunner.tsx
@@ -8,6 +8,9 @@ import { CompletionScreen } from './runner/CompletionScreen';
 import { FloatingNav } from '@/components/ui';
 import { FooterControls } from './runner/FooterControls';
 import { FocusGuideDisplay } from './runner/FocusGuideDisplay';
+import { RunnerProgressBar } from './runner/RunnerProgressBar';
+import { NextStepAlert } from './runner/NextStepAlert';
+import { buildNextStepAlert, buildNextStepPreview, calcRunnerProgressRatio } from '@/lib/drip-guide/runnerDisplay';
 
 interface DripGuideRunnerProps {
   recipe: DripRecipe;
@@ -31,6 +34,27 @@ export const DripGuideRunner: React.FC<DripGuideRunnerProps> = ({ recipe }) => {
   const currentStepIndex = isManualMode ? manualStepIndex : autoModeStepIndex;
   const currentStep = currentStepIndex !== -1 && currentStepIndex < steps.length ? steps[currentStepIndex] : null;
   const nextStep = currentStepIndex < steps.length - 1 ? steps[currentStepIndex + 1] : null;
+
+  // 次の1手の予告と全体進捗（表示用の導出値）
+  const nextStepPreview = buildNextStepPreview({
+    nextStep,
+    currentTime,
+    totalDurationSec: recipe.totalDurationSec,
+    isManualMode,
+  });
+  const nextStepAlert = buildNextStepAlert({
+    nextStep,
+    currentTime,
+    isManualMode,
+    isRunning,
+  });
+  const progressRatio = calcRunnerProgressRatio({
+    isManualMode,
+    currentTime,
+    totalDurationSec: recipe.totalDurationSec,
+    currentStepIndex,
+    totalSteps: steps.length,
+  });
 
   // Timer logic
   useRunnerTimer({
@@ -99,22 +123,24 @@ export const DripGuideRunner: React.FC<DripGuideRunnerProps> = ({ recipe }) => {
 
   return (
     <div className="flex flex-col h-[100dvh] bg-ground relative overflow-hidden">
+      <RunnerProgressBar ratio={progressRatio} />
       <FloatingNav backHref="/drip-guide" />
 
-      <div className="flex-1 flex items-center px-5 sm:px-6 lg:px-12 pb-4 lg:pb-6 overflow-y-auto">
+      {/* FloatingNav（左上固定の戻るボタン）と情報カードが重ならないよう上余白を確保する */}
+      <div className="flex-1 flex items-center px-5 sm:px-6 lg:px-12 pt-12 lg:pt-6 pb-4 lg:pb-6 overflow-y-auto">
         <FocusGuideDisplay
           currentTime={currentTime}
           recipeName={recipe.name}
           currentStep={currentStep}
           currentStepIndex={currentStepIndex}
           totalSteps={steps.length}
+          nextStepPreview={nextStepPreview}
         />
       </div>
 
       <FooterControls
         isManualMode={isManualMode}
         isRunning={isRunning}
-        nextStep={nextStep}
         manualStepIndex={manualStepIndex}
         stepsLength={steps.length}
         currentStepIndex={currentStepIndex}
@@ -124,6 +150,8 @@ export const DripGuideRunner: React.FC<DripGuideRunnerProps> = ({ recipe }) => {
         onGoToPrevStep={goToPrevStep}
         onComplete={handleComplete}
       />
+
+      {nextStepAlert && <NextStepAlert alert={nextStepAlert} />}
     </div>
   );
 };

--- a/components/drip-guide/runner/FocusGuideDisplay.tsx
+++ b/components/drip-guide/runner/FocusGuideDisplay.tsx
@@ -3,6 +3,8 @@
 import React from 'react';
 import { formatSecondsAsTimer as formatTime } from '@/lib/dateUtils';
 import type { DripStep } from '@/lib/drip-guide/types';
+import { splitStepTitle, type NextStepPreview as NextStepPreviewData } from '@/lib/drip-guide/runnerDisplay';
+import { NextStepPreview } from './NextStepPreview';
 
 interface FocusGuideDisplayProps {
   currentTime: number;
@@ -10,19 +12,7 @@ interface FocusGuideDisplayProps {
   currentStep: DripStep | null;
   currentStepIndex: number;
   totalSteps: number;
-}
-
-function splitStepTitle(title: string): { mainTitle: string; detail?: string } {
-  const match = title.match(/^(.+?)[（(](.+)[）)]$/);
-
-  if (!match) {
-    return { mainTitle: title };
-  }
-
-  return {
-    mainTitle: match[1],
-    detail: match[2],
-  };
+  nextStepPreview: NextStepPreviewData;
 }
 
 function WaterTarget({ targetTotalWater }: { targetTotalWater?: number }) {
@@ -33,12 +23,12 @@ function WaterTarget({ targetTotalWater }: { targetTotalWater?: number }) {
   return (
     <div className="text-center" data-testid="drip-current-water">
       <div className="flex items-baseline justify-center gap-2">
-        <span className="text-[7rem] lg:text-[7.25rem] font-extrabold leading-none text-spot tabular-nums font-nunito">
+        <span className="text-[7rem] lg:text-[5rem] font-extrabold leading-none text-spot tabular-nums font-nunito">
           {targetTotalWater}
         </span>
         <span className="text-[2rem] font-extrabold text-spot/65">g</span>
       </div>
-      <p className="-mt-1 text-2xl font-extrabold text-ink">まで注ぐ</p>
+      <p className="-mt-1 text-2xl lg:text-xl font-extrabold text-ink">まで注ぐ</p>
     </div>
   );
 }
@@ -49,6 +39,7 @@ export const FocusGuideDisplay: React.FC<FocusGuideDisplayProps> = ({
   currentStep,
   currentStepIndex,
   totalSteps,
+  nextStepPreview,
 }) => {
   if (!currentStep) {
     return (
@@ -71,7 +62,7 @@ export const FocusGuideDisplay: React.FC<FocusGuideDisplayProps> = ({
       className="w-full max-w-md lg:max-w-5xl mx-auto lg:h-full lg:flex lg:items-center"
     >
       {/* Smartphone portrait: quick-glance stacked layout */}
-      <div className="w-full space-y-7 lg:hidden">
+      <div className="w-full space-y-5 lg:hidden">
         <section className="rounded-lg bg-surface border border-edge px-4 py-3 shadow-card flex items-center justify-between gap-4">
           <div className="min-w-0">
             <div className="flex items-center justify-between">
@@ -88,22 +79,26 @@ export const FocusGuideDisplay: React.FC<FocusGuideDisplayProps> = ({
           </div>
         </section>
 
-        <section className="min-h-[360px] rounded-lg bg-surface border border-edge px-6 py-8 shadow-card text-center flex flex-col justify-center">
+        <section className="min-h-[320px] rounded-lg bg-surface border border-edge px-5 py-6 shadow-card text-center flex flex-col justify-center">
           <WaterTarget targetTotalWater={currentStep.targetTotalWater} />
-          <p className="mt-8 text-[1.4rem] font-extrabold leading-relaxed text-ink">{currentStep.description}</p>
+          <p className="mt-6 text-[1.4rem] font-extrabold leading-snug text-ink">{currentStep.description}</p>
           {currentStep.note && (
-            <p className="mt-5 text-lg font-semibold leading-relaxed text-ink-sub">{currentStep.note}</p>
+            <p className="mt-4 text-base font-semibold leading-snug text-ink-sub">{currentStep.note}</p>
           )}
+          <NextStepPreview preview={nextStepPreview} variant="compact" />
         </section>
       </div>
 
       {/* Tablet landscape / wide screens: one information card, controls stay in footer */}
-      <section className="hidden lg:grid w-full min-h-[390px] grid-cols-[0.82fr_1.18fr] gap-10 rounded-xl border border-edge bg-surface px-10 py-9 shadow-card">
-        <div className="flex flex-col justify-center border-r border-edge pr-10">
+      <section className="hidden lg:grid w-full min-h-[300px] grid-cols-[0.82fr_1.18fr] gap-8 rounded-xl border border-edge bg-surface px-8 py-6 shadow-card">
+        <div className="flex flex-col justify-center border-r border-edge pr-8">
           <div className="mx-auto w-full max-w-[330px]">
-            <h2 className="text-[2rem] font-extrabold leading-tight text-ink">{mainTitle}</h2>
-            {detail && <p className="mt-2 text-xl font-bold leading-tight text-ink-muted">{detail}</p>}
-            <div className="mt-8 text-[6.75rem] font-extrabold leading-none text-ink tabular-nums font-nunito">
+            <p className="mb-1.5 text-sm font-extrabold tracking-wide text-ink-muted tabular-nums">
+              {currentStepIndex + 1} / {totalSteps}
+            </p>
+            <h2 className="text-[1.875rem] font-extrabold leading-tight text-ink">{mainTitle}</h2>
+            {detail && <p className="mt-1.5 text-lg font-bold leading-tight text-ink-muted">{detail}</p>}
+            <div className="mt-5 text-[5rem] font-extrabold leading-none text-ink tabular-nums font-nunito">
               {formatTime(currentTime)}
             </div>
           </div>
@@ -111,10 +106,9 @@ export const FocusGuideDisplay: React.FC<FocusGuideDisplayProps> = ({
 
         <div className="flex flex-col justify-center text-center">
           <WaterTarget targetTotalWater={currentStep.targetTotalWater} />
-          <p className="mt-9 text-[2.1rem] font-extrabold leading-relaxed text-ink">{currentStep.description}</p>
-          {currentStep.note && (
-            <p className="mt-5 text-[1.35rem] font-bold leading-relaxed text-ink-sub">{currentStep.note}</p>
-          )}
+          <p className="mt-6 text-2xl font-extrabold leading-snug text-ink">{currentStep.description}</p>
+          {currentStep.note && <p className="mt-3 text-base font-bold leading-snug text-ink-sub">{currentStep.note}</p>}
+          <NextStepPreview preview={nextStepPreview} variant="wide" />
         </div>
       </section>
     </div>

--- a/components/drip-guide/runner/FooterControls.tsx
+++ b/components/drip-guide/runner/FooterControls.tsx
@@ -4,13 +4,11 @@ import React from 'react';
 import { Play, Pause, ArrowCounterClockwise, X, ArrowLeft, ArrowRight, CheckCircle } from 'phosphor-react';
 import { clsx } from 'clsx';
 import Link from 'next/link';
-import type { DripStep } from '@/lib/drip-guide/types';
 import { IconButton } from '@/components/ui';
 
 interface FooterControlsProps {
   isManualMode: boolean;
   isRunning: boolean;
-  nextStep?: DripStep | null;
   manualStepIndex: number;
   stepsLength: number;
   currentStepIndex: number;

--- a/components/drip-guide/runner/NextStepAlert.tsx
+++ b/components/drip-guide/runner/NextStepAlert.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import React from 'react';
+import type { NextStepAlert as NextStepAlertData } from '@/lib/drip-guide/runnerDisplay';
+
+interface NextStepAlertProps {
+  alert: NextStepAlertData;
+}
+
+/**
+ * 次の注湯が来る直前（残り3秒）の合図。
+ * 画面外周のリングで周辺視野に気づかせ、下からせり上がるバーで次の指示を伝える。
+ * 現在の湯量・説明文は隠さない。
+ */
+export const NextStepAlert: React.FC<NextStepAlertProps> = ({ alert }) => {
+  return (
+    <>
+      <div
+        data-testid="drip-alert-ring"
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 z-30 animate-drip-alert-ring"
+      />
+
+      <div
+        data-testid="drip-alert-bar"
+        className="absolute inset-x-0 bottom-0 z-40 flex items-center justify-between gap-4 bg-spot px-6 py-9 text-on-spot shadow-[0_-8px_24px_rgba(0,0,0,0.18)] animate-drip-alert-slide-up safe-area-bottom sm:px-8 lg:py-8"
+      >
+        <div className="min-w-0">
+          <p className="text-xs font-extrabold tracking-wide text-on-spot/80 sm:text-sm">まもなく次の注湯</p>
+          <div className="mt-0.5 flex flex-wrap items-baseline gap-x-2 font-extrabold leading-tight">
+            <span className="text-xl sm:text-2xl lg:text-[1.75rem]">{alert.title}</span>
+            {alert.targetTotalWater && (
+              <>
+                <span className="text-2xl tabular-nums sm:text-3xl lg:text-[2.25rem]">→ {alert.targetTotalWater}g</span>
+                <span className="text-base text-on-spot/85 sm:text-lg">まで注ぐ</span>
+              </>
+            )}
+          </div>
+        </div>
+
+        <div
+          data-testid="drip-alert-countdown"
+          className="flex-none text-[3.5rem] font-extrabold leading-none tabular-nums font-nunito animate-drip-alert-beat sm:text-[4.5rem]"
+        >
+          {alert.remainingSec}
+        </div>
+      </div>
+    </>
+  );
+};

--- a/components/drip-guide/runner/NextStepPreview.tsx
+++ b/components/drip-guide/runner/NextStepPreview.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import React from 'react';
+import { clsx } from 'clsx';
+import type { NextStepPreview as NextStepPreviewData } from '@/lib/drip-guide/runnerDisplay';
+
+interface NextStepPreviewProps {
+  preview: NextStepPreviewData;
+  /** compact: スマホ縦 / wide: タブレット横 */
+  variant: 'compact' | 'wide';
+}
+
+/**
+ * 情報カード最下部に出す「次の1手」予告。
+ * 直前の合図は NextStepAlert（リング＋せり上がるバー）が担うため、この行は常に控えめな見た目を保つ。
+ */
+export const NextStepPreview: React.FC<NextStepPreviewProps> = ({ preview, variant }) => {
+  const isWide = variant === 'wide';
+
+  return (
+    <div
+      data-testid="drip-next-preview"
+      className={clsx(
+        'flex flex-wrap items-center justify-center border-t border-edge pt-4 text-ink-sub',
+        isWide ? 'mt-5 gap-x-3 gap-y-1' : 'mt-6 gap-x-2 gap-y-0.5'
+      )}
+    >
+      {preview.leadLabel && (
+        <span className={clsx('font-extrabold tracking-widest text-ink-muted', isWide ? 'text-sm' : 'text-xs')}>
+          {preview.leadLabel}
+        </span>
+      )}
+      <span className={clsx('font-extrabold', isWide ? 'text-lg' : 'text-sm')}>{preview.body}</span>
+      {preview.remainingText && (
+        <>
+          <span aria-hidden="true" className={clsx('text-edge-strong', isWide ? 'text-sm' : 'text-xs')}>
+            ・
+          </span>
+          <span className={clsx('font-extrabold tabular-nums', isWide ? 'text-lg' : 'text-sm')}>
+            {preview.remainingText}
+          </span>
+        </>
+      )}
+    </div>
+  );
+};

--- a/components/drip-guide/runner/RunnerProgressBar.tsx
+++ b/components/drip-guide/runner/RunnerProgressBar.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import React from 'react';
+
+interface RunnerProgressBarProps {
+  /** 進捗の比率（0〜1） */
+  ratio: number;
+}
+
+/**
+ * 実行画面の最上部に出す全体進捗バー。
+ * 自動モードは経過時間、手動モードはステップ数を基準にした比率を受け取る。
+ */
+export const RunnerProgressBar: React.FC<RunnerProgressBarProps> = ({ ratio }) => {
+  const percent = Math.round(ratio * 100);
+
+  return (
+    <div
+      data-testid="drip-progress-bar"
+      role="progressbar"
+      aria-label="抽出の進捗"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={percent}
+      className="flex-none h-1.5 w-full bg-edge"
+    >
+      <div
+        className="h-full bg-spot rounded-r-full transition-[width] duration-500 ease-linear"
+        style={{ width: `${percent}%` }}
+      />
+    </div>
+  );
+};

--- a/lib/dateUtils.test.ts
+++ b/lib/dateUtils.test.ts
@@ -12,6 +12,7 @@ import {
   formatTimeHM,
   formatMinutesToHHMM,
   formatSecondsAsTimer,
+  formatSecondsAsShortRemaining,
 } from './dateUtils';
 
 describe('formatDateToYMD', () => {
@@ -143,5 +144,25 @@ describe('formatSecondsAsTimer', () => {
     expect(formatSecondsAsTimer(0)).toBe('00:00');
     expect(formatSecondsAsTimer(60)).toBe('01:00');
     expect(formatSecondsAsTimer(3661)).toBe('61:01');
+  });
+});
+
+describe('formatSecondsAsShortRemaining', () => {
+  it('60秒未満は秒だけで表す', () => {
+    expect(formatSecondsAsShortRemaining(45)).toBe('45秒');
+    expect(formatSecondsAsShortRemaining(3)).toBe('3秒');
+    expect(formatSecondsAsShortRemaining(0)).toBe('0秒');
+    expect(formatSecondsAsShortRemaining(59)).toBe('59秒');
+  });
+
+  it('60秒以上はM:SS形式（分の先頭ゼロなし）で表す', () => {
+    expect(formatSecondsAsShortRemaining(60)).toBe('1:00');
+    expect(formatSecondsAsShortRemaining(80)).toBe('1:20');
+    expect(formatSecondsAsShortRemaining(605)).toBe('10:05');
+  });
+
+  it('負値と小数を0秒側に丸める', () => {
+    expect(formatSecondsAsShortRemaining(-5)).toBe('0秒');
+    expect(formatSecondsAsShortRemaining(12.7)).toBe('12秒');
   });
 });

--- a/lib/dateUtils.ts
+++ b/lib/dateUtils.ts
@@ -95,3 +95,17 @@ export function formatSecondsAsTimer(seconds: number): string {
   const s = seconds % 60;
   return `${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
 }
+
+/**
+ * 残り秒数を短い可読形式に変換（例: 45 → "45秒" / 80 → "1:20"）。
+ * 60秒未満は秒だけ、60秒以上はM:SS（分の先頭ゼロなし）。負値は0秒扱い。
+ */
+export function formatSecondsAsShortRemaining(seconds: number): string {
+  const safe = Math.max(0, Math.floor(seconds));
+  if (safe < 60) {
+    return `${safe}秒`;
+  }
+  const m = Math.floor(safe / 60);
+  const s = safe % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}

--- a/lib/drip-guide/runnerDisplay.test.ts
+++ b/lib/drip-guide/runnerDisplay.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect } from 'vitest';
+import { splitStepTitle, buildNextStepPreview, buildNextStepAlert, calcRunnerProgressRatio } from './runnerDisplay';
+import type { DripStep } from './types';
+
+const step = (override: Partial<DripStep> = {}): DripStep => ({
+  id: 'step-x',
+  startTimeSec: 135,
+  title: '濃度調整（60%）',
+  description: '濃度を調整する注湯です。',
+  targetTotalWater: 120,
+  ...override,
+});
+
+describe('splitStepTitle', () => {
+  it('括弧付きの見出しを主見出しと補足に分ける', () => {
+    expect(splitStepTitle('濃度調整（60%）')).toEqual({ mainTitle: '濃度調整', detail: '60%' });
+    expect(splitStepTitle('蒸らし(1投目)')).toEqual({ mainTitle: '蒸らし', detail: '1投目' });
+  });
+
+  it('括弧がない見出しはそのまま主見出しにする', () => {
+    expect(splitStepTitle('4投目／仕上げ')).toEqual({ mainTitle: '4投目／仕上げ' });
+  });
+});
+
+describe('buildNextStepPreview', () => {
+  describe('自動モード', () => {
+    it('次ステップの主見出し・目標湯量・残り秒を返す', () => {
+      const preview = buildNextStepPreview({
+        nextStep: step(),
+        currentTime: 115,
+        totalDurationSec: 210,
+        isManualMode: false,
+      });
+
+      expect(preview.leadLabel).toBe('次');
+      expect(preview.body).toBe('濃度調整 → 120g');
+      expect(preview.remainingText).toBe('あと 20秒');
+    });
+
+    it('残り3秒以内でも予告行の中身は同じ書式のまま（強調は NextStepAlert が担う）', () => {
+      const preview = buildNextStepPreview({
+        nextStep: step(),
+        currentTime: 132,
+        totalDurationSec: 210,
+        isManualMode: false,
+      });
+
+      expect(preview.remainingText).toBe('あと 3秒');
+    });
+
+    it('60秒以上の残りはM:SS形式で表す', () => {
+      const preview = buildNextStepPreview({
+        nextStep: step({ startTimeSec: 200 }),
+        currentTime: 120,
+        totalDurationSec: 210,
+        isManualMode: false,
+      });
+
+      expect(preview.remainingText).toBe('あと 1:20');
+    });
+
+    it('目標湯量がないステップは見出しだけにする', () => {
+      const preview = buildNextStepPreview({
+        nextStep: step({ title: '落ち切り待ち', targetTotalWater: undefined }),
+        currentTime: 130,
+        totalDurationSec: 210,
+        isManualMode: false,
+      });
+
+      expect(preview.body).toBe('落ち切り待ち');
+    });
+
+    it('最終ステップでは完了までの残りを返す', () => {
+      const preview = buildNextStepPreview({
+        nextStep: null,
+        currentTime: 165,
+        totalDurationSec: 210,
+        isManualMode: false,
+      });
+
+      expect(preview.leadLabel).toBe('残り');
+      expect(preview.body).toBe('完了まで');
+      expect(preview.remainingText).toBe('あと 45秒');
+    });
+
+    it('残り時間が負にならないよう0秒で止める', () => {
+      const preview = buildNextStepPreview({
+        nextStep: null,
+        currentTime: 250,
+        totalDurationSec: 210,
+        isManualMode: false,
+      });
+
+      expect(preview.remainingText).toBe('あと 0秒');
+    });
+  });
+
+  describe('手動モード', () => {
+    it('残り秒を付けず、見出しと目標湯量だけ返す', () => {
+      const preview = buildNextStepPreview({
+        nextStep: step({ title: '1投目', targetTotalWater: 90 }),
+        currentTime: 0,
+        totalDurationSec: 180,
+        isManualMode: true,
+      });
+
+      expect(preview.leadLabel).toBe('次');
+      expect(preview.body).toBe('1投目 → 90g');
+      expect(preview.remainingText).toBeUndefined();
+    });
+
+    it('最終ステップでは最後の手順である旨を返す', () => {
+      const preview = buildNextStepPreview({
+        nextStep: null,
+        currentTime: 0,
+        totalDurationSec: 180,
+        isManualMode: true,
+      });
+
+      expect(preview.leadLabel).toBeUndefined();
+      expect(preview.body).toBe('これが最後の手順');
+      expect(preview.remainingText).toBeUndefined();
+    });
+  });
+});
+
+describe('buildNextStepAlert', () => {
+  const params = {
+    nextStep: step(),
+    currentTime: 133,
+    isManualMode: false,
+    isRunning: true,
+  };
+
+  it('残り3秒以内なら次ステップの見出し・目標湯量・残り秒を返す', () => {
+    expect(buildNextStepAlert({ ...params, currentTime: 132 })).toEqual({
+      title: '濃度調整',
+      targetTotalWater: 120,
+      remainingSec: 3,
+    });
+    expect(buildNextStepAlert({ ...params, currentTime: 134 })?.remainingSec).toBe(1);
+    expect(buildNextStepAlert({ ...params, currentTime: 135 })?.remainingSec).toBe(0);
+  });
+
+  it('残り4秒以上では出さない', () => {
+    expect(buildNextStepAlert({ ...params, currentTime: 131 })).toBeNull();
+  });
+
+  it('タイマー停止中は出さない', () => {
+    expect(buildNextStepAlert({ ...params, currentTime: 132, isRunning: false })).toBeNull();
+  });
+
+  it('手動モードでは出さない', () => {
+    expect(buildNextStepAlert({ ...params, currentTime: 132, isManualMode: true })).toBeNull();
+  });
+
+  it('次ステップがない（最終ステップ）ときは出さない', () => {
+    expect(buildNextStepAlert({ ...params, nextStep: null })).toBeNull();
+  });
+
+  it('開始時刻を過ぎたステップでは出さない', () => {
+    expect(buildNextStepAlert({ ...params, currentTime: 136 })).toBeNull();
+  });
+
+  it('目標湯量を持たないステップでは湯量を省く', () => {
+    const alert = buildNextStepAlert({
+      ...params,
+      nextStep: step({ title: '落ち切り待ち', targetTotalWater: undefined }),
+      currentTime: 133,
+    });
+
+    expect(alert).toEqual({ title: '落ち切り待ち', targetTotalWater: undefined, remainingSec: 2 });
+  });
+});
+
+describe('calcRunnerProgressRatio', () => {
+  it('自動モードは経過時間の比率を返す', () => {
+    expect(
+      calcRunnerProgressRatio({
+        isManualMode: false,
+        currentTime: 105,
+        totalDurationSec: 210,
+        currentStepIndex: 2,
+        totalSteps: 5,
+      })
+    ).toBeCloseTo(0.5);
+  });
+
+  it('手動モードはステップ数の比率を返す', () => {
+    expect(
+      calcRunnerProgressRatio({
+        isManualMode: true,
+        currentTime: 0,
+        totalDurationSec: 180,
+        currentStepIndex: 3,
+        totalSteps: 8,
+      })
+    ).toBeCloseTo(0.5);
+  });
+
+  it('0〜1の範囲に収める', () => {
+    expect(
+      calcRunnerProgressRatio({
+        isManualMode: false,
+        currentTime: 300,
+        totalDurationSec: 210,
+        currentStepIndex: 4,
+        totalSteps: 5,
+      })
+    ).toBe(1);
+
+    expect(
+      calcRunnerProgressRatio({
+        isManualMode: true,
+        currentTime: 0,
+        totalDurationSec: 180,
+        currentStepIndex: -1,
+        totalSteps: 5,
+      })
+    ).toBe(0);
+  });
+
+  it('総時間・総ステップ数が0なら0を返す', () => {
+    expect(
+      calcRunnerProgressRatio({
+        isManualMode: false,
+        currentTime: 10,
+        totalDurationSec: 0,
+        currentStepIndex: 0,
+        totalSteps: 0,
+      })
+    ).toBe(0);
+
+    expect(
+      calcRunnerProgressRatio({
+        isManualMode: true,
+        currentTime: 10,
+        totalDurationSec: 180,
+        currentStepIndex: 0,
+        totalSteps: 0,
+      })
+    ).toBe(0);
+  });
+});

--- a/lib/drip-guide/runnerDisplay.ts
+++ b/lib/drip-guide/runnerDisplay.ts
@@ -1,11 +1,11 @@
 import { formatSecondsAsShortRemaining } from '@/lib/dateUtils';
 import type { DripStep } from './types';
 
-/** 次ステップ予告の直前強調に切り替わる残り秒数（カウントダウン音と同じタイミング） */
-export const NEXT_STEP_SOON_THRESHOLD_SEC = 3;
+/** 次ステップ直前アラートに切り替わる残り秒数（カウントダウン音と同じタイミング） */
+const NEXT_STEP_SOON_THRESHOLD_SEC = 3;
 
 /** ステップ見出しを主見出しと補足（括弧内）に分解した結果 */
-export interface SplitStepTitle {
+interface SplitStepTitle {
   mainTitle: string;
   detail?: string;
 }

--- a/lib/drip-guide/runnerDisplay.ts
+++ b/lib/drip-guide/runnerDisplay.ts
@@ -1,0 +1,163 @@
+import { formatSecondsAsShortRemaining } from '@/lib/dateUtils';
+import type { DripStep } from './types';
+
+/** 次ステップ予告の直前強調に切り替わる残り秒数（カウントダウン音と同じタイミング） */
+export const NEXT_STEP_SOON_THRESHOLD_SEC = 3;
+
+/** ステップ見出しを主見出しと補足（括弧内）に分解した結果 */
+export interface SplitStepTitle {
+  mainTitle: string;
+  detail?: string;
+}
+
+/**
+ * ステップ見出しを主見出しと括弧内の補足に分解する。
+ * 例: '濃度調整（60%）' → { mainTitle: '濃度調整', detail: '60%' }
+ */
+export function splitStepTitle(title: string): SplitStepTitle {
+  const match = title.match(/^(.+?)[（(](.+)[）)]$/);
+
+  if (!match) {
+    return { mainTitle: title };
+  }
+
+  return { mainTitle: match[1], detail: match[2] };
+}
+
+/** 実行画面の最下部に出す「次の1手」予告 */
+export interface NextStepPreview {
+  /** 行頭の小さなラベル。手動モードの最終ステップでは付けない */
+  leadLabel?: string;
+  /** 本文（例: '濃度調整 → 120g'） */
+  body: string;
+  /** 残り時間（例: 'あと 20秒'）。手動モードでは時間軸がないため付けない */
+  remainingText?: string;
+}
+
+interface BuildNextStepPreviewParams {
+  nextStep: DripStep | null | undefined;
+  currentTime: number;
+  totalDurationSec: number;
+  isManualMode: boolean;
+}
+
+/**
+ * 次ステップ（なければ完了まで）の予告を組み立てる。
+ * 自動モードは残り秒付き、手動モードは時間軸がないため見出しと目標湯量のみ。
+ */
+export function buildNextStepPreview({
+  nextStep,
+  currentTime,
+  totalDurationSec,
+  isManualMode,
+}: BuildNextStepPreviewParams): NextStepPreview {
+  if (!nextStep) {
+    if (isManualMode) {
+      return { body: 'これが最後の手順' };
+    }
+
+    const remaining = Math.max(0, totalDurationSec - currentTime);
+    return {
+      leadLabel: '残り',
+      body: '完了まで',
+      remainingText: `あと ${formatSecondsAsShortRemaining(remaining)}`,
+    };
+  }
+
+  const { mainTitle } = splitStepTitle(nextStep.title);
+  const body = nextStep.targetTotalWater ? `${mainTitle} → ${nextStep.targetTotalWater}g` : mainTitle;
+
+  if (isManualMode) {
+    return { leadLabel: '次', body };
+  }
+
+  const remaining = Math.max(0, nextStep.startTimeSec - currentTime);
+  return {
+    leadLabel: '次',
+    body,
+    remainingText: `あと ${formatSecondsAsShortRemaining(remaining)}`,
+  };
+}
+
+/** 次ステップ直前アラート（画面外周のリング＋せり上がる予告バー）の表示内容 */
+export interface NextStepAlert {
+  /** 次ステップの主見出し（例: '濃度調整'） */
+  title: string;
+  /** 次ステップの目標総湯量。持たないステップでは undefined */
+  targetTotalWater?: number;
+  /** 残り秒（3 → 2 → 1） */
+  remainingSec: number;
+}
+
+interface BuildNextStepAlertParams {
+  nextStep: DripStep | null | undefined;
+  currentTime: number;
+  isManualMode: boolean;
+  isRunning: boolean;
+}
+
+/**
+ * 次ステップ直前アラートを出すべきか判定し、出すなら表示内容を返す。
+ * カウントダウン音と発火条件を揃えるため、自動モードで次ステップがあるときだけ・タイマー実行中だけ出す。
+ */
+export function buildNextStepAlert({
+  nextStep,
+  currentTime,
+  isManualMode,
+  isRunning,
+}: BuildNextStepAlertParams): NextStepAlert | null {
+  if (isManualMode || !isRunning || !nextStep) {
+    return null;
+  }
+
+  const remainingSec = nextStep.startTimeSec - currentTime;
+  if (remainingSec < 0 || remainingSec > NEXT_STEP_SOON_THRESHOLD_SEC) {
+    return null;
+  }
+
+  const { mainTitle } = splitStepTitle(nextStep.title);
+  return {
+    title: mainTitle,
+    targetTotalWater: nextStep.targetTotalWater,
+    remainingSec,
+  };
+}
+
+interface RunnerProgressParams {
+  isManualMode: boolean;
+  currentTime: number;
+  totalDurationSec: number;
+  currentStepIndex: number;
+  totalSteps: number;
+}
+
+/**
+ * 実行画面上部の進捗バーの比率（0〜1）を求める。
+ * 自動モードは経過時間基準、手動モードは時間軸がないためステップ数基準。
+ */
+export function calcRunnerProgressRatio({
+  isManualMode,
+  currentTime,
+  totalDurationSec,
+  currentStepIndex,
+  totalSteps,
+}: RunnerProgressParams): number {
+  if (isManualMode) {
+    if (totalSteps <= 0) {
+      return 0;
+    }
+    return clampRatio((currentStepIndex + 1) / totalSteps);
+  }
+
+  if (totalDurationSec <= 0) {
+    return 0;
+  }
+  return clampRatio(currentTime / totalDurationSec);
+}
+
+function clampRatio(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.min(1, Math.max(0, value));
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roastplus",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## 目的

ドリップガイドの実行画面で「次に何がいつ来るか」が一切読めなかったため、先読みできる表示を追加します。

抽出中は手が離せず、iPad は周辺視野でしか見ていません。これまでの合図は「次ステップ3秒前に音が1回鳴る」だけで、音が聞こえない環境では気づけず、目で見ても次の目標湯量が分かりませんでした。

## 変更内容

### 1. 次ステップ予告（常時表示）

情報カード最下部に1行追加します。

- 自動モード: `次 濃度調整 → 120g ・ あと 20秒`
- 手動モード（BYSN）: 時間軸がないため残秒なしで `次 1投目 → 90g`
- 最終ステップ: 自動は `残り 完了まで あと 45秒`、手動は `これが最後の手順`

### 2. 次ステップ直前アラート（残り3秒）

画面全体で気づける合図に変えます。

- 画面外周のリングが1秒周期でパルス（周辺視野向け・情報を隠さない）
- 下からせり上がるバーに `まもなく次の注湯` / `濃度調整 → 150g まで注ぐ` / 残り秒（3→2→1）
- 発火条件は既存のカウントダウン音と完全一致（自動モード・次ステップあり・タイマー実行中・残り3秒以内）。音側のロジックは変更していません
- `prefers-reduced-motion` ではアニメーションを止め、色と面積だけで伝えます

### 3. 全体進捗バー

画面最上部に細い帯を追加します。自動モードは経過時間基準（`currentTime / totalDurationSec`）、手動モードは時間軸がないためステップ数基準です。

### 4. 表示の整理

- iPad横（`lg:`）で落ちていたステップ番号 `3 / 5` を復活
- タイポスケールを 80 / 30 / 24 / 20 / 18 / 16 / 14 に整理（見出しと説明文が同サイズで主従が潰れていたため）
- カード余白を詰め、戻るボタンとの重なりと縦画面のスクロールを解消
- `FooterControls` に渡っていた未使用の `nextStep` prop を削除

## 設計

業務ロジックは `lib/drip-guide/runnerDisplay.ts` の純粋関数に集約しています。

- `buildNextStepPreview()` — 予告行の文面
- `buildNextStepAlert()` — アラートの発火判定と表示内容
- `calcRunnerProgressRatio()` — 進捗比率
- `splitStepTitle()` — `FocusGuideDisplay` 内にあったものを移設

残り時間の書式は `lib/dateUtils.ts` に `formatSecondsAsShortRemaining()` を追加しました（60秒未満は `45秒`、以上は `1:20`）。

## 検証

- `npm run typecheck` / `npm run lint` / `npm run test:run`（122ファイル・1358件）/ `npm run format:check` / `npm run docs:check` すべてパス
- 新規テスト: `lib/drip-guide/runnerDisplay.test.ts`（純粋関数）、`lib/dateUtils.test.ts`（書式）、`components/drip-guide/DripGuideRunner.test.tsx`（予告行・アラート・進捗バー）
- iPad横（1024x768）とスマホ縦（390x844）で実画面を目視確認

バージョンは 0.19.1（UI改善のためパッチ）。ページ追加ではないため法的ドキュメントの更新対象外です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWxo2ZpLgqp8pd54g9qF1f
