### PR TITLE
fix: 自動コードレビューの結果を PR にコメントさせる

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,6 +35,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # --comment を付けないとレビュー結果を実行ログに出すだけで PR に投稿しない
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## 問題

`claude-code-review.yml` は毎回 success で終わるのに、PR にレビューコメントが1件も付いていなかった（#568・#570 で確認）。

## 原因

`code-review` プラグインの仕様に、次の記述がある。

> If `--comment` argument was NOT provided, stop here. Do not post any GitHub comments.

`/install-github-app` が生成した prompt には `--comment` が無く、**レビュー結果を実行ログに出力するだけで終了する設定**になっていた。実行ログにも `permission_denials_count: 1` / `No buffered inline comments` が残っている。

## 変更

prompt の末尾に `--comment` を追加。プラグイン本体（4エージェント並列レビュー＋確信度スコアリング）はそのまま使う。

## 補足：コメントが付かない正常ケース

このプラグインは以下を最初にスキップする。修正後もこれらでは無言のまま終わる。

- closed / draft の PR
- 自明に正しい些細な変更、自動生成 PR
- すでに Claude がコメント済みの PR

## 検証

このPRのマージ後、実コードを含む次のPRでコメントが投稿されるかを確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWxo2ZpLgqp8pd54g9qF1f